### PR TITLE
Cursor/implement tier gating for premium ai mod

### DIFF
--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -45,7 +45,7 @@ export function isTierSufficient(
 ): boolean {
   if (!requiredTier) return true;
   const userRank = TIER_RANK[workspaceTier as BillingTier] ?? 0;
-  const requiredRank = TIER_RANK[requiredTier as BillingTier] ?? 0;
+  const requiredRank = TIER_RANK[requiredTier as BillingTier] ?? Infinity;
   return userRank >= requiredRank;
 }
 

--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -22,6 +22,31 @@ export interface AIModel {
    *   claude-opus-4-*  (fallback):        32 000
    */
   thinkingBudgetTokens?: number;
+  /** Minimum billing tier required to use this model. Unset means free-tier. */
+  requiredTier?: "pro" | "enterprise";
+}
+
+export type BillingTier = "free" | "pro" | "enterprise";
+
+const TIER_RANK: Record<BillingTier, number> = {
+  free: 0,
+  pro: 1,
+  enterprise: 2,
+};
+
+/**
+ * Check whether a workspace tier is sufficient for a model's required tier.
+ * Returns true when no tier is required (free models) or the workspace tier
+ * meets/exceeds the model requirement.
+ */
+export function isTierSufficient(
+  workspaceTier: string,
+  requiredTier?: string,
+): boolean {
+  if (!requiredTier) return true;
+  const userRank = TIER_RANK[workspaceTier as BillingTier] ?? 0;
+  const requiredRank = TIER_RANK[requiredTier as BillingTier] ?? 0;
+  return userRank >= requiredRank;
 }
 
 /**
@@ -35,6 +60,7 @@ export const ALL_MODELS: AIModel[] = [
     provider: "openai",
     name: "GPT-5.2 Codex",
     description: "Previous flagship model with enhanced intelligence",
+    requiredTier: "pro",
   },
   // OpenAI - GPT-5.2 (released Dec 11, 2025)
   {
@@ -42,6 +68,7 @@ export const ALL_MODELS: AIModel[] = [
     provider: "openai",
     name: "GPT-5.2",
     description: "Previous flagship model with enhanced intelligence",
+    requiredTier: "pro",
   },
   {
     id: "gpt-4o",
@@ -57,6 +84,7 @@ export const ALL_MODELS: AIModel[] = [
     description: "Most capable, latest flagship with enhanced reasoning",
     supportsThinking: true,
     thinkingBudgetTokens: 30000, // SDK caps opus-4-* at 32K total output
+    requiredTier: "pro",
   },
   {
     id: "claude-opus-4-5",
@@ -65,6 +93,7 @@ export const ALL_MODELS: AIModel[] = [
     description: "Previous flagship, autonomous coding for 30+ hours",
     supportsThinking: true,
     thinkingBudgetTokens: 60000, // SDK caps opus-4-5/sonnet-4-5 at 64K total output
+    requiredTier: "pro",
   },
   {
     id: "claude-sonnet-4-5",
@@ -73,6 +102,7 @@ export const ALL_MODELS: AIModel[] = [
     description: "Best balance of speed and intelligence",
     supportsThinking: true,
     thinkingBudgetTokens: 60000, // SDK caps opus-4-5/sonnet-4-5 at 64K total output
+    requiredTier: "pro",
   },
   {
     id: "claude-3-5-haiku-latest",
@@ -137,10 +167,15 @@ export function getModelById(modelId: string): AIModel | undefined {
 }
 
 /**
- * Get the default model (Claude Opus 4.6 if available, otherwise first available)
+ * Get the default model (Gemini 2.5 Flash if available, otherwise first available free model)
  */
 export function getDefaultModel(): AIModel {
   const available = getAvailableModels();
-  const opus = available.find(m => m.id === "claude-opus-4-6");
-  return opus || available[0] || ALL_MODELS[0];
+  const flash = available.find(m => m.id === "gemini-2.5-flash");
+  return (
+    flash ||
+    available.find(m => !m.requiredTier) ||
+    available[0] ||
+    ALL_MODELS[0]
+  );
 }

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -20,7 +20,11 @@ import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { workspaceService } from "../services/workspace.service";
 import type { ConsoleDataV2 } from "../agent-lib/types";
-import { getModelById, getAvailableModels } from "../agent-lib/ai-models";
+import {
+  getModelById,
+  getAvailableModels,
+  isTierSufficient,
+} from "../agent-lib/ai-models";
 import {
   Workspace,
   DatabaseConnection,
@@ -46,10 +50,19 @@ agentRoutes.use("*", unifiedAuthMiddleware);
 
 /**
  * GET /models - List available AI models based on configured API keys
+ * Includes a `locked` flag per model based on workspace billing tier
  */
 agentRoutes.get("/models", async (c: AuthenticatedContext) => {
   const models = getAvailableModels();
-  return c.json({ models });
+  const workspace = c.get("workspace");
+  const billingTier = workspace?.settings?.billingTier ?? "free";
+
+  const modelsWithLock = models.map(m => ({
+    ...m,
+    locked: !isTierSufficient(billingTier, m.requiredTier),
+  }));
+
+  return c.json({ models: modelsWithLock });
 });
 
 /**
@@ -191,6 +204,29 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
       { error: "'chatId' is required and must be a valid ObjectId" },
       400,
     );
+  }
+
+  // Tier-gate: reject if free workspace requests a premium model
+  if (modelId) {
+    const requestedModel = getModelById(modelId);
+    const billingTier =
+      (
+        workspace ??
+        (await Workspace.findById(workspaceId).select({ settings: 1 }))
+      )?.settings?.billingTier ?? "free";
+    if (
+      requestedModel &&
+      !isTierSufficient(billingTier, requestedModel.requiredTier)
+    ) {
+      return c.json(
+        {
+          error: "MODEL_TIER_REQUIRED",
+          requiredTier: requestedModel.requiredTier,
+          message: `Upgrade to ${requestedModel.requiredTier === "enterprise" ? "Enterprise" : "Pro"} to use this model`,
+        },
+        403,
+      );
+    }
   }
 
   // Check if this is a new chat (first message)

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -23,6 +23,7 @@ import type { ConsoleDataV2 } from "../agent-lib/types";
 import {
   getModelById,
   getAvailableModels,
+  getDefaultModel,
   isTierSufficient,
 } from "../agent-lib/ai-models";
 import {
@@ -62,10 +63,14 @@ agentRoutes.get("/models", async (c: AuthenticatedContext) => {
   if (workspace) {
     billingTier = workspace.settings?.billingTier ?? "free";
   } else {
+    const user = c.get("user");
     const workspaceId = c.req.header("x-workspace-id");
-    if (workspaceId) {
-      const ws = await Workspace.findById(workspaceId).select({ settings: 1 });
-      billingTier = ws?.settings?.billingTier ?? "free";
+    if (workspaceId && user) {
+      const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+      if (hasAccess) {
+        const ws = await Workspace.findById(workspaceId).select({ settings: 1 });
+        billingTier = ws?.settings?.billingTier ?? "free";
+      }
     }
   }
 
@@ -219,9 +224,8 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   }
 
   // Tier-gate: reject if free workspace requests a premium model
-  // Resolve the effective model – when modelId is omitted the default is gpt-5.2
   {
-    const effectiveModelId = modelId ?? "gpt-5.2";
+    const effectiveModelId = modelId ?? getDefaultModel().id;
     const requestedModel = getModelById(effectiveModelId);
     const billingTier =
       (

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -54,8 +54,20 @@ agentRoutes.use("*", unifiedAuthMiddleware);
  */
 agentRoutes.get("/models", async (c: AuthenticatedContext) => {
   const models = getAvailableModels();
+
+  // Resolve billing tier: API key auth sets workspace in context; session auth does not,
+  // so fall back to a DB lookup using the x-workspace-id header sent by the frontend.
+  let billingTier: string = "free";
   const workspace = c.get("workspace");
-  const billingTier = workspace?.settings?.billingTier ?? "free";
+  if (workspace) {
+    billingTier = workspace.settings?.billingTier ?? "free";
+  } else {
+    const workspaceId = c.req.header("x-workspace-id");
+    if (workspaceId) {
+      const ws = await Workspace.findById(workspaceId).select({ settings: 1 });
+      billingTier = ws?.settings?.billingTier ?? "free";
+    }
+  }
 
   const modelsWithLock = models.map(m => ({
     ...m,
@@ -207,8 +219,10 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   }
 
   // Tier-gate: reject if free workspace requests a premium model
-  if (modelId) {
-    const requestedModel = getModelById(modelId);
+  // Resolve the effective model – when modelId is omitted the default is gpt-5.2
+  {
+    const effectiveModelId = modelId ?? "gpt-5.2";
+    const requestedModel = getModelById(effectiveModelId);
     const billingTier =
       (
         workspace ??

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -57,6 +57,7 @@ import type { ConsoleTab } from "../store/lib/types";
 import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { ModelSelector } from "./ModelSelector";
+import { UpgradePrompt } from "./UpgradePrompt";
 import { generateObjectId } from "../utils/objectId";
 import {
   ConsoleModification,
@@ -583,6 +584,10 @@ const Chat: React.FC<ChatProps> = ({
   const [modeSelectorAnchor, setModeSelectorAnchor] =
     useState<null | HTMLElement>(null);
   const modeSelectorOpen = Boolean(modeSelectorAnchor);
+
+  // Upgrade prompt triggered by tier-gated model errors
+  const [upgradePromptOpen, setUpgradePromptOpen] = useState(false);
+  const [tierError, setTierError] = useState<string | null>(null);
 
   // Filter to only real console tabs (used for capturedConsoleTitle)
   const realConsoleTabs = useMemo(
@@ -1218,6 +1223,16 @@ const Chat: React.FC<ChatProps> = ({
     },
 
     onError: err => {
+      // Parse MODEL_TIER_REQUIRED from 403 responses embedded in the error message
+      const msg = err?.message || "";
+      if (
+        msg.includes("MODEL_TIER_REQUIRED") ||
+        msg.includes("Upgrade to Pro")
+      ) {
+        setTierError("This model requires a Pro plan");
+        setUpgradePromptOpen(true);
+        return;
+      }
       console.error("[Chat] Error:", err);
     },
     onFinish: () => {
@@ -1617,8 +1632,30 @@ const Chat: React.FC<ChatProps> = ({
         )}
       </Menu>
 
+      {/* Tier upgrade error */}
+      {tierError && (
+        <Box sx={{ p: 1 }}>
+          <Alert
+            severity="warning"
+            sx={{ fontSize: "0.875rem" }}
+            action={
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => setUpgradePromptOpen(true)}
+              >
+                Upgrade
+              </Button>
+            }
+            onClose={() => setTierError(null)}
+          >
+            {tierError}
+          </Alert>
+        </Box>
+      )}
+
       {/* Error display */}
-      {error && (
+      {error && !tierError && (
         <Box sx={{ p: 1 }}>
           <Alert severity="error" sx={{ fontSize: "0.875rem" }}>
             {error.message}
@@ -2231,6 +2268,12 @@ const Chat: React.FC<ChatProps> = ({
           </Box>
         </form>
       </Paper>
+
+      {/* Upgrade Prompt Dialog */}
+      <UpgradePrompt
+        open={upgradePromptOpen}
+        onClose={() => setUpgradePromptOpen(false)}
+      />
 
       {/* Tool Debug Dialog */}
       <Dialog

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1715,6 +1715,7 @@ const Chat: React.FC<ChatProps> = ({
                     has_context: false,
                     from_suggestion: true,
                   });
+                  setTierError(null);
                   sendMessage({ text: suggestion });
                 }}
                 sx={{
@@ -2036,6 +2037,7 @@ const Chat: React.FC<ChatProps> = ({
                 model: selectedModelId,
                 has_context: !!activeConsole?.content,
               });
+              setTierError(null);
               sendMessage({ text: input });
               setInput("");
             }
@@ -2064,6 +2066,7 @@ const Chat: React.FC<ChatProps> = ({
                     model: selectedModelId,
                     has_context: !!activeConsole?.content,
                   });
+                  setTierError(null);
                   sendMessage({ text: input });
                   setInput("");
                 }

--- a/app/src/components/ModelSelector.tsx
+++ b/app/src/components/ModelSelector.tsx
@@ -15,7 +15,9 @@ import {
   Tooltip,
 } from "@mui/material";
 import { KeyboardArrowDown } from "@mui/icons-material";
+import { Lock } from "lucide-react";
 import { useSettingsStore } from "../store/settingsStore";
+import { UpgradePrompt } from "./UpgradePrompt";
 
 import type { AIModel } from "../lib/api-types";
 
@@ -35,6 +37,7 @@ const PROVIDER_ORDER: Array<AIModel["provider"]> = [
 
 export const ModelSelector: React.FC = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
   const selectedModelId = useSettingsStore(s => s.selectedModelId);
   const setSelectedModelId = useSettingsStore(s => s.setSelectedModelId);
   const models = useSettingsStore(s => s.models);
@@ -56,8 +59,13 @@ export const ModelSelector: React.FC = () => {
     setAnchorEl(null);
   };
 
-  const handleSelectModel = (modelId: string) => {
-    setSelectedModelId(modelId);
+  const handleSelectModel = (model: AIModel) => {
+    if (model.locked) {
+      handleClose();
+      setUpgradeOpen(true);
+      return;
+    }
+    setSelectedModelId(model.id);
     handleClose();
   };
 
@@ -162,28 +170,41 @@ export const ModelSelector: React.FC = () => {
             <MenuItem
               key={model.id}
               selected={model.id === selectedModelId}
-              onClick={() => handleSelectModel(model.id)}
+              onClick={() => handleSelectModel(model)}
               sx={{
                 py: 1,
                 px: 2,
+                opacity: model.locked ? 0.7 : 1,
               }}
             >
-              <Box>
-                <Typography variant="body2">{model.name}</Typography>
-                {model.description && (
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ display: "block" }}
-                  >
-                    {model.description}
-                  </Typography>
+              <Box
+                sx={{ display: "flex", alignItems: "center", gap: 1, flex: 1 }}
+              >
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="body2">{model.name}</Typography>
+                  {model.description && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: "block" }}
+                    >
+                      {model.description}
+                    </Typography>
+                  )}
+                </Box>
+                {model.locked && (
+                  <Tooltip title="Requires Pro plan">
+                    <Box sx={{ display: "flex", color: "text.disabled" }}>
+                      <Lock size={14} />
+                    </Box>
+                  </Tooltip>
                 )}
               </Box>
             </MenuItem>
           )),
         ])}
       </Menu>
+      <UpgradePrompt open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
     </>
   );
 };

--- a/app/src/components/UpgradePrompt.tsx
+++ b/app/src/components/UpgradePrompt.tsx
@@ -1,0 +1,102 @@
+/**
+ * UpgradePrompt Component
+ * Modal prompting free-tier users to upgrade for premium model access
+ */
+
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { Sparkles, Zap, BarChart3, Shield } from "lucide-react";
+
+interface UpgradePromptProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const DEMO_URL =
+  import.meta.env.VITE_DEMO_BOOKING_URL || "https://calendly.com/mako-ai/demo";
+
+const BENEFITS = [
+  {
+    icon: <Sparkles size={18} />,
+    text: "Access to premium AI models (Claude Opus, GPT-5.2, and more)",
+  },
+  {
+    icon: <Zap size={18} />,
+    text: "Higher rate limits and priority inference",
+  },
+  {
+    icon: <BarChart3 size={18} />,
+    text: "Advanced analytics and usage insights",
+  },
+  {
+    icon: <Shield size={18} />,
+    text: "Priority support and dedicated onboarding",
+  },
+];
+
+export const UpgradePrompt: React.FC<UpgradePromptProps> = ({
+  open,
+  onClose,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pb: 0 }}>
+        <Typography variant="h6" fontWeight={600}>
+          Upgrade to Pro
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mt: 1, mb: 2 }}
+        >
+          Unlock the most powerful AI models and advanced features for your
+          workspace.
+        </Typography>
+        <List dense disablePadding>
+          {BENEFITS.map((b, i) => (
+            <ListItem key={i} disableGutters sx={{ py: 0.5 }}>
+              <ListItemIcon sx={{ minWidth: 32, color: "primary.main" }}>
+                {b.icon}
+              </ListItemIcon>
+              <ListItemText
+                primary={b.text}
+                primaryTypographyProps={{ variant: "body2" }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} color="inherit" size="small">
+          Maybe later
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="contained"
+          href={DEMO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="small"
+        >
+          Book a Demo
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default UpgradePrompt;

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -265,6 +265,8 @@ export interface AIModel {
   description?: string;
   contextLength?: number;
   supportsTools?: boolean;
+  requiredTier?: "pro" | "enterprise";
+  locked?: boolean;
 }
 
 export interface ModelListResponse {

--- a/app/src/store/settingsStore.ts
+++ b/app/src/store/settingsStore.ts
@@ -49,12 +49,15 @@ export const useSettingsStore = create<SettingsState>()(
 
           set({ models });
 
-          // Ensure selected model exists
+          // Ensure selected model exists and is not locked
           if (models.length > 0) {
             const current = get().selectedModelId;
-            const isAvailable = models.some(model => model.id === current);
+            const isAvailable = models.some(
+              model => model.id === current && !model.locked,
+            );
             if (!isAvailable) {
-              set({ selectedModelId: models[0].id });
+              const firstUnlocked = models.find(model => !model.locked);
+              set({ selectedModelId: (firstUnlocked ?? models[0]).id });
             }
           }
         } catch (error) {

--- a/app/src/store/settingsStore.ts
+++ b/app/src/store/settingsStore.ts
@@ -28,7 +28,7 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       // Default model
-      selectedModelId: "claude-opus-4-6",
+      selectedModelId: "gemini-2.5-flash",
       setSelectedModelId: modelId => set({ selectedModelId: modelId }),
 
       // Models list


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core chat request path and model listing to enforce billing tiers, which can block users if tier resolution or defaults are wrong. UI error parsing relies on string matching, which is brittle and could miss/false-trigger upgrade prompts.
> 
> **Overview**
> Adds model-tier metadata (`requiredTier`) and a `isTierSufficient` helper, marking several premium models (e.g. Claude Opus/Sonnet 4.5+ and GPT-5.2*) as Pro-only and changing the default model selection to prefer `gemini-2.5-flash` / first free model.
> 
> Updates `/agent/models` to return a per-model `locked` flag based on the workspace’s `billingTier` (with a session-auth fallback lookup via `x-workspace-id`), and enforces tier gating in `/api/agent/chat` by rejecting premium-model requests with a 403 `MODEL_TIER_REQUIRED` error.
> 
> Front-end now understands `requiredTier`/`locked`, prevents selecting locked models (shows a lock icon), defaults to `gemini-2.5-flash`, and introduces an `UpgradePrompt` modal + warning banner when tier-gated errors occur (including parsing the error from `useChat` failures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f868d11314c103de7a25dbd7fb03bad455259216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->