### PR TITLE
Stop embedding the Vega-Lite JSON Schema in chart/widget tool definitions

### DIFF
--- a/packages/agent-tools/src/chart-tools.ts
+++ b/packages/agent-tools/src/chart-tools.ts
@@ -15,10 +15,22 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { MakoChartSpecBase } from "./chart-spec-schema";
 
 export const modifyChartSpecSchema = z.object({
-  vegaLiteSpec: MakoChartSpecBase.describe("Vega-Lite chart specification"),
+  // A loose record instead of the full ~98 KB Vega-Lite JSON Schema: the model
+  // already knows Vega-Lite, so we describe only the Mako-specific constraints
+  // and rely on the client-side `MakoChartSpec` schema (app/src/lib/chart-spec.ts)
+  // to validate and feed errors back for self-correction.
+  vegaLiteSpec: z
+    .record(z.string(), z.unknown())
+    .describe(
+      "A Vega-Lite spec object (the model already knows Vega-Lite). " +
+        "Do NOT include a `data` property — data is injected from the query results at render time. " +
+        "Marks: bar | line | area | point | arc | boxplot | rect | rule | text | tick | trail. " +
+        "Use a `fold` transform to unpivot multiple numeric columns into one series for multi-line charts. " +
+        "For complex patterns (multi-series hover, donut, stacked bar) call get_chart_template first. " +
+        "Invalid specs are reported back with the exact validation error so you can fix and retry.",
+    ),
   reasoning: z
     .string()
     .describe("Brief explanation of the chart choice and why it fits the data"),

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -14,8 +14,20 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { MakoChartSpecBase } from "./chart-spec-schema";
 import { clientScreenshotTools } from "./screenshot-tools";
+
+// A loose record instead of the full ~98 KB Vega-Lite JSON Schema. The model
+// already knows Vega-Lite; we describe only the Mako-specific constraints and
+// rely on the client-side `MakoChartSpec` schema + `validateVegaSpec` render
+// check (app/src/dashboard-runtime/validation.ts) to validate and feed errors
+// back for self-correction.
+const vegaLiteSpecField = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(
+    "Vega-Lite spec for chart widgets. Omit the `data` property — the widget binds to the local DuckDB table. " +
+      "If the spec is invalid or fails to render, the tool returns the error/hint so you can fix it with modify_widget.",
+  );
 
 const addWidgetSchema = z.object({
   dashboardId: z.string().describe("Dashboard ID"),
@@ -25,9 +37,7 @@ const addWidgetSchema = z.object({
     .string()
     .describe("ID of the data source within the dashboard"),
   localSql: z.string().describe("SQL query against the local DuckDB table"),
-  vegaLiteSpec: MakoChartSpecBase.optional().describe(
-    "Vega-Lite chart spec (for chart type). Do NOT include data property.",
-  ),
+  vegaLiteSpec: vegaLiteSpecField,
   kpiConfig: z
     .object({
       valueField: z.string(),
@@ -63,7 +73,7 @@ const modifyWidgetSchema = z.object({
   widgetId: z.string().describe("Widget ID to modify"),
   title: z.string().optional(),
   localSql: z.string().optional(),
-  vegaLiteSpec: MakoChartSpecBase.optional(),
+  vegaLiteSpec: vegaLiteSpecField,
   kpiConfig: z
     .object({
       valueField: z.string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`modify_chart_spec`, `add_widget`, and `modify_widget` embedded the full `MakoChartSpecBase` Vega-Lite JSON Schema as their tool `inputSchema`, serialized into the prompt on **every** turn. Langfuse traces showed these three accounted for ~87% of all tool-definition bytes (~294 KB of cached prefix), re-teaching the model a schema it already knows.

This replaces the embedded schema with a small, loose primitive — `z.record(z.string(), z.unknown())` — carrying the Mako-specific constraints in a tight description. The model already knows Vega-Lite; we lean on its weights and the **existing** client-side validation/self-correction loop.

**Measured impact:** `MakoChartSpecBase` serializes to **~88 KB** of JSON Schema each; the loose record is **134 bytes**. Across the three tools that's ~264 KB → ~0.4 KB of tool-definition bytes.

## Why this is safe

The embedded schema did **no** runtime validation — it was only serialized into the prompt. Validation + self-correction already happen client-side against a **separate** copy of the schema, which is untouched:

- **Console** — `app/src/agent-runtime/console-agent-tools.ts` `safeParse`s against `MakoChartSpec` (`app/src/lib/chart-spec.ts`) and returns `Invalid Vega-Lite spec: …. Fix the spec and try again.`
- **Dashboard** — `app/src/dashboard-runtime/agent-tools.ts` calls `validateVegaSpec(...)` (`app/src/dashboard-runtime/validation.ts`), which `safeParse`s against the same client schema and adds Vega render-failure hints.

`MakoChartSpecBase` was already `.passthrough()`, so it never strictly constrained input. Both client handlers already cast `input.vegaLiteSpec as Record<string, unknown>`, and `validateVegaSpec` takes `unknown`, so loosening the upstream type introduces no type errors.

## Changes

- `packages/agent-tools/src/chart-tools.ts`: `modify_chart_spec.vegaLiteSpec` → loose `z.record` with a constraint-carrying description.
- `packages/agent-tools/src/dashboard-tools.ts`: shared `vegaLiteSpecField` (loose `z.record().optional()`) reused by `add_widget` and `modify_widget`.
- Removed the now-unused `MakoChartSpecBase` import from both files. `chart-spec-schema.ts` is left in place and still re-exported from `index.ts` (it remains the client validation source of truth) — no deletion, keeping the diff focused.

Untouched (as required): `app/src/lib/chart-spec.ts`, `validateVegaSpec`, the client tool handlers, and the `kpiConfig`/`tableConfig`/`layouts` schemas.

## Verification

- `pnpm --filter @mako/agent-tools run build` ✅
- `pnpm --filter app run typecheck` ✅, `pnpm --filter app run lint` ✅
- `pnpm --filter api run lint` ✅
- `client-tool-manifest.test.ts` (tool-name contract) ✅
- Measured schema sizes (88 KB → 134 B each).

Manual smoke + Langfuse before/after (cached-prefix token drop) to be confirmed in a dev environment with live credentials.

## Secondary change (dashboard tool gating) — deferred to a follow-up

I investigated gating `clientDashboardTools` to dashboard turns. Findings and rationale for deferring:

- The dashboard tools are registered server-side in the unified agent factory (`api/src/agents/unified/index.ts` spreads `...clientDashboardTools`); `client-tool-manifest.ts` is UI/dispatch only. `AgentContext` exposes `openTabs`/`openDashboards`, so gating is mechanically possible.
- **But** after this PR, the two dominant offenders (`add_widget`/`modify_widget` at ~88 KB each) are already gone, so gating's remaining benefit is small (a handful of tiny dashboard tool schemas on console turns).
- Meanwhile the regression risk is real: the unified agent supports console→dashboard pivots, including **creating a brand-new dashboard from a console-only session** (no dashboard tab open). Gating on "has an open dashboard tab" would break that flow, and gating only the active tab would break mid-conversation pivots.

Given the now-marginal benefit vs. the pivot-regression risk, this is best done as its own PR with a careful keep-a-minimal-dashboard-toolset design (always expose `list_open_dashboards`/`search_dashboards`/`open_dashboard`/`create_dashboard`; gate only the heavy editing tools). The task explicitly authorized shipping the primary change first.

## Out of scope (noted for later)
- `lazy: true` deferred tool schemas (not in our `ai` version yet).
- Code-mode `search()`+`execute()` tool surface.
- Moving the skills block above the cache breakpoint.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6fdc03-783d-45ad-93f3-25913b09ed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6fdc03-783d-45ad-93f3-25913b09ed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

