### PR TITLE
feat(dbt): move dbt file storage from Mongo to per-project git repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,13 @@ DB_CONNECT_MAX_DELAY_MS=5000
 # Port Configuration
 WEB_API_PORT=8080
 
+# dbt file storage (git) — every dbt project owns a bare git repository under
+# this root ("nothing in Mongo, all in git"). Must point at DURABLE storage in
+# production: it holds blank-project content and unpushed per-user drafts
+# (repo-bound base trees are rebuildable from GitHub). Defaults to
+# api/.data/dbt-git locally and /data/dbt-git in production.
+# DBT_GIT_ROOT=/data/dbt-git
+
 # Dashboard Materialization (optional - defaults to filesystem)
 # For local GCS materialization, use a service-account credential file because
 # signed URL generation requires credentials with a private key.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ account manually, flip `emailVerified` in the DB to log in.
 
 ### Misc caveats
 
+- dbt project files live in per-project bare git repos under `DBT_GIT_ROOT`
+ (default `api/.data/dbt-git`), not in Mongo. Inspect a project's files with
+ `git --git-dir=<root>/<workspaceId>/<projectId>.git log/ls-tree main`.
+
 - No `docker-compose.yml` is committed, so `pnpm docker:*` scripts don't work
   here — use the local Mongo/Postgres above instead.
 - The demo Postgres (`demo` DB, role `mako`/`mako`) uses lowercase, unquoted

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -29,18 +29,12 @@ import {
 } from "@mako/agent-tools";
 import {
   DatabaseConnection,
-  DbtFile,
   DbtJob,
   DbtProject,
   DbtRun,
 } from "../../database/workspace-schema";
 import { publishRealtimeEvent } from "../../services/realtime.service";
 import { workspaceService } from "../../services/workspace.service";
-import {
-  createVersion,
-  getLatestVersionNumber,
-  getUserDisplayName,
-} from "../../services/entity-version.service";
 import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
@@ -76,6 +70,7 @@ import {
   getCheckoutBranch,
   listWorkingFiles,
   readWorkingFile,
+  seedProjectFiles,
   writeWorkingFile,
 } from "../../dbt/dbt-working-tree.service";
 import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
@@ -313,30 +308,6 @@ export const createDbtServerTools = (
     return null;
   };
 
-  // Snapshot a dbt file version (entity-version pattern, mirrors the route).
-  const snapshotVersion = async (
-    fileId: Types.ObjectId,
-    wsId: Types.ObjectId,
-    path: string,
-    content: string,
-  ) => {
-    try {
-      const latest = await getLatestVersionNumber(fileId, "dbt-file");
-      const savedBy = userId ?? "agent";
-      await createVersion({
-        entityType: "dbt-file",
-        entityId: fileId,
-        workspaceId: wsId,
-        snapshot: { path, content },
-        savedBy,
-        savedByName: userId ? await getUserDisplayName(userId) : "Agent",
-        comment: `Save ${path} (v${latest + 1})`,
-      });
-    } catch {
-      /* version history is best-effort */
-    }
-  };
-
   return {
     read_dbt_project_tree: tool({
       description:
@@ -439,18 +410,7 @@ export const createDbtServerTools = (
               error: `File already exists: ${path}. Use modify_dbt_file to change it.`,
             };
           }
-          const { versionEntityId } = await writeWorkingFile(
-            project,
-            actingUserId,
-            path,
-            contents ?? "",
-          );
-          await snapshotVersion(
-            versionEntityId,
-            project.workspaceId,
-            path,
-            contents ?? "",
-          );
+          await writeWorkingFile(project, actingUserId, path, contents ?? "");
           await DbtProject.updateOne(
             { _id: project._id },
             { $currentDate: { updatedAt: true } },
@@ -482,18 +442,7 @@ export const createDbtServerTools = (
           if ((contents ?? "").length > 1_000_000) {
             return { success: false, error: "File too large (max 1MB)" };
           }
-          const { versionEntityId } = await writeWorkingFile(
-            project,
-            actingUserId,
-            path,
-            contents ?? "",
-          );
-          await snapshotVersion(
-            versionEntityId,
-            project.workspaceId,
-            path,
-            contents ?? "",
-          );
+          await writeWorkingFile(project, actingUserId, path, contents ?? "");
           await DbtProject.updateOne(
             { _id: project._id },
             { $currentDate: { updatedAt: true } },
@@ -530,11 +479,7 @@ export const createDbtServerTools = (
           if (!isSafeDbtPath(path)) {
             return { success: false, error: "Invalid file path" };
           }
-          const file = await DbtFile.findOne({
-            projectId: project._id,
-            path,
-            is_deleted: { $ne: true },
-          });
+          const file = await readWorkingFile(project, actingUserId, path);
           if (!file) {
             return {
               success: false,
@@ -560,20 +505,14 @@ export const createDbtServerTools = (
             newString,
             result.replacements,
           );
-          file.content = result.contents;
-          if (userId) file.updatedBy = userId;
-          await file.save();
-          await snapshotVersion(
-            file._id,
-            project.workspaceId,
-            path,
-            result.contents,
-          );
+          await writeWorkingFile(project, actingUserId, path, result.contents);
           await DbtProject.updateOne(
             { _id: project._id },
             { $currentDate: { updatedAt: true } },
           );
-          publishFileUpdated(projectId, path);
+          publishFileUpdated(projectId, path, {
+            draft: Boolean(project.repo),
+          });
           return {
             success: true,
             path,
@@ -690,15 +629,7 @@ export const createDbtServerTools = (
           });
 
           const scaffold = buildStarterScaffold(name);
-          await DbtFile.insertMany(
-            scaffold.map(file => ({
-              workspaceId: project.workspaceId,
-              projectId: project._id,
-              path: file.path,
-              content: file.content,
-              updatedBy: "agent",
-            })),
-          );
+          await seedProjectFiles(project, actingUserId, scaffold);
 
           publishProjectUpdated(project._id.toString());
           return {

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4192,8 +4192,11 @@ export const RealtimePresence = mongoose.model<IRealtimePresence>(
 /**
  * dbt — workspace-scoped dbt Core projects ("dbt Cloud replica").
  *
- * A project is a virtual filesystem in Mongo (one DbtFile doc per file)
- * materialized to a temp dir at run time by api/src/dbt/runner.service.ts.
+ * File CONTENT lives in a per-project bare git repository on disk
+ * (api/src/dbt/dbt-git-store.service.ts) — nothing in Mongo. Mongo keeps
+ * only metadata: projects, jobs, runs, and per-user checkout pointers.
+ * DbtFile/DbtFileDraft are LEGACY collections read exactly once per project
+ * to materialize its git repo (lazy migration) and never written again.
  * Jobs hold command lists + cron schedules (claim pattern mirrors
  * SavedConsole.scheduledRun); runs are the per-execution records with
  * capped logs and parsed run_results.json step results.
@@ -4214,9 +4217,9 @@ export interface IDbtEnvironment {
 
 /**
  * Optional binding of a dbt project to a Git repository. When present, the
- * project's files are imported/synced from this repo. Mongo (DbtFile) stays
- * the canonical source the runner materializes from; this binding records
- * where those files came from and lets us sync/commit against the remote.
+ * project's local git store mirrors this remote (fetch on sync, push on
+ * commit); this binding records where the files come from and which
+ * installation authenticates the transport.
  */
 export interface IDbtRepoBinding {
   provider: "github";
@@ -4345,6 +4348,11 @@ export const DbtProject = mongoose.model<IDbtProject>(
   DbtProjectSchema,
 );
 
+/**
+ * LEGACY — dbt file contents now live in the project's git store. Rows are
+ * read once per project by the lazy migration in dbt-working-tree.service.ts
+ * (ensureProjectRepo) and never written again.
+ */
 export interface IDbtFile extends Document {
   _id: Types.ObjectId;
   workspaceId: Types.ObjectId;
@@ -4401,11 +4409,9 @@ DbtFileSchema.index({ workspaceId: 1, projectId: 1, is_deleted: 1 });
 export const DbtFile = mongoose.model<IDbtFile>("DbtFile", DbtFileSchema);
 
 /**
- * Per-user uncommitted edit to a dbt file (the draft overlay). Reads for a
- * user merge draft-over-base: other workspace members never see a draft, so
- * collaborators only observe committed changes — like separate git working
- * trees. Drafts follow the user across branch switches (a dirty git tree
- * carried through `git checkout`) and are cleared when committed.
+ * LEGACY — per-user uncommitted edits now live as draft overlay refs in the
+ * project's git store. Rows are read once per project by the lazy migration
+ * (ensureProjectRepo) and never written again.
  */
 export interface IDbtFileDraft extends Document {
   _id: Types.ObjectId;

--- a/api/src/dbt/dbt-git-remote.ts
+++ b/api/src/dbt/dbt-git-remote.ts
@@ -1,0 +1,29 @@
+/**
+ * Remote URL + auth resolution for repo-bound dbt projects.
+ *
+ * Kept in its own tiny module so tests can mock it and point the git store at
+ * a local bare repo (file path) standing in for GitHub.
+ */
+import type { IDbtRepoBinding } from "../database/workspace-schema";
+import { resolveRepoToken } from "../integrations/github/app-auth";
+
+export interface ResolvedRemote {
+  /** URL (or local path in tests) `git fetch` / `git push` talk to. */
+  url: string;
+  /**
+   * `http.extraheader` value carrying the auth token, or undefined for
+   * anonymous access (public repos). Passing the token as a header keeps it
+   * out of the URL, and therefore out of git's error output.
+   */
+  authHeader?: string;
+}
+
+export async function resolveProjectRemote(
+  binding: Pick<IDbtRepoBinding, "owner" | "repo" | "installationId">,
+): Promise<ResolvedRemote> {
+  const token = await resolveRepoToken(binding.installationId);
+  const url = `https://github.com/${binding.owner}/${binding.repo}.git`;
+  if (!token) return { url };
+  const basic = Buffer.from(`x-access-token:${token}`).toString("base64");
+  return { url, authHeader: `Authorization: Basic ${basic}` };
+}

--- a/api/src/dbt/dbt-git-store.service.ts
+++ b/api/src/dbt/dbt-git-store.service.ts
@@ -1,0 +1,701 @@
+/**
+ * Git-backed file store for dbt projects — "nothing in Mongo, all in git".
+ *
+ * Every dbt project owns a BARE git repository on disk under DBT_GIT_ROOT
+ * (`<root>/<workspaceId>/<projectId>.git`). File contents live exclusively in
+ * git objects; Mongo keeps only metadata (projects, jobs, runs, checkouts).
+ *
+ *  - Blank (non-repo) projects: a single local branch (`main`) is the shared
+ *    working tree every member edits — each save is a commit, so history is
+ *    free.
+ *  - Repo-bound projects: local branches mirror the GitHub remote
+ *    (`git fetch` on sync, `git push` on commit, authenticated with the App
+ *    installation token). Per-user uncommitted work lives in overlay refs:
+ *      refs/mako/drafts/<user>       — draft tip (one commit per save)
+ *      refs/mako/drafts-base/<user>  — the branch head the overlay forked from
+ *    The user's pending changes are exactly `diff(drafts-base, drafts)`; the
+ *    overlay is applied onto whatever branch their checkout points at, so
+ *    drafts carry across branch switches and a base sync can never clobber
+ *    them (same collaboration semantics as the previous Mongo draft rows).
+ *
+ * All operations shell out to the system `git` (no shell interpolation — argv
+ * arrays only) with a hermetic environment (no user/system git config).
+ * Ref updates use compare-and-swap (`git update-ref <ref> <new> <old>`), so
+ * concurrent writers retry instead of clobbering each other.
+ */
+
+import { spawn } from "child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { loggers } from "../logging";
+import type { ResolvedRemote } from "./dbt-git-remote";
+
+const logger = loggers.api("dbt-git-store");
+
+/** SHA-1 of the empty tree (constant across every git repository). */
+export const EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+/** All-zeros object id — "ref must not exist" in update-ref CAS terms. */
+export const ZERO_SHA = "0".repeat(40);
+
+/** Per-file size cap (parity with the previous Mongo document limit). */
+export const MAX_DBT_FILE_BYTES = 1_000_000;
+
+export interface GitAuthor {
+  name: string;
+  email: string;
+}
+
+/** Commit identity for a Mako-side actor (userId or "agent"). */
+export function authorFor(userId: string): GitAuthor {
+  const safe = (userId || "unknown").replace(/[<>\n]/g, "_").slice(0, 128);
+  return { name: safe, email: `${safe}@mako.dev` };
+}
+
+// ---------------------------------------------------------------------------
+// Repo location
+// ---------------------------------------------------------------------------
+
+export function dbtGitRoot(): string {
+  if (process.env.DBT_GIT_ROOT) return process.env.DBT_GIT_ROOT;
+  if (process.env.NODE_ENV === "production") return "/data/dbt-git";
+  return path.resolve(process.cwd(), ".data", "dbt-git");
+}
+
+function assertObjectIdLike(value: string, label: string): string {
+  if (!/^[a-f0-9]{24}$/i.test(value)) {
+    throw new Error(`Invalid ${label} for dbt git repo path`);
+  }
+  return value;
+}
+
+/** Absolute path of a project's bare repository. */
+export function repoDirFor(workspaceId: string, projectId: string): string {
+  return path.join(
+    dbtGitRoot(),
+    assertObjectIdLike(workspaceId, "workspaceId"),
+    `${assertObjectIdLike(projectId, "projectId")}.git`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Refs
+// ---------------------------------------------------------------------------
+
+/** Branch used as the shared tree of blank (non-repo) projects. */
+export const BLANK_PROJECT_BRANCH = "main";
+
+/**
+ * Encode an arbitrary identifier (user id, branch name) into a single safe
+ * git ref path component. [A-Za-z0-9_-] pass through; every other byte is
+ * escaped as `!xx` (hex). Never needs decoding — refs are always constructed
+ * from known identifiers.
+ */
+export function encodeRefComponent(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, ch =>
+    [...Buffer.from(ch, "utf8")]
+      .map(byte => `!${byte.toString(16).padStart(2, "0")}`)
+      .join(""),
+  );
+}
+
+export function branchRef(branch: string): string {
+  return `refs/heads/${branch}`;
+}
+
+export interface DraftRefs {
+  /** Draft tip — tree is the user's full working tree, one commit per save. */
+  tip: string;
+  /** Fork point — the branch head the overlay was started from. */
+  base: string;
+  /** Marker set once legacy Mongo drafts were imported for this user. */
+  migrated: string;
+}
+
+export function draftRefsFor(userId: string): DraftRefs {
+  const user = encodeRefComponent(userId);
+  return {
+    tip: `refs/mako/drafts/${user}`,
+    base: `refs/mako/drafts-base/${user}`,
+    migrated: `refs/mako/drafts-migrated/${user}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// git invocation
+// ---------------------------------------------------------------------------
+
+interface GitResult {
+  code: number;
+  stdout: Buffer;
+  stderr: string;
+}
+
+/**
+ * Hermetic git environment: no system/global config (a host's core.autocrlf
+ * or hooks must never affect stored content), no terminal prompts, and no
+ * inherited credentials.
+ */
+function gitEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_TERMINAL_PROMPT: "0",
+    ...extra,
+  };
+  if (process.env.HOME) env.HOME = process.env.HOME;
+  return env;
+}
+
+function runGit(
+  args: string[],
+  opts: {
+    cwd?: string;
+    input?: Buffer | string;
+    env?: Record<string, string>;
+  } = {},
+): Promise<GitResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, {
+      cwd: opts.cwd,
+      env: gitEnv(opts.env),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", chunk => stdout.push(chunk as Buffer));
+    child.stderr.on("data", chunk => stderr.push(chunk as Buffer));
+    child.on("error", reject);
+    child.on("close", code => {
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+    if (opts.input !== undefined) child.stdin.write(opts.input);
+    child.stdin.end();
+  });
+}
+
+async function git(
+  repoDir: string,
+  args: string[],
+  opts: { input?: Buffer | string; env?: Record<string, string> } = {},
+): Promise<string> {
+  const result = await runGit(args, { cwd: repoDir, ...opts });
+  if (result.code !== 0) {
+    throw new Error(
+      `git ${args[0]} failed (${result.code}): ${result.stderr.trim().slice(0, 500)}`,
+    );
+  }
+  return result.stdout.toString("utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Repo lifecycle
+// ---------------------------------------------------------------------------
+
+export function repoExists(repoDir: string): boolean {
+  return existsSync(path.join(repoDir, "HEAD"));
+}
+
+/** Initialize the bare repository if missing. Returns the repo dir. */
+export async function ensureBareRepo(repoDir: string): Promise<string> {
+  if (repoExists(repoDir)) return repoDir;
+  await mkdir(repoDir, { recursive: true });
+  await runGitOrThrow(["init", "--bare", "--initial-branch", "main", repoDir]);
+  return repoDir;
+}
+
+async function runGitOrThrow(args: string[]): Promise<void> {
+  const result = await runGit(args);
+  if (result.code !== 0) {
+    throw new Error(
+      `git ${args[0]} failed (${result.code}): ${result.stderr.trim().slice(0, 500)}`,
+    );
+  }
+}
+
+export async function deleteRepoDir(repoDir: string): Promise<void> {
+  await rm(repoDir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/** Tree SHA of a commit-ish, or null when it does not resolve. */
+export async function treeShaOf(
+  repoDir: string,
+  commitish: string,
+): Promise<string | null> {
+  const result = await runGit(
+    ["rev-parse", "--verify", "--quiet", `${commitish}^{tree}`],
+    { cwd: repoDir },
+  );
+  if (result.code !== 0) return null;
+  return result.stdout.toString("utf8").trim() || null;
+}
+
+/** Resolve a ref/treeish to a commit SHA, or null when it does not exist. */
+export async function resolveCommit(
+  repoDir: string,
+  ref: string,
+): Promise<string | null> {
+  const result = await runGit(
+    ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`],
+    { cwd: repoDir },
+  );
+  if (result.code !== 0) return null;
+  return result.stdout.toString("utf8").trim() || null;
+}
+
+export interface TreeEntry {
+  path: string;
+  blobSha: string;
+  size: number;
+}
+
+/**
+ * Recursively list blobs of a tree-ish. Returns [] when the ref is missing
+ * (e.g. a blank project before its first commit).
+ */
+export async function listTree(
+  repoDir: string,
+  ref: string,
+): Promise<TreeEntry[]> {
+  if (!(await resolveCommit(repoDir, ref))) return [];
+  const out = await git(repoDir, ["ls-tree", "-r", "-l", "-z", ref]);
+  const entries: TreeEntry[] = [];
+  for (const record of out.split("\0")) {
+    if (!record) continue;
+    // "<mode> SP <type> SP <sha> SP+ <size> TAB <path>"
+    const tab = record.indexOf("\t");
+    if (tab === -1) continue;
+    const meta = record.slice(0, tab).trim().split(/\s+/);
+    if (meta[1] !== "blob") continue;
+    entries.push({
+      path: record.slice(tab + 1),
+      blobSha: meta[2],
+      size: Number(meta[3]) || 0,
+    });
+  }
+  return entries;
+}
+
+/** Read one file at a ref. Null when the ref or the path does not exist. */
+export async function readBlobAt(
+  repoDir: string,
+  ref: string,
+  filePath: string,
+): Promise<string | null> {
+  const result = await runGit(["cat-file", "blob", `${ref}:${filePath}`], {
+    cwd: repoDir,
+  });
+  if (result.code !== 0) return null;
+  return result.stdout.toString("utf8");
+}
+
+/**
+ * Batch-read blobs by SHA (one `cat-file --batch` round-trip). Returns a
+ * map of blobSha → utf8 content for every sha found.
+ */
+export async function readBlobs(
+  repoDir: string,
+  blobShas: string[],
+): Promise<Map<string, string>> {
+  const contents = new Map<string, string>();
+  const unique = [...new Set(blobShas)];
+  if (unique.length === 0) return contents;
+  const result = await runGit(["cat-file", "--batch"], {
+    cwd: repoDir,
+    input: unique.join("\n") + "\n",
+  });
+  if (result.code !== 0) {
+    throw new Error(`git cat-file --batch failed: ${result.stderr.trim()}`);
+  }
+  const buf = result.stdout;
+  let offset = 0;
+  while (offset < buf.length) {
+    const headerEnd = buf.indexOf(0x0a, offset);
+    if (headerEnd === -1) break;
+    const header = buf.subarray(offset, headerEnd).toString("utf8");
+    offset = headerEnd + 1;
+    const [sha, type, sizeRaw] = header.split(" ");
+    if (type !== "blob") {
+      // "<sha> missing" — skip (no body follows).
+      continue;
+    }
+    const size = Number(sizeRaw) || 0;
+    contents.set(sha, buf.subarray(offset, offset + size).toString("utf8"));
+    offset += size + 1; // trailing newline after each object body
+  }
+  return contents;
+}
+
+export interface TreeFileChange {
+  path: string;
+  status: "added" | "modified" | "deleted";
+}
+
+/**
+ * Name-status diff between two tree-ishes (renames reported as add+delete,
+ * matching the working-tree status the IDE shows).
+ */
+export async function diffTrees(
+  repoDir: string,
+  fromRef: string,
+  toRef: string,
+): Promise<TreeFileChange[]> {
+  const out = await git(repoDir, [
+    "diff-tree",
+    "-r",
+    "-z",
+    "--no-renames",
+    "--name-status",
+    fromRef,
+    toRef,
+  ]);
+  const parts = out.split("\0");
+  const changes: TreeFileChange[] = [];
+  for (let i = 0; i + 1 < parts.length; i += 2) {
+    const status = parts[i];
+    const filePath = parts[i + 1];
+    if (!status || !filePath) continue;
+    changes.push({
+      path: filePath,
+      status:
+        status[0] === "A"
+          ? "added"
+          : status[0] === "D"
+            ? "deleted"
+            : "modified",
+    });
+  }
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export interface CommitTreeUpdateParams {
+  /**
+   * Full ref to update, e.g. refs/heads/main or refs/mako/drafts/u1. Omit to
+   * create a dangling commit the caller refs (or discards) later.
+   */
+  ref?: string;
+  /**
+   * CAS guard: current SHA the ref must have (ZERO_SHA when the ref must not
+   * exist yet). Omit to skip the guard (last write wins).
+   */
+  expectedOldSha?: string;
+  /** Tree-ish the new tree starts from; omitted → empty tree. */
+  baseTree?: string;
+  /** Parent commit SHAs of the new commit. */
+  parents: string[];
+  writes: Array<{ path: string; content: string }>;
+  deletes: string[];
+  message: string;
+  author: GitAuthor;
+}
+
+export class RefCasError extends Error {
+  constructor(ref: string) {
+    super(`Concurrent update to ${ref} — retry`);
+    this.name = "RefCasError";
+  }
+}
+
+/**
+ * Create a commit that applies `writes` + `deletes` on top of `baseTree` and
+ * point `ref` at it (CAS-guarded). Returns the new commit SHA.
+ */
+export async function commitTreeUpdate(
+  repoDir: string,
+  params: CommitTreeUpdateParams,
+): Promise<{ sha: string; treeSha: string }> {
+  const scratch = await mkdtemp(path.join(tmpdir(), "mako-git-"));
+  const indexFile = path.join(scratch, "index");
+  const indexEnv = { GIT_INDEX_FILE: indexFile };
+  try {
+    if (params.baseTree) {
+      await git(repoDir, ["read-tree", params.baseTree], { env: indexEnv });
+    } else {
+      await git(repoDir, ["read-tree", "--empty"], { env: indexEnv });
+    }
+
+    // Hash all written blobs in one spawn (contents staged as temp files).
+    const blobShas: string[] = [];
+    if (params.writes.length > 0) {
+      const paths: string[] = [];
+      for (let i = 0; i < params.writes.length; i++) {
+        const tmpFile = path.join(scratch, `blob-${i}`);
+        await writeFile(tmpFile, params.writes[i].content, "utf8");
+        paths.push(tmpFile);
+      }
+      const out = await git(repoDir, ["hash-object", "-w", "--stdin-paths"], {
+        input: paths.join("\n") + "\n",
+      });
+      blobShas.push(...out.trim().split("\n"));
+      if (blobShas.length !== params.writes.length) {
+        throw new Error("git hash-object returned unexpected output");
+      }
+    }
+
+    // Apply writes + deletes to the index in one NUL-delimited batch.
+    const indexInfo: string[] = [];
+    params.writes.forEach((write, i) => {
+      indexInfo.push(`100644 ${blobShas[i]}\t${write.path}`);
+    });
+    for (const del of params.deletes) {
+      indexInfo.push(`0 ${ZERO_SHA}\t${del}`);
+    }
+    if (indexInfo.length > 0) {
+      await git(repoDir, ["update-index", "-z", "--index-info"], {
+        env: indexEnv,
+        input: indexInfo.join("\0") + "\0",
+      });
+    }
+
+    const treeSha = (
+      await git(repoDir, ["write-tree"], { env: indexEnv })
+    ).trim();
+
+    const commitArgs = ["commit-tree", treeSha, "-m", params.message || "."];
+    for (const parent of params.parents) commitArgs.push("-p", parent);
+    const sha = (
+      await git(repoDir, commitArgs, {
+        env: {
+          GIT_AUTHOR_NAME: params.author.name,
+          GIT_AUTHOR_EMAIL: params.author.email,
+          GIT_COMMITTER_NAME: params.author.name,
+          GIT_COMMITTER_EMAIL: params.author.email,
+        },
+      })
+    ).trim();
+
+    if (params.ref) {
+      await updateRef(repoDir, params.ref, sha, params.expectedOldSha);
+    }
+    return { sha, treeSha };
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+/** CAS ref update. `expectedOldSha` = ZERO_SHA → the ref must not exist. */
+export async function updateRef(
+  repoDir: string,
+  ref: string,
+  newSha: string,
+  expectedOldSha?: string,
+): Promise<void> {
+  const args = ["update-ref", ref, newSha];
+  if (expectedOldSha !== undefined) args.push(expectedOldSha);
+  const result = await runGit(args, { cwd: repoDir });
+  if (result.code !== 0) {
+    if (expectedOldSha !== undefined) throw new RefCasError(ref);
+    throw new Error(`git update-ref failed: ${result.stderr.trim()}`);
+  }
+}
+
+export async function deleteRef(repoDir: string, ref: string): Promise<void> {
+  await runGit(["update-ref", "-d", ref], { cwd: repoDir });
+}
+
+// ---------------------------------------------------------------------------
+// Remote transport (repo-bound projects; file paths in tests)
+// ---------------------------------------------------------------------------
+
+function remoteArgs(remote: ResolvedRemote): string[] {
+  return remote.authHeader
+    ? ["-c", `http.extraheader=${remote.authHeader}`]
+    : [];
+}
+
+/**
+ * Fetch one remote branch into the same-named local branch (forced — the
+ * remote is authoritative for base trees). Returns the branch head SHA.
+ */
+export async function fetchBranch(
+  repoDir: string,
+  remote: ResolvedRemote,
+  branch: string,
+): Promise<string> {
+  await git(repoDir, [
+    ...remoteArgs(remote),
+    "fetch",
+    "--quiet",
+    "--no-write-fetch-head",
+    remote.url,
+    `+refs/heads/${branch}:refs/heads/${branch}`,
+  ]);
+  const sha = await resolveCommit(repoDir, branchRef(branch));
+  if (!sha) throw new Error(`Branch "${branch}" not found on remote`);
+  return sha;
+}
+
+/** Push a local commit to a remote branch. */
+export async function pushBranch(
+  repoDir: string,
+  remote: ResolvedRemote,
+  params: {
+    localSha: string;
+    branch: string;
+    /** Expected remote head (compare-and-swap); omit for new branches. */
+    expectedRemoteSha?: string;
+  },
+): Promise<void> {
+  // Lease with an empty expectation means "the ref must not exist yet".
+  const expect =
+    params.expectedRemoteSha === ZERO_SHA ? "" : params.expectedRemoteSha;
+  const lease =
+    expect !== undefined
+      ? [`--force-with-lease=refs/heads/${params.branch}:${expect}`]
+      : [];
+  await git(repoDir, [
+    ...remoteArgs(remote),
+    "push",
+    "--quiet",
+    ...lease,
+    remote.url,
+    `${params.localSha}:refs/heads/${params.branch}`,
+  ]);
+}
+
+/** Delete a branch on the remote (no-op if it is already gone). */
+export async function pushDeleteBranch(
+  repoDir: string,
+  remote: ResolvedRemote,
+  branch: string,
+): Promise<void> {
+  const result = await runGit(
+    [
+      ...remoteArgs(remote),
+      "push",
+      "--quiet",
+      remote.url,
+      `:refs/heads/${branch}`,
+    ],
+    { cwd: repoDir },
+  );
+  if (result.code !== 0 && !/remote ref does not exist/i.test(result.stderr)) {
+    throw new Error(`git push (delete) failed: ${result.stderr.trim()}`);
+  }
+}
+
+/** List branch names on the remote (`git ls-remote --heads`). */
+export async function listRemoteBranchNames(
+  repoDir: string,
+  remote: ResolvedRemote,
+): Promise<string[]> {
+  const out = await git(repoDir, [
+    ...remoteArgs(remote),
+    "ls-remote",
+    "--heads",
+    remote.url,
+  ]);
+  const names: string[] = [];
+  for (const line of out.split("\n")) {
+    const match = line.match(/\trefs\/heads\/(.+)$/);
+    if (match) names.push(match[1]);
+  }
+  return names.sort((a, b) => a.localeCompare(b));
+}
+
+/** Default branch of the remote (`ls-remote --symref HEAD`), or null. */
+export async function remoteDefaultBranch(
+  repoDir: string,
+  remote: ResolvedRemote,
+): Promise<string | null> {
+  const out = await git(repoDir, [
+    ...remoteArgs(remote),
+    "ls-remote",
+    "--symref",
+    remote.url,
+    "HEAD",
+  ]);
+  const match = out.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m);
+  return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// History helpers
+// ---------------------------------------------------------------------------
+
+export interface DeletedFileRecord {
+  path: string;
+  /** Commit that deleted the file (content is at `<sha>^:<path>`). */
+  commitSha: string;
+  deletedAt: Date;
+  deletedBy: string;
+}
+
+/**
+ * Files deleted on a branch within the last `maxCommits` commits that do not
+ * exist at the branch head anymore (the git-native "recoverable files").
+ */
+export async function listDeletedFiles(
+  repoDir: string,
+  ref: string,
+  maxCommits = 200,
+): Promise<DeletedFileRecord[]> {
+  if (!(await resolveCommit(repoDir, ref))) return [];
+  const out = await git(repoDir, [
+    "log",
+    `-n`,
+    String(maxCommits),
+    "--diff-filter=D",
+    "--name-only",
+    "--no-renames",
+    "--pretty=format:__C__%H%x09%at%x09%an",
+    ref,
+  ]);
+  const alive = new Set((await listTree(repoDir, ref)).map(e => e.path));
+  const seen = new Set<string>();
+  const records: DeletedFileRecord[] = [];
+  let current: { sha: string; at: Date; by: string } | null = null;
+  for (const line of out.split("\n")) {
+    if (line.startsWith("__C__")) {
+      const [sha, at, by] = line.slice(5).split("\t");
+      current = { sha, at: new Date(Number(at) * 1000), by: by ?? "" };
+      continue;
+    }
+    const filePath = line.trim();
+    if (!filePath || !current) continue;
+    if (alive.has(filePath) || seen.has(filePath)) continue;
+    seen.add(filePath);
+    records.push({
+      path: filePath,
+      commitSha: current.sha,
+      deletedAt: current.at,
+      deletedBy: current.by,
+    });
+  }
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Retry wrapper for CAS races
+// ---------------------------------------------------------------------------
+
+export async function withCasRetry<T>(
+  fn: () => Promise<T>,
+  attempts = 3,
+): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!(error instanceof RefCasError)) throw error;
+      lastError = error;
+      logger.debug("dbt git ref CAS retry", { attempt: i + 1 });
+    }
+  }
+  throw lastError;
+}

--- a/api/src/dbt/dbt-github-git.integration.test.ts
+++ b/api/src/dbt/dbt-github-git.integration.test.ts
@@ -1,13 +1,15 @@
 /**
  * Per-user dbt working trees + git surface — integration tests.
  *
- * Real Mongoose persistence (mongodb-memory-server) with a fake in-memory
- * GitHub remote (mocked github-api module), so commit/sync/branch/merge run
- * their actual code paths. Verifies the collaboration model end-to-end:
+ * Real Mongoose persistence (mongodb-memory-server) and a REAL git remote: a
+ * local bare repository stands in for GitHub (dbt-git-remote is mocked to
+ * return its path), so fetch/push/branch operations run their actual git
+ * transport code paths. Only the pull-request REST calls are faked.
  *
+ * Verifies the collaboration model end-to-end:
  *  - drafts are per user (uncommitted edits invisible to other users)
- *  - syncs never touch drafts
- *  - commits push drafts, advance the branch base tree, and clear drafts
+ *  - syncs never touch drafts (overlays rebase onto the new head)
+ *  - commits push drafts, advance the branch mirror, and clear drafts
  *  - protected branches refuse direct commits; commit-to-branch is the
  *    escape hatch
  *  - checkouts (branch pointers) are per user
@@ -24,137 +26,34 @@ import {
 } from "vitest";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
-import { gitBlobSha } from "../integrations/github/git-blob";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
 
 vi.mock("../integrations/github/app-auth", () => ({
   resolveRepoToken: vi.fn(async () => "token"),
 }));
 
-// ---------------------------------------------------------------------------
-// Fake GitHub remote: branches are maps of path → content; head SHAs advance
-// on every commit. Implements exactly the github-api surface the services use.
-// ---------------------------------------------------------------------------
-const remote = vi.hoisted(() => {
-  const state = {
-    branches: new Map<string, { head: string; files: Map<string, string> }>(),
-    pulls: new Map<
-      number,
-      { headRef: string; baseRef: string; state: string }
-    >(),
-    commitCounter: 0,
-    defaultBranch: "main",
-  };
-  return {
-    state,
-    reset() {
-      state.branches.clear();
-      state.pulls.clear();
-      state.commitCounter = 0;
-    },
-    setBranch(name: string, files: Record<string, string>) {
-      state.commitCounter += 1;
-      state.branches.set(name, {
-        head: `commit-${state.commitCounter}`,
-        files: new Map(Object.entries(files)),
-      });
-    },
-    branch(name: string) {
-      const b = state.branches.get(name);
-      if (!b) throw new Error(`GitHub 404: no branch ${name}`);
-      return b;
-    },
-    branchByHead(sha: string) {
-      for (const [name, b] of state.branches) {
-        if (b.head === sha) return { name, ...b };
-      }
-      throw new Error(`GitHub 404: no ref ${sha}`);
-    },
-  };
-});
+// The remote is a real local bare repo; its path is set in beforeAll.
+const remotePath = vi.hoisted(() => ({ url: "" }));
+vi.mock("./dbt-git-remote", () => ({
+  resolveProjectRemote: vi.fn(async () => ({ url: remotePath.url })),
+}));
+
+// Fake pull-request REST surface backed by the real remote repo: "merging"
+// applies the head branch's tree onto the base branch with a real commit.
+const pulls = vi.hoisted(() => ({
+  state: new Map<number, { headRef: string; baseRef: string; state: string }>(),
+  reset() {
+    this.state.clear();
+  },
+}));
 
 vi.mock("../integrations/github/github-api", () => ({
-  getBranchHeadSha: vi.fn(async (_o: string, _r: string, branch: string) => {
-    return remote.branch(branch).head;
-  }),
-  getRepoTree: vi.fn(async (_o: string, _r: string, sha: string) => {
-    const branchName = sha.startsWith("tree:")
-      ? sha.slice("tree:".length)
-      : remote.branchByHead(sha).name;
-    const b = remote.branch(branchName);
-    return {
-      sha,
-      truncated: false,
-      entries: [...b.files.entries()].map(([path, content]) => ({
-        path,
-        type: "blob" as const,
-        sha: gitBlobSha(content),
-        size: content.length,
-      })),
-    };
-  }),
-  getBlobContent: vi.fn(async (_o: string, _r: string, blobSha: string) => {
-    for (const b of remote.state.branches.values()) {
-      for (const content of b.files.values()) {
-        if (gitBlobSha(content) === blobSha) return content;
-      }
-    }
-    throw new Error(`GitHub 404: no blob ${blobSha}`);
-  }),
-  getRefCommit: vi.fn(async (_o: string, _r: string, branch: string) => {
-    const b = remote.branch(branch);
-    return { commitSha: b.head, treeSha: `tree:${branch}` };
-  }),
-  commitChanges: vi.fn(
-    async (
-      _o: string,
-      _r: string,
-      params: {
-        branch: string;
-        changes: Array<{ path: string; content: string | null }>;
-      },
-    ) => {
-      const b = remote.branch(params.branch);
-      for (const change of params.changes) {
-        if (change.content === null) b.files.delete(change.path);
-        else b.files.set(change.path, change.content);
-      }
-      remote.state.commitCounter += 1;
-      b.head = `commit-${remote.state.commitCounter}`;
-      return b.head;
-    },
-  ),
-  listBranches: vi.fn(async () => [...remote.state.branches.keys()]),
-  createBranch: vi.fn(
-    async (_o: string, _r: string, name: string, fromSha: string) => {
-      const source = remote.branchByHead(fromSha);
-      remote.state.branches.set(name, {
-        head: source.head,
-        files: new Map(source.files),
-      });
-    },
-  ),
-  deleteBranch: vi.fn(async (_o: string, _r: string, name: string) => {
-    remote.state.branches.delete(name);
-  }),
-  tryDeleteBranch: vi.fn(async (_o: string, _r: string, name: string) => {
-    remote.state.branches.delete(name);
-    return { deleted: true };
-  }),
-  getRepoInfo: vi.fn(async () => ({
-    fullName: "acme/analytics",
-    owner: "acme",
-    name: "analytics",
-    defaultBranch: remote.state.defaultBranch,
-    private: false,
-  })),
   createPullRequest: vi.fn(
-    async (
-      _o: string,
-      _r: string,
-      params: { head: string; base: string },
-    ) => {
-      const number = remote.state.pulls.size + 1;
-      remote.state.pulls.set(number, {
+    async (_o: string, _r: string, params: { head: string; base: string }) => {
+      const number = pulls.state.size + 1;
+      pulls.state.set(number, {
         headRef: params.head,
         baseRef: params.base,
         state: "open",
@@ -163,7 +62,7 @@ vi.mock("../integrations/github/github-api", () => ({
     },
   ),
   getPullRequest: vi.fn(async (_o: string, _r: string, prNumber: number) => {
-    const pr = remote.state.pulls.get(prNumber);
+    const pr = pulls.state.get(prNumber);
     if (!pr) throw new Error(`GitHub 404: no PR ${prNumber}`);
     return {
       number: prNumber,
@@ -173,27 +72,32 @@ vi.mock("../integrations/github/github-api", () => ({
       state: pr.state,
     };
   }),
+  listPullRequests: vi.fn(async () => []),
+  updatePullRequest: vi.fn(),
   mergePullRequest: vi.fn(async (_o: string, _r: string, prNumber: number) => {
-    const pr = remote.state.pulls.get(prNumber);
+    const pr = pulls.state.get(prNumber);
     if (!pr) throw new Error(`GitHub 404: no PR ${prNumber}`);
-    const head = remote.branch(pr.headRef);
-    const base = remote.branch(pr.baseRef);
-    for (const [path, content] of head.files) base.files.set(path, content);
-    remote.state.commitCounter += 1;
-    base.head = `commit-${remote.state.commitCounter}`;
+    const sha = await remoteMergeBranches(pr.headRef, pr.baseRef);
     pr.state = "closed";
-    return { sha: base.head };
+    return { sha };
   }),
 }));
 
 // Imported after the mocks are registered.
 import {
   DbtCheckout,
-  DbtFile,
-  DbtFileDraft,
   DbtProject,
   type IDbtProject,
 } from "../database/workspace-schema";
+import {
+  commitTreeUpdate,
+  ensureBareRepo,
+  listTree,
+  readBlobs,
+  resolveCommit,
+  branchRef,
+  deleteRef,
+} from "./dbt-git-store.service";
 import { syncProjectBranchFromRepo } from "./dbt-github-sync.service";
 import {
   commitAndPush,
@@ -202,8 +106,11 @@ import {
   deleteProjectBranch,
   getGitStatus,
   getProjectFileDiff,
+  listProjectBranches,
+  listRecoverableFiles,
   mergeProjectPullRequest,
   ProtectedBranchError,
+  restoreDeletedFile,
   switchProjectBranch,
 } from "./dbt-github-git.service";
 import {
@@ -216,7 +123,60 @@ import {
 } from "./dbt-working-tree.service";
 
 let mongo: MongoMemoryServer;
+let gitScratch: string;
 const WS = new Types.ObjectId();
+
+const TEST_AUTHOR = { name: "tester", email: "tester@mako.dev" };
+
+/** Commit `files` as the full tree of a remote branch (like a GitHub push). */
+async function remoteSetBranch(
+  branch: string,
+  files: Record<string, string>,
+): Promise<string> {
+  const head = await resolveCommit(remotePath.url, branchRef(branch));
+  const { sha } = await commitTreeUpdate(remotePath.url, {
+    ref: branchRef(branch),
+    parents: head ? [head] : [],
+    writes: Object.entries(files).map(([p, content]) => ({
+      path: p,
+      content,
+    })),
+    // Full-tree semantics: drop files not in `files`.
+    deletes: head
+      ? (await listTree(remotePath.url, head))
+          .map(e => e.path)
+          .filter(p => !(p in files))
+      : [],
+    baseTree: head ?? undefined,
+    message: `remote update ${branch}`,
+    author: TEST_AUTHOR,
+  });
+  return sha;
+}
+
+async function remoteFiles(branch: string): Promise<Map<string, string>> {
+  const entries = await listTree(remotePath.url, branchRef(branch));
+  const blobs = await readBlobs(
+    remotePath.url,
+    entries.map(e => e.blobSha),
+  );
+  return new Map(
+    entries.map(e => [e.path, blobs.get(e.blobSha) ?? ""] as const),
+  );
+}
+
+async function remoteBranchExists(branch: string): Promise<boolean> {
+  return (await resolveCommit(remotePath.url, branchRef(branch))) !== null;
+}
+
+/** Squash-apply `head`'s tree onto `base` (the fake GitHub merge). */
+async function remoteMergeBranches(
+  head: string,
+  base: string,
+): Promise<string> {
+  const files = await remoteFiles(head);
+  return remoteSetBranch(base, Object.fromEntries(files));
+}
 
 async function seedProject(
   opts: { protectedBranches?: string[] } = {},
@@ -250,17 +210,28 @@ async function seedProject(
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create();
   await mongoose.connect(mongo.getUri());
+  gitScratch = await mkdtemp(path.join(tmpdir(), "mako-dbt-git-test-"));
+  process.env.DBT_GIT_ROOT = path.join(gitScratch, "store");
 });
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongo.stop();
+  await rm(gitScratch, { recursive: true, force: true });
+  delete process.env.DBT_GIT_ROOT;
 });
 
 beforeEach(async () => {
   vi.clearAllMocks();
-  remote.reset();
-  remote.setBranch("main", {
+  pulls.reset();
+  // Fresh remote + fresh local store for every test.
+  await rm(path.join(gitScratch, "store"), { recursive: true, force: true });
+  remotePath.url = path.join(
+    gitScratch,
+    `remote-${new Types.ObjectId().toString()}.git`,
+  );
+  await ensureBareRepo(remotePath.url);
+  await remoteSetBranch("main", {
     "dbt_project.yml": "name: analytics",
     "models/a.sql": "select 1",
   });
@@ -317,9 +288,6 @@ describe("per-user draft isolation", () => {
     await writeWorkingFile(project, "alice", "models/a.sql", "select 1");
     const status = await getGitStatus(project, "alice");
     expect(status.hasChanges).toBe(false);
-    expect(
-      await DbtFileDraft.countDocuments({ projectId: project._id }),
-    ).toBe(0);
   });
 
   it("diffs compare the caller's draft against the committed base", async () => {
@@ -335,16 +303,18 @@ describe("per-user draft isolation", () => {
 });
 
 describe("sync safety", () => {
-  it("a branch sync fast-forwards the base tree but never touches drafts", async () => {
+  it("a branch sync fast-forwards the mirror but never touches drafts", async () => {
     const project = await seedProject();
     await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
 
-    remote.setBranch("main", {
+    await remoteSetBranch("main", {
       "dbt_project.yml": "name: analytics",
       "models/a.sql": "select 10",
       "models/b.sql": "select 20",
     });
-    await syncProjectBranchFromRepo(project, "main", "webhook");
+    const sync = await syncProjectBranchFromRepo(project, "main", "webhook");
+    expect(sync.added).toBe(1);
+    expect(sync.updated).toBe(1);
 
     // Bob (clean tree) sees the new committed state.
     expect(
@@ -357,11 +327,14 @@ describe("sync safety", () => {
     expect(
       (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
     ).toBe("select 2");
+    expect(
+      (await readWorkingFile(project, "alice", "models/b.sql"))?.content,
+    ).toBe("select 20");
   });
 });
 
 describe("commit & push (per-user)", () => {
-  it("pushes the caller's drafts, updates the base tree, and clears drafts", async () => {
+  it("pushes the caller's drafts, advances the branch, and clears drafts", async () => {
     const project = await seedProject();
     await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
 
@@ -375,16 +348,13 @@ describe("commit & push (per-user)", () => {
     expect(result.pushed).toEqual({ added: 0, modified: 1, deleted: 0 });
 
     // Remote advanced.
-    expect(remote.branch("main").files.get("models/a.sql")).toBe("select 2");
-    // Base tree advanced → every user now sees the committed content.
+    expect((await remoteFiles("main")).get("models/a.sql")).toBe("select 2");
+    // Branch mirror advanced → every user now sees the committed content.
     expect(
       (await readWorkingFile(project, "bob", "models/a.sql"))?.content,
     ).toBe("select 2");
     // Drafts cleared → author's tree is clean.
     expect((await getGitStatus(project, "alice")).hasChanges).toBe(false);
-    expect(
-      await DbtFileDraft.countDocuments({ projectId: project._id }),
-    ).toBe(0);
   });
 
   it("commits only selected paths, leaving other drafts pending", async () => {
@@ -399,15 +369,18 @@ describe("commit & push (per-user)", () => {
       paths: ["models/a.sql"],
     });
     expect(result.pushed).toEqual({ added: 0, modified: 1, deleted: 0 });
-    expect(remote.branch("main").files.has("models/new.sql")).toBe(false);
+    expect((await remoteFiles("main")).has("models/new.sql")).toBe(false);
 
     const status = await getGitStatus(project, "alice");
     expect(status.changes).toEqual([
       { path: "models/new.sql", status: "added" },
     ]);
+    expect(
+      (await readWorkingFile(project, "alice", "models/new.sql"))?.content,
+    ).toBe("select 3");
   });
 
-  it("commits a draft deletion by removing the file from branch and base", async () => {
+  it("commits a draft deletion by removing the file from the branch", async () => {
     const project = await seedProject();
     await deleteWorkingFile(project, "alice", "models/a.sql");
     const result = await commitAndPush(project, {
@@ -416,8 +389,30 @@ describe("commit & push (per-user)", () => {
       updatedBy: "alice",
     });
     expect(result.pushed.deleted).toBe(1);
-    expect(remote.branch("main").files.has("models/a.sql")).toBe(false);
+    expect((await remoteFiles("main")).has("models/a.sql")).toBe(false);
     expect(await readWorkingFile(project, "bob", "models/a.sql")).toBeNull();
+  });
+
+  it("commits land on the fresh remote head when the remote advanced concurrently", async () => {
+    const project = await seedProject();
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
+
+    // Someone pushed to the remote outside Mako after alice's last sync.
+    await remoteSetBranch("main", {
+      "dbt_project.yml": "name: analytics",
+      "models/a.sql": "select 1",
+      "models/upstream.sql": "select 99",
+    });
+
+    const result = await commitAndPush(project, {
+      userId: "alice",
+      message: "fix: bump a",
+      updatedBy: "alice",
+    });
+    expect(result.committed).toBe(true);
+    const files = await remoteFiles("main");
+    expect(files.get("models/a.sql")).toBe("select 2");
+    expect(files.get("models/upstream.sql")).toBe("select 99");
   });
 });
 
@@ -433,8 +428,8 @@ describe("branch protection", () => {
         updatedBy: "alice",
       }),
     ).rejects.toThrow(ProtectedBranchError);
-    // Nothing moved: remote and base tree untouched, draft still pending.
-    expect(remote.branch("main").files.get("models/a.sql")).toBe("select 1");
+    // Nothing moved: remote untouched, draft still pending.
+    expect((await remoteFiles("main")).get("models/a.sql")).toBe("select 1");
     expect((await getGitStatus(project, "alice")).hasChanges).toBe(true);
   });
 
@@ -453,8 +448,8 @@ describe("branch protection", () => {
     expect(result.branch).toBe("feat/a");
 
     // main untouched; feature branch carries the change.
-    expect(remote.branch("main").files.get("models/a.sql")).toBe("select 1");
-    expect(remote.branch("feat/a").files.get("models/a.sql")).toBe("select 2");
+    expect((await remoteFiles("main")).get("models/a.sql")).toBe("select 1");
+    expect((await remoteFiles("feat/a")).get("models/a.sql")).toBe("select 2");
 
     // Only alice's checkout moved.
     expect(await getCheckoutBranch(project, "alice")).toBe("feat/a");
@@ -475,7 +470,7 @@ describe("branch protection", () => {
 describe("per-user checkouts", () => {
   it("switching branches moves only the caller's checkout and carries drafts", async () => {
     const project = await seedProject();
-    remote.setBranch("feature/x", {
+    await remoteSetBranch("feature/x", {
       "dbt_project.yml": "name: analytics",
       "models/a.sql": "select 100",
     });
@@ -506,7 +501,9 @@ describe("per-user checkouts", () => {
 
   it("discardLocalChanges drops the caller's drafts on switch", async () => {
     const project = await seedProject();
-    remote.setBranch("feature/x", { "dbt_project.yml": "name: analytics" });
+    await remoteSetBranch("feature/x", {
+      "dbt_project.yml": "name: analytics",
+    });
     await writeWorkingFile(project, "alice", "models/wip.sql", "select 42");
 
     const result = await switchProjectBranch(
@@ -524,19 +521,14 @@ describe("per-user checkouts", () => {
     ).toBeNull();
   });
 
-  it("create branch clones the base tree locally and checks it out for the caller", async () => {
+  it("create branch pushes the fork to the remote and checks it out for the caller", async () => {
     const project = await seedProject();
     const result = await createProjectBranch(project, "alice", "feat/clone");
     expect(result).toEqual({ branch: "feat/clone", fromBranch: "main" });
     expect(await getCheckoutBranch(project, "alice")).toBe("feat/clone");
-    expect(
-      await DbtFile.countDocuments({
-        projectId: project._id,
-        branch: "feat/clone",
-        is_deleted: { $ne: true },
-      }),
-    ).toBe(2);
-    // Working tree contents come from the cloned branch.
+    expect(await remoteBranchExists("feat/clone")).toBe(true);
+    expect(await listProjectBranches(project)).toContain("feat/clone");
+    // Working tree contents come from the forked branch.
     const files = await loadWorkingTreeContents(project, { userId: "alice" });
     expect(files.map(f => f.path)).toEqual([
       "dbt_project.yml",
@@ -546,7 +538,9 @@ describe("per-user checkouts", () => {
 
   it("refuses to delete a branch that any user has checked out", async () => {
     const project = await seedProject();
-    remote.setBranch("feature/x", { "dbt_project.yml": "name: analytics" });
+    await remoteSetBranch("feature/x", {
+      "dbt_project.yml": "name: analytics",
+    });
     await switchProjectBranch(project, "alice", "feature/x", "alice");
 
     await expect(
@@ -560,6 +554,42 @@ describe("per-user checkouts", () => {
       /default branch/,
     );
   });
+
+  it("deletes an unclaimed branch on the remote and locally", async () => {
+    const project = await seedProject();
+    await remoteSetBranch("feature/dead", {
+      "dbt_project.yml": "name: analytics",
+    });
+    await syncProjectBranchFromRepo(project, "feature/dead", "seed");
+    const result = await deleteProjectBranch(project, "bob", "feature/dead");
+    expect(result.deleted).toBe("feature/dead");
+    expect(await remoteBranchExists("feature/dead")).toBe(false);
+  });
+});
+
+describe("recoverable files (git history)", () => {
+  it("lists committed deletions and restores them as pending adds", async () => {
+    const project = await seedProject();
+    await deleteWorkingFile(project, "alice", "models/a.sql");
+    await commitAndPush(project, {
+      userId: "alice",
+      message: "chore: drop a",
+      updatedBy: "alice",
+    });
+
+    const recoverable = await listRecoverableFiles(project);
+    expect(recoverable.map(f => f.path)).toContain("models/a.sql");
+    expect(
+      recoverable.find(f => f.path === "models/a.sql")?.content,
+    ).toBe("select 1");
+
+    const restored = await restoreDeletedFile(project, "bob", "models/a.sql");
+    expect(restored.content).toBe("select 1");
+    const status = await getGitStatus(project, "bob");
+    expect(status.changes).toEqual([
+      { path: "models/a.sql", status: "added" },
+    ]);
+  });
 });
 
 describe("pull request merge", () => {
@@ -572,11 +602,7 @@ describe("pull request merge", () => {
       message: "feat: change a",
       updatedBy: "alice",
     });
-    remote.state.pulls.set(7, {
-      headRef: "feat/a",
-      baseRef: "main",
-      state: "open",
-    });
+    pulls.state.set(7, { headRef: "feat/a", baseRef: "main", state: "open" });
 
     const result = await mergeProjectPullRequest(project, {
       userId: "alice",
@@ -589,19 +615,14 @@ describe("pull request merge", () => {
     expect(result.workingTreeClean).toBe(true);
 
     // main now carries the merged change for everyone.
-    expect(remote.branch("main").files.get("models/a.sql")).toBe("select 2");
+    expect((await remoteFiles("main")).get("models/a.sql")).toBe("select 2");
     expect(
       (await readWorkingFile(project, "bob", "models/a.sql"))?.content,
     ).toBe("select 2");
 
-    // Alice is back on main; the deleted branch's base tree is gone.
+    // Alice is back on main; the head branch is gone everywhere.
     expect(await getCheckoutBranch(project, "alice")).toBe("main");
-    expect(
-      await DbtFile.countDocuments({
-        projectId: project._id,
-        branch: "feat/a",
-      }),
-    ).toBe(0);
+    expect(await remoteBranchExists("feat/a")).toBe(false);
     expect(
       await DbtCheckout.countDocuments({
         projectId: project._id,
@@ -612,7 +633,7 @@ describe("pull request merge", () => {
 
   it("rejects closed pull requests", async () => {
     const project = await seedProject();
-    remote.state.pulls.set(5, {
+    pulls.state.set(5, {
       headRef: "feat/done",
       baseRef: "main",
       state: "closed",
@@ -624,5 +645,159 @@ describe("pull request merge", () => {
         updatedBy: "alice",
       }),
     ).rejects.toThrow("Pull request #5 is closed");
+  });
+});
+
+describe("legacy Mongo lazy migration", () => {
+  it("materializes dbt_files base trees + per-user drafts into git on first touch", async () => {
+    // Seed a legacy-shaped project directly in Mongo (no git repo yet).
+    const project = await DbtProject.create({
+      workspaceId: WS,
+      name: `Legacy-${new Types.ObjectId().toString()}`,
+      environments: [
+        {
+          name: "dev",
+          connectionId: new Types.ObjectId(),
+          targetSchema: "analytics",
+          threads: 4,
+        },
+      ],
+      defaultEnvironment: "dev",
+      createdBy: "tester",
+    });
+    await mongoose.connection.collection("dbt_files").insertMany([
+      {
+        workspaceId: WS,
+        projectId: project._id,
+        path: "dbt_project.yml",
+        content: "name: legacy",
+        updatedBy: "u1",
+        is_deleted: false,
+      },
+      {
+        workspaceId: WS,
+        projectId: project._id,
+        path: "models/x.sql",
+        content: "select 1",
+        updatedBy: "u1",
+        is_deleted: false,
+      },
+      {
+        workspaceId: WS,
+        projectId: project._id,
+        path: "models/gone.sql",
+        content: "select 0",
+        updatedBy: "u1",
+        is_deleted: true,
+      },
+    ]);
+
+    const files = await loadWorkingTreeContents(project, { userId: "u1" });
+    expect(files).toEqual([
+      { path: "dbt_project.yml", content: "name: legacy" },
+      { path: "models/x.sql", content: "select 1" },
+    ]);
+
+    // Soft-deleted legacy content survives in git history: it was committed
+    // then deleted, so the blob is reachable from the import commits.
+    const state = await readWorkingFile(project, "u1", "models/gone.sql");
+    expect(state).toBeNull();
+  });
+
+  it("imports repo-project drafts as per-user overlays", async () => {
+    // Remote + legacy Mongo mirror + one pending draft for alice.
+    const project = await DbtProject.create({
+      workspaceId: WS,
+      name: `LegacyRepo-${new Types.ObjectId().toString()}`,
+      environments: [
+        {
+          name: "dev",
+          connectionId: new Types.ObjectId(),
+          targetSchema: "analytics",
+          threads: 4,
+        },
+      ],
+      defaultEnvironment: "dev",
+      createdBy: "tester",
+      repo: {
+        provider: "github",
+        owner: "acme",
+        repo: "analytics",
+        branch: "main",
+        installationId: 123,
+      },
+    });
+    await mongoose.connection.collection("dbt_files").insertMany([
+      {
+        workspaceId: WS,
+        projectId: project._id,
+        branch: "main",
+        path: "dbt_project.yml",
+        content: "name: analytics",
+        updatedBy: "u1",
+        is_deleted: false,
+      },
+      {
+        workspaceId: WS,
+        projectId: project._id,
+        branch: "main",
+        path: "models/a.sql",
+        content: "select 1",
+        updatedBy: "u1",
+        is_deleted: false,
+      },
+    ]);
+    await mongoose.connection.collection("dbt_file_drafts").insertOne({
+      workspaceId: WS,
+      projectId: project._id,
+      userId: "alice",
+      path: "models/a.sql",
+      content: "select 2",
+      is_deleted: false,
+    });
+
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 2");
+    expect(
+      (await readWorkingFile(project, "bob", "models/a.sql"))?.content,
+    ).toBe("select 1");
+    const status = await getGitStatus(project, "alice");
+    expect(status.changes).toEqual([
+      { path: "models/a.sql", status: "modified" },
+    ]);
+  });
+});
+
+describe("draft ref hygiene", () => {
+  it("an overlay that becomes redundant after a sync is dropped", async () => {
+    const project = await seedProject();
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
+    // The same change lands upstream.
+    await remoteSetBranch("main", {
+      "dbt_project.yml": "name: analytics",
+      "models/a.sql": "select 2",
+    });
+    await syncProjectBranchFromRepo(project, "main", "webhook");
+    const status = await getGitStatus(project, "alice");
+    expect(status.hasChanges).toBe(false);
+  });
+
+  it("cleans up when a draft ref survives without its base", async () => {
+    const project = await seedProject();
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
+    // Simulate a lost base ref (crash between ref updates).
+    const { repoDirFor, draftRefsFor } = await import(
+      "./dbt-git-store.service"
+    );
+    const repoDir = repoDirFor(
+      project.workspaceId.toString(),
+      project._id.toString(),
+    );
+    await deleteRef(repoDir, draftRefsFor("alice").base);
+    // Base defaults to the current head → overlay stays intact.
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 2");
   });
 });

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -3,12 +3,12 @@
  * status, commit & push, branch create/switch, and pull requests — the in-IDE
  * git surface that mirrors dbt Cloud.
  *
- * The working tree is per user: DbtFile rows are the COMMITTED base tree of a
- * branch, DbtFileDraft rows are the caller's uncommitted overlay, and
- * DbtCheckout points each user at their own branch. Status/commit therefore
- * only ever see the acting user's drafts. Pushing builds a single commit via
- * the Git Data API, updates the branch's base tree, and clears the committed
- * drafts.
+ * File content lives exclusively in the project's local bare git repository
+ * (dbt-git-store.service.ts): local branches mirror the GitHub remote, and a
+ * user's uncommitted work is a draft overlay ref rebased onto their checkout
+ * branch head. Commits are real git commits pushed with
+ * `--force-with-lease`; branch create/delete are `git push` operations.
+ * Pull-request metadata (open/list/merge/close) stays on the GitHub API.
  *
  * Branch protection: branches listed in `project.protectedBranches` refuse
  * direct commits — changes reach them only through a PR (commit-to-branch →
@@ -16,39 +16,48 @@
  */
 import {
   DbtCheckout,
-  DbtFile,
-  DbtFileDraft,
   DbtProject,
   type IDbtProject,
 } from "../database/workspace-schema";
 import { resolveRepoToken } from "../integrations/github/app-auth";
-import { gitBlobSha } from "../integrations/github/git-blob";
 import {
-  commitChanges,
-  createBranch,
   createPullRequest,
-  deleteBranch,
   getPullRequest,
-  getRefCommit,
-  getRepoInfo,
-  getRepoTree,
-  listBranches,
   listPullRequests,
   mergePullRequest,
-  tryDeleteBranch,
   updatePullRequest,
   type MergeMethod,
   type PullRequestSummary,
-  type TreeChange,
 } from "../integrations/github/github-api";
+import { resolveProjectRemote } from "./dbt-git-remote";
+import {
+  ZERO_SHA,
+  authorFor,
+  branchRef,
+  commitTreeUpdate,
+  deleteRef,
+  draftRefsFor,
+  fetchBranch,
+  listDeletedFiles,
+  listRemoteBranchNames,
+  pushBranch,
+  pushDeleteBranch,
+  readBlobAt,
+  remoteDefaultBranch,
+  resolveCommit,
+  treeShaOf,
+  updateRef,
+} from "./dbt-git-store.service";
+import { toProjectPath, toRepoPath } from "./dbt-paths";
 import { syncProjectBranchFromRepo } from "./dbt-github-sync.service";
 import {
-  baseTreeFilter,
-  cloneBranchBaseTree,
-  deleteBranchBaseTree,
   discardUserDrafts,
+  ensureProjectRepo,
   getCheckoutBranch,
+  resolveWorkingState,
   setCheckoutBranch,
+  workingTreeChanges,
+  writeWorkingFile,
 } from "./dbt-working-tree.service";
 
 /**
@@ -143,11 +152,6 @@ export interface GitStatusOptions {
   paths?: string[];
 }
 
-function repoPath(project: IDbtProject, path: string): string {
-  const subdir = project.repo?.subdirectory?.replace(/^\/+|\/+$/g, "");
-  return subdir ? `${subdir}/${path}` : path;
-}
-
 function normalizeCommitPaths(paths?: string[]): string[] | undefined {
   if (!paths) return undefined;
   const normalized = [
@@ -205,90 +209,22 @@ function filterGitStatus(status: GitStatus, paths?: string[]): GitStatus {
   return summarizeChanges(status.branch, selectedChanges);
 }
 
-interface DraftForStatus {
-  path: string;
-  content?: string;
-  is_deleted?: boolean;
-}
-
-interface BaseForStatus {
-  path: string;
-  content?: string;
-  repoBlobSha?: string;
-}
-
-/** Pure status computation: the caller's drafts vs a branch's base tree. */
-export function computeDraftStatus(
-  branch: string,
-  drafts: DraftForStatus[],
-  baseByPath: Map<string, BaseForStatus>,
-): GitStatus {
-  const changes: GitFileStatus[] = [];
-  for (const draft of drafts) {
-    const base = baseByPath.get(draft.path);
-    if (draft.is_deleted) {
-      // Only counts as a deletion if the file exists on the branch.
-      if (base) changes.push({ path: draft.path, status: "deleted" });
-      continue;
-    }
-    if (!base) {
-      changes.push({ path: draft.path, status: "added" });
-      continue;
-    }
-    const baseSha = base.repoBlobSha ?? gitBlobSha(base.content ?? "");
-    if (gitBlobSha(draft.content ?? "") !== baseSha) {
-      changes.push({ path: draft.path, status: "modified" });
-    }
-  }
-  changes.sort((a, b) => a.path.localeCompare(b.path));
-  return summarizeChanges(branch, changes);
-}
-
-async function loadStatusInputs(
-  project: IDbtProject,
-  userId: string,
-): Promise<{
-  branch: string;
-  drafts: DraftForStatus[];
-  baseByPath: Map<string, BaseForStatus>;
-}> {
-  if (!project.repo) {
-    throw new Error("Project is not connected to a repository");
-  }
-  const branch = (await getCheckoutBranch(project, userId)) as string;
-  const [drafts, baseRows] = await Promise.all([
-    DbtFileDraft.find({ projectId: project._id, userId })
-      .select("path content is_deleted")
-      .lean(),
-    DbtFile.find({
-      ...baseTreeFilter(project, branch),
-      is_deleted: { $ne: true },
-    })
-      .select("path content repoBlobSha")
-      .lean(),
-  ]);
-  return {
-    branch,
-    drafts,
-    baseByPath: new Map(baseRows.map(row => [row.path, row])),
-  };
-}
-
 /**
- * Compute the caller's working-tree status: their drafts vs the committed
- * base tree of their checked-out branch. Other users' drafts never appear.
+ * Compute the caller's working-tree status: their draft overlay vs the head
+ * of their checked-out branch. Other users' drafts never appear.
  */
 export async function getGitStatus(
   project: IDbtProject,
   userId: string,
   options: GitStatusOptions = {},
 ): Promise<GitStatus> {
-  const { branch, drafts, baseByPath } = await loadStatusInputs(
-    project,
-    userId,
-  );
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  const state = await resolveWorkingState(project, userId);
+  const changes = await workingTreeChanges(project, state);
   return filterGitStatus(
-    computeDraftStatus(branch, drafts, baseByPath),
+    summarizeChanges(state.branch, changes),
     options.paths,
   );
 }
@@ -303,9 +239,8 @@ export interface GitFileDiff {
 }
 
 /**
- * Side-by-side diff for one changed file: the committed base content (from
- * the branch's base tree in Mongo — no GitHub round-trip) vs the caller's
- * draft content.
+ * Side-by-side diff for one changed file: the committed content at the
+ * branch head vs the caller's working-tree content.
  */
 export async function getProjectFileDiff(
   project: IDbtProject,
@@ -315,30 +250,21 @@ export async function getProjectFileDiff(
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
-  const branch = await getCheckoutBranch(project, userId);
-  const [draft, baseRow] = await Promise.all([
-    DbtFileDraft.findOne({ projectId: project._id, userId, path })
-      .select("content is_deleted")
-      .lean(),
-    DbtFile.findOne({
-      ...baseTreeFilter(project, branch),
-      path,
-      is_deleted: { $ne: true },
-    })
-      .select("content")
-      .lean(),
-  ]);
-  if (!draft) throw new Error(`No pending change for file: ${path}`);
+  const state = await resolveWorkingState(project, userId);
+  const changes = await workingTreeChanges(project, state);
+  const change = changes.find(c => c.path === path);
+  if (!change) throw new Error(`No pending change for file: ${path}`);
 
-  const base = baseRow?.content ?? "";
-  const working = draft.is_deleted ? "" : (draft.content ?? "");
-  const status: GitFileStatus["status"] = draft.is_deleted
-    ? "deleted"
-    : baseRow
-      ? "modified"
-      : "added";
+  const repoPath = toRepoPath(project, path);
+  const base = state.headSha
+    ? ((await readBlobAt(state.repoDir, state.headSha, repoPath)) ?? "")
+    : "";
+  const working =
+    change.status === "deleted" || !state.workingSha
+      ? ""
+      : ((await readBlobAt(state.repoDir, state.workingSha, repoPath)) ?? "");
 
-  return { path, status, base, working };
+  return { path, status: change.status, base, working };
 }
 
 export interface CommitResult {
@@ -349,9 +275,9 @@ export interface CommitResult {
 }
 
 /**
- * Commit the caller's draft changes and push them to their checked-out branch
- * in a single commit. Updates the branch's base tree (so every user on that
- * branch sees the committed state) and clears the committed drafts.
+ * Commit the caller's pending changes and push them to their checked-out
+ * branch in a single commit. Advances the local branch mirror (so every user
+ * on that branch sees the committed state) and clears the committed overlay.
  *
  * Refuses when the checkout branch is protected (PR-only).
  */
@@ -366,118 +292,89 @@ export async function commitAndPush(
 ): Promise<CommitResult> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
-    const branch = (await getCheckoutBranch(fresh, params.userId)) as string;
+    const branch = await getCheckoutBranch(fresh, params.userId);
     assertNotProtected(fresh, branch);
-    const status = await getGitStatus(fresh, params.userId, {
+    return pushWorkingTree(fresh, params.userId, branch, {
+      message: params.message,
       paths: params.paths,
+      allowEmpty: true,
     });
-    if (!status.hasChanges) {
+  });
+}
+
+/**
+ * Build a single commit from the caller's overlay and push it to `branch`.
+ * The caller MUST hold the project git lock.
+ */
+async function pushWorkingTree(
+  project: RepoBoundProject,
+  userId: string,
+  branch: string,
+  params: { message: string; paths?: string[]; allowEmpty?: boolean },
+): Promise<CommitResult> {
+  const repoDir = await ensureProjectRepo(project);
+  const remote = await resolveProjectRemote(project.repo);
+
+  // Refresh the branch from the remote first so the commit applies on the
+  // true head (concurrent pushes from outside Mako).
+  const headSha = await fetchBranch(repoDir, remote, branch);
+
+  const state = await resolveWorkingState(project, userId);
+  const allChanges = await workingTreeChanges(project, state);
+  const status = filterGitStatus(
+    summarizeChanges(branch, allChanges),
+    params.paths,
+  );
+  if (!status.hasChanges) {
+    if (params.allowEmpty) {
       return {
         committed: false,
         branch,
         pushed: { added: 0, modified: 0, deleted: 0 },
       };
     }
-    return pushWorkingTree(fresh, params.userId, branch, status, {
-      message: params.message,
-      updatedBy: params.updatedBy,
-    });
-  });
-}
-
-/**
- * Build a single commit from the caller's drafts and push it to `branch`.
- * Updates base rows, clears the committed drafts, and stamps sync SHAs. The
- * caller MUST hold the project git lock.
- */
-async function pushWorkingTree(
-  project: RepoBoundProject,
-  userId: string,
-  branch: string,
-  status: GitStatus,
-  params: { message: string; updatedBy: string },
-): Promise<CommitResult> {
-  const token = await resolveRepoToken(project.repo.installationId);
-  const { owner, repo } = project.repo;
-
-  const drafts = await DbtFileDraft.find({ projectId: project._id, userId })
-    .select("path content is_deleted")
-    .lean();
-  const draftByPath = new Map(drafts.map(d => [d.path, d]));
-
-  const { commitSha, treeSha } = await getRefCommit(owner, repo, branch, token);
-
-  // GitHub returns 422 GitRPC::BadObject if a tree entry deletes (sha:null) a
-  // path that isn't in base_tree. Phantom deletions (files removed upstream
-  // but still draft-deleted locally) would trip this, so drop any deletion
-  // whose path no longer exists on the branch and just reconcile it locally.
-  const baseTree = await getRepoTree(owner, repo, treeSha, token);
-  const baseTreePaths = new Set(
-    baseTree.entries.filter(e => e.type === "blob").map(e => e.path),
-  );
-
-  const treeChanges: TreeChange[] = [];
-  const phantomDeletions: string[] = [];
-  for (const change of status.changes) {
-    const path = repoPath(project, change.path);
-    if (change.status === "deleted") {
-      if (!baseTreePaths.has(path)) {
-        phantomDeletions.push(change.path);
-        continue;
-      }
-      treeChanges.push({ path, content: null });
-    } else {
-      treeChanges.push({
-        path,
-        content: draftByPath.get(change.path)?.content ?? "",
-      });
-    }
-  }
-
-  // Reconcile local state: base rows advance to the committed content and the
-  // committed drafts disappear. Phantom deletions never reach GitHub but must
-  // still be cleaned up so they stop showing as pending changes.
-  const ops: Array<Promise<unknown>> = [];
-  for (const change of status.changes) {
-    ops.push(
-      DbtFileDraft.deleteOne({
-        projectId: project._id,
-        userId,
-        path: change.path,
-      }).exec(),
+    throw new Error(
+      "No working-tree changes to promote — nothing to put on a new branch. " +
+        "The changes may already be committed (check dbt_git_status).",
     );
+  }
+
+  // Selected changes come out of the draft tip's tree.
+  const writes: Array<{ path: string; content: string }> = [];
+  const deletes: string[] = [];
+  for (const change of status.changes) {
+    const repoPath = toRepoPath(project, change.path);
     if (change.status === "deleted") {
-      ops.push(
-        DbtFile.deleteOne({
-          projectId: project._id,
-          branch,
-          path: change.path,
-        }).exec(),
-      );
+      deletes.push(repoPath);
     } else {
-      const content = draftByPath.get(change.path)?.content ?? "";
-      ops.push(
-        DbtFile.updateOne(
-          { projectId: project._id, branch, path: change.path },
-          {
-            $set: {
-              content,
-              updatedBy: params.updatedBy,
-              is_deleted: false,
-              workspaceId: project.workspaceId,
-              repoBlobSha: gitBlobSha(content),
-            },
-          },
-          { upsert: true, setDefaultsOnInsert: true },
-        ).exec(),
+      const content = await readBlobAt(
+        repoDir,
+        state.workingSha as string,
+        repoPath,
       );
+      writes.push({ path: repoPath, content: content ?? "" });
     }
   }
 
-  // Nothing real to push (every change was a phantom deletion): heal local
-  // state without creating an empty commit.
-  if (treeChanges.length === 0) {
-    await Promise.all(ops);
+  // Dangling commit first; the local branch mirror only advances after the
+  // remote accepted the push, so it always mirrors the remote.
+  const { sha, treeSha } = await commitTreeUpdate(repoDir, {
+    baseTree: headSha,
+    parents: [headSha],
+    writes,
+    deletes,
+    message: params.message,
+    author: authorFor(userId),
+  });
+
+  // Every selected change was a no-op against the fresh head (e.g. deletions
+  // of files already removed upstream) — heal the overlay without pushing an
+  // empty commit.
+  if (treeSha === (await treeShaOf(repoDir, headSha))) {
+    await clearCommittedOverlay(project, userId, repoDir, status, {
+      newHead: headSha,
+      allChanges,
+    });
     return {
       committed: false,
       branch,
@@ -485,24 +382,21 @@ async function pushWorkingTree(
     };
   }
 
-  const newSha = await commitChanges(
-    owner,
-    repo,
-    {
-      branch,
-      parentSha: commitSha,
-      baseTreeSha: treeSha,
-      message: params.message,
-      changes: treeChanges,
-    },
-    token,
-  );
+  await pushBranch(repoDir, remote, {
+    localSha: sha,
+    branch,
+    expectedRemoteSha: headSha,
+  });
+  await updateRef(repoDir, branchRef(branch), sha, headSha);
 
-  await Promise.all(ops);
+  await clearCommittedOverlay(project, userId, repoDir, status, {
+    newHead: sha,
+    allChanges,
+  });
 
-  await setCheckoutBranch(project, userId, branch, { lastSyncedSha: newSha });
+  await setCheckoutBranch(project, userId, branch, { lastSyncedSha: sha });
   if (branch === project.repo.branch) {
-    project.repo.lastSyncedSha = newSha;
+    project.repo.lastSyncedSha = sha;
     project.repo.lastSyncedAt = new Date();
     project.markModified("repo");
     await project.save();
@@ -510,14 +404,62 @@ async function pushWorkingTree(
 
   return {
     committed: true,
-    sha: newSha,
+    sha,
     branch,
     pushed: {
       added: status.added,
       modified: status.modified,
-      deleted: status.deleted - phantomDeletions.length,
+      deleted: status.deleted,
     },
   };
+}
+
+/**
+ * After a commit lands, drop the committed paths from the user's overlay.
+ * A partial commit (`paths`) keeps the remaining changes as a fresh overlay
+ * forked from the new head; a full commit deletes the overlay.
+ */
+async function clearCommittedOverlay(
+  project: RepoBoundProject,
+  userId: string,
+  repoDir: string,
+  status: GitStatus,
+  opts: { newHead: string; allChanges: GitFileStatus[] },
+): Promise<void> {
+  const refs = draftRefsFor(userId);
+  const committedPaths = new Set(status.changes.map(change => change.path));
+  const remaining = opts.allChanges.filter(
+    change => !committedPaths.has(change.path),
+  );
+
+  if (remaining.length === 0) {
+    await deleteRef(repoDir, refs.tip);
+    await deleteRef(repoDir, refs.base);
+    return;
+  }
+
+  const tip = await resolveCommit(repoDir, refs.tip);
+  const writes: Array<{ path: string; content: string }> = [];
+  const deletes: string[] = [];
+  for (const change of remaining) {
+    const repoPath = toRepoPath(project, change.path);
+    if (change.status === "deleted") {
+      deletes.push(repoPath);
+    } else {
+      const content = tip ? await readBlobAt(repoDir, tip, repoPath) : null;
+      writes.push({ path: repoPath, content: content ?? "" });
+    }
+  }
+  await commitTreeUpdate(repoDir, {
+    ref: refs.tip,
+    baseTree: opts.newHead,
+    parents: [opts.newHead],
+    writes,
+    deletes,
+    message: "Carry uncommitted changes",
+    author: authorFor(userId),
+  });
+  await updateRef(repoDir, refs.base, opts.newHead);
 }
 
 export interface PromoteResult extends CommitResult {
@@ -527,9 +469,9 @@ export interface PromoteResult extends CommitResult {
 
 /**
  * Atomic "promote": create a feature branch off the caller's checked-out
- * branch HEAD and commit their drafts onto it — in one locked critical
- * section. This is the path around protected branches: work done on a
- * protected checkout moves to a feature branch for review.
+ * branch HEAD and commit their pending changes onto it — in one locked
+ * critical section. This is the path around protected branches: work done on
+ * a protected checkout moves to a feature branch for review.
  *
  * Afterwards the caller's checkout tracks the new branch with a clean
  * overlay; open a PR with `openProjectPullRequest`.
@@ -547,39 +489,33 @@ export async function commitToNewBranch(
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
     assertNotProtected(fresh, params.branchName);
-    const fromBranch = (await getCheckoutBranch(
-      fresh,
-      params.userId,
-    )) as string;
-    const status = await getGitStatus(fresh, params.userId, {
-      paths: params.paths,
-    });
-    if (!status.hasChanges) {
-      throw new Error(
-        "No working-tree changes to promote — nothing to put on a new branch. " +
-          "The changes may already be committed (check dbt_git_status).",
-      );
-    }
+    const fromBranch = await getCheckoutBranch(fresh, params.userId);
 
-    const token = await resolveRepoToken(fresh.repo.installationId);
-    const { owner, repo } = fresh.repo;
-
-    // Fork the new branch from the branch the user currently tracks, clone
-    // its committed base tree, and point the user's checkout at it BEFORE
-    // committing so pushWorkingTree targets the new branch.
-    const { commitSha } = await getRefCommit(owner, repo, fromBranch, token);
-    await createBranch(owner, repo, params.branchName, commitSha, token);
-    await cloneBranchBaseTree(fresh, fromBranch, params.branchName);
-    await setCheckoutBranch(fresh, params.userId, params.branchName);
-
-    const result = await pushWorkingTree(
+    // Fork the new branch from the branch the user currently tracks and
+    // point their checkout at it BEFORE committing so pushWorkingTree
+    // targets the new branch. Their overlay follows the checkout.
+    const created = await createBranchFromCheckout(
       fresh,
       params.userId,
       params.branchName,
-      status,
-      { message: params.message, updatedBy: params.updatedBy },
     );
-    return { ...result, fromBranch };
+
+    try {
+      const result = await pushWorkingTree(
+        fresh,
+        params.userId,
+        params.branchName,
+        { message: params.message, paths: params.paths },
+      );
+      return { ...result, fromBranch };
+    } catch (error) {
+      // Restore the previous checkout so a failed promote leaves the user
+      // where they started (the new remote branch may remain — harmless).
+      await setCheckoutBranch(fresh, params.userId, fromBranch, {
+        lastSyncedSha: created.fromSha,
+      });
+      throw error;
+    }
   });
 }
 
@@ -589,14 +525,41 @@ export async function listProjectBranches(
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
-  const token = await resolveRepoToken(project.repo.installationId);
-  return listBranches(project.repo.owner, project.repo.repo, token);
+  const repoDir = await ensureProjectRepo(project);
+  const remote = await resolveProjectRemote(project.repo);
+  return listRemoteBranchNames(repoDir, remote);
+}
+
+/** Fork a new branch off the user's checkout head and check it out. */
+async function createBranchFromCheckout(
+  project: RepoBoundProject,
+  userId: string,
+  branchName: string,
+): Promise<{ fromBranch: string; fromSha: string }> {
+  const fromBranch = await getCheckoutBranch(project, userId);
+  const repoDir = await ensureProjectRepo(project);
+  const remote = await resolveProjectRemote(project.repo);
+  const fromSha = await fetchBranch(repoDir, remote, fromBranch);
+
+  const existing = await resolveCommit(repoDir, branchRef(branchName));
+  if (existing) {
+    throw new Error(`Branch "${branchName}" already exists`);
+  }
+  await pushBranch(repoDir, remote, {
+    localSha: fromSha,
+    branch: branchName,
+    expectedRemoteSha: ZERO_SHA,
+  });
+  await updateRef(repoDir, branchRef(branchName), fromSha);
+  await setCheckoutBranch(project, userId, branchName, {
+    lastSyncedSha: fromSha,
+  });
+  return { fromBranch, fromSha };
 }
 
 /**
  * Create a new branch off the caller's checkout HEAD and check it out for
- * them (only their checkout moves — other users are unaffected). Content is
- * identical to the source branch, so the base tree is cloned locally.
+ * them (only their checkout moves — other users are unaffected).
  */
 export async function createProjectBranch(
   project: IDbtProject,
@@ -605,25 +568,20 @@ export async function createProjectBranch(
 ): Promise<{ branch: string; fromBranch: string }> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
-    const fromBranch = (await getCheckoutBranch(fresh, userId)) as string;
-    const token = await resolveRepoToken(fresh.repo.installationId);
-    const { owner, repo } = fresh.repo;
-    const { commitSha } = await getRefCommit(owner, repo, fromBranch, token);
-    await createBranch(owner, repo, branchName, commitSha, token);
-    await cloneBranchBaseTree(fresh, fromBranch, branchName);
-    await setCheckoutBranch(fresh, userId, branchName, {
-      lastSyncedSha: commitSha,
-    });
+    const { fromBranch } = await createBranchFromCheckout(
+      fresh,
+      userId,
+      branchName,
+    );
     return { branch: branchName, fromBranch };
   });
 }
 
 /**
  * Switch the caller's checkout to another branch. Only their branch pointer
- * moves; their drafts carry over as an overlay (like `git checkout` with a
- * dirty tree), so nothing is lost. Pass `discardLocalChanges` to drop the
- * caller's drafts instead. The target branch's committed base tree is synced
- * from GitHub.
+ * moves; their pending changes carry over as an overlay (like `git checkout`
+ * with a dirty tree), so nothing is lost. Pass `discardLocalChanges` to drop
+ * the caller's changes instead. The target branch is synced from the remote.
  */
 export async function switchProjectBranch(
   project: IDbtProject,
@@ -642,7 +600,7 @@ export async function switchProjectBranch(
       await discardUserDrafts(fresh, userId);
     }
 
-    // Materialize/refresh the target branch's committed base tree.
+    // Materialize/refresh the target branch from the remote.
     const sync = await syncProjectBranchFromRepo(fresh, branchName, updatedBy);
     await setCheckoutBranch(fresh, userId, branchName, {
       lastSyncedSha: sync.sha,
@@ -660,7 +618,7 @@ export async function switchProjectBranch(
 /**
  * Delete a remote branch. Refuses to delete the caller's checked-out branch,
  * any branch another user has checked out, the project default branch, and
- * the repo default branch. Cleans up the branch's local base tree.
+ * the repo default branch. Cleans up the local mirror ref.
  */
 export async function deleteProjectBranch(
   project: IDbtProject,
@@ -669,8 +627,8 @@ export async function deleteProjectBranch(
 ): Promise<{ deleted: string }> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
-    const token = await resolveRepoToken(fresh.repo.installationId);
-    const { owner, repo } = fresh.repo;
+    const repoDir = await ensureProjectRepo(fresh);
+    const remote = await resolveProjectRemote(fresh.repo);
     const userBranch = await getCheckoutBranch(fresh, userId);
     if (branchName === userBranch) {
       throw new Error(
@@ -695,14 +653,14 @@ export async function deleteProjectBranch(
         `Cannot delete "${branchName}" — another user has it checked out.`,
       );
     }
-    const info = await getRepoInfo(owner, repo, token);
-    if (branchName === info.defaultBranch) {
+    const defaultBranch = await remoteDefaultBranch(repoDir, remote);
+    if (branchName === defaultBranch) {
       throw new Error(
         `Refusing to delete the repository's default branch "${branchName}".`,
       );
     }
-    await deleteBranch(owner, repo, branchName, token);
-    await deleteBranchBaseTree(fresh, branchName);
+    await pushDeleteBranch(repoDir, remote, branchName);
+    await deleteRef(repoDir, branchRef(branchName));
     return { deleted: branchName };
   });
 }
@@ -715,34 +673,45 @@ export interface RecoverableFile {
 }
 
 /**
- * Soft-deleted files whose content is still retained in Mongo and can be
- * restored — e.g. work hidden by a destructive branch switch/sync before the
- * non-destructive guards landed. These don't appear in the normal file tree.
+ * Files deleted in recent commits of the project's tracked branch whose
+ * content is still recoverable from git history. These don't appear in the
+ * normal file tree.
  */
 export async function listRecoverableFiles(
   project: IDbtProject,
 ): Promise<RecoverableFile[]> {
-  const files = await DbtFile.find({
-    projectId: project._id,
-    is_deleted: true,
-  })
-    .select("path content updatedAt updatedBy")
-    .sort({ updatedAt: -1 })
-    .lean();
-  return files
-    .filter(f => (f.content ?? "").length > 0)
-    .map(f => ({
-      path: f.path,
-      content: f.content ?? "",
-      updatedAt: f.updatedAt,
-      updatedBy: f.updatedBy,
-    }));
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  const repoDir = await ensureProjectRepo(project);
+  const records = await listDeletedFiles(
+    repoDir,
+    branchRef(project.repo.branch),
+  );
+  const files: RecoverableFile[] = [];
+  for (const record of records) {
+    const rel = toProjectPath(project, record.path);
+    if (!rel) continue;
+    const content = await readBlobAt(
+      repoDir,
+      `${record.commitSha}^`,
+      record.path,
+    );
+    if (!content) continue;
+    files.push({
+      path: rel,
+      content,
+      updatedAt: record.deletedAt,
+      updatedBy: record.deletedBy,
+    });
+  }
+  return files;
 }
 
 /**
- * Restore a soft-deleted file into the caller's working tree as a pending
- * "added" draft, so they can review and commit it. Returns the restored
- * content for confirmation.
+ * Restore a deleted file (from git history) into the caller's working tree
+ * as a pending "added" change, so they can review and commit it. Returns the
+ * restored content for confirmation.
  */
 export async function restoreDeletedFile(
   project: IDbtProject,
@@ -750,29 +719,13 @@ export async function restoreDeletedFile(
   path: string,
 ): Promise<{ path: string; content: string }> {
   return withProjectGitLock(project._id.toString(), async () => {
-    const file = await DbtFile.findOne({
-      projectId: project._id,
-      path,
-      is_deleted: true,
-    })
-      .select("content")
-      .sort({ updatedAt: -1 })
-      .lean();
+    const files = await listRecoverableFiles(project);
+    const file = files.find(f => f.path === path);
     if (!file) {
       throw new Error(`No recoverable file at "${path}".`);
     }
-    await DbtFileDraft.updateOne(
-      { projectId: project._id, userId, path },
-      {
-        $set: {
-          content: file.content ?? "",
-          is_deleted: false,
-          workspaceId: project.workspaceId,
-        },
-      },
-      { upsert: true },
-    ).exec();
-    return { path, content: file.content ?? "" };
+    await writeWorkingFile(project, userId, path, file.content);
+    return { path, content: file.content };
   });
 }
 
@@ -786,11 +739,12 @@ export async function openProjectPullRequest(
   }
   const token = await resolveRepoToken(project.repo.installationId);
   const { owner, repo } = project.repo;
-  const branch = (await getCheckoutBranch(project, userId)) as string;
+  const branch = await getCheckoutBranch(project, userId);
   let base = params.base;
   if (!base) {
-    const info = await getRepoInfo(owner, repo, token);
-    base = info.defaultBranch;
+    const repoDir = await ensureProjectRepo(project);
+    const remote = await resolveProjectRemote(project.repo);
+    base = (await remoteDefaultBranch(repoDir, remote)) ?? project.repo.branch;
   }
   if (base === branch) {
     throw new Error(
@@ -869,11 +823,32 @@ export interface ClosePullRequestResult {
   branchDeleteWarning?: string;
 }
 
+/** Best-effort remote branch deletion with a user-facing warning on failure. */
+async function tryDeleteRemoteBranch(
+  project: RepoBoundProject,
+  branch: string,
+): Promise<{ deleted: boolean; warning?: string }> {
+  try {
+    const repoDir = await ensureProjectRepo(project);
+    const remote = await resolveProjectRemote(project.repo);
+    await pushDeleteBranch(repoDir, remote, branch);
+    await deleteRef(repoDir, branchRef(branch));
+    return { deleted: true };
+  } catch (error) {
+    return {
+      deleted: false,
+      warning: `Branch "${branch}" could not be deleted: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
 /**
  * Close a pull request WITHOUT merging it. Optionally delete its head branch
  * afterwards (default false — closing shouldn't destroy the work). Branch
  * deletion refuses when the branch is the project default or any user has it
- * checked out; a deleted branch's local base tree is cleaned up.
+ * checked out.
  */
 export async function closeProjectPullRequest(
   project: IDbtProject,
@@ -918,12 +893,9 @@ export async function closeProjectPullRequest(
           `Branch "${headRef}" was not deleted — a user has it checked out. ` +
           "Delete it with dbt_delete_branch after they switch away.";
       } else {
-        const deleteResult = await tryDeleteBranch(owner, repo, headRef, token);
+        const deleteResult = await tryDeleteRemoteBranch(fresh, headRef);
         branchDeleted = deleteResult.deleted;
         branchDeleteWarning = deleteResult.warning;
-        if (branchDeleted) {
-          await deleteBranchBaseTree(fresh, headRef);
-        }
       }
     }
 
@@ -942,9 +914,9 @@ export interface MergePullRequestResult {
 /**
  * Merge a GitHub pull request, optionally delete its head branch, then switch
  * the caller's checkout back to the repo default branch and sync the merged
- * state into that branch's base tree. The caller's drafts (if any) carry over
- * as an overlay. Users checked out on the deleted head branch are moved back
- * to the default branch.
+ * state. The caller's pending changes (if any) carry over as an overlay.
+ * Users checked out on the deleted head branch are moved back to the default
+ * branch.
  */
 export async function mergeProjectPullRequest(
   project: IDbtProject,
@@ -968,8 +940,10 @@ export async function mergeProjectPullRequest(
       );
     }
 
-    const info = await getRepoInfo(owner, repo, token);
-    const defaultBranch = info.defaultBranch;
+    const repoDir = await ensureProjectRepo(fresh);
+    const remote = await resolveProjectRemote(fresh.repo);
+    const defaultBranch =
+      (await remoteDefaultBranch(repoDir, remote)) ?? fresh.repo.branch;
 
     const { sha } = await mergePullRequest(
       owner,
@@ -979,8 +953,8 @@ export async function mergeProjectPullRequest(
       token,
     );
 
-    // Pull the merged state into the default branch's base tree and move the
-    // caller (plus anyone stranded on the head branch) onto it.
+    // Pull the merged state into the local default branch mirror and move
+    // the caller (plus anyone stranded on the head branch) onto it.
     const syncResult = await syncProjectBranchFromRepo(
       fresh,
       defaultBranch,
@@ -993,16 +967,10 @@ export async function mergeProjectPullRequest(
     let branchDeleted = false;
     let branchDeleteWarning: string | undefined;
     if (params.deleteBranch !== false) {
-      const deleteResult = await tryDeleteBranch(
-        owner,
-        repo,
-        pr.headRef,
-        token,
-      );
+      const deleteResult = await tryDeleteRemoteBranch(fresh, pr.headRef);
       branchDeleted = deleteResult.deleted;
       branchDeleteWarning = deleteResult.warning;
       if (branchDeleted) {
-        await deleteBranchBaseTree(fresh, pr.headRef);
         await DbtCheckout.updateMany(
           { projectId: fresh._id, branch: pr.headRef },
           {

--- a/api/src/dbt/dbt-github-sync.service.ts
+++ b/api/src/dbt/dbt-github-sync.service.ts
@@ -1,160 +1,30 @@
 /**
- * Import / sync dbt project files from a GitHub repository into Mongo
- * (DbtFile). Mongo stays the canonical source the runner materializes from;
- * this service is the bridge that pulls a repo's contents in.
+ * Import / sync a repo-bound dbt project's branches from its GitHub remote
+ * into the project's local bare git repository (the canonical file store —
+ * see dbt-git-store.service.ts). A sync is a forced `git fetch` of one
+ * branch: the remote is authoritative for committed base trees.
  *
- * DbtFile rows are the COMMITTED base tree of a branch — uncommitted work
- * lives in per-user DbtFileDraft overlays — so a sync is always safe: the
- * remote is authoritative for the base tree and can never clobber anyone's
- * drafts. Files present on the branch are upserted, files no longer on the
- * branch are soft-deleted (a branch pull, like dbt Cloud).
+ * Always safe for collaborators: uncommitted work lives in per-user draft
+ * overlay refs that rebase onto the new head lazily — a pull can never
+ * clobber anyone's drafts.
  */
-import { Types } from "mongoose";
-
 import {
   DbtCheckout,
-  DbtFile,
   type IDbtProject,
-  type IDbtRepoBinding,
 } from "../database/workspace-schema";
-import { resolveRepoToken } from "../integrations/github/app-auth";
+import { resolveProjectRemote } from "./dbt-git-remote";
 import {
-  getBlobContent,
-  getBranchHeadSha,
-  getRepoTree,
-} from "../integrations/github/github-api";
+  branchRef,
+  diffTrees,
+  fetchBranch,
+  listTree,
+  readBlobAt,
+  resolveCommit,
+} from "./dbt-git-store.service";
+import { ensureProjectRepo } from "./dbt-working-tree.service";
+import { toProjectPath, toRepoPath } from "./dbt-paths";
 
-/** Per-file cap (matches the PUT /files content limit). */
-const MAX_FILE_BYTES = 1_000_000;
-/** Safety cap on number of imported files. */
-const MAX_FILES = 3000;
-/** Concurrent blob fetches. */
-const BLOB_CONCURRENCY = 8;
-
-/**
- * Text extensions we import. dbt projects are SQL/YAML/CSV/Markdown; we also
- * keep .gitkeep so empty model dirs survive. Generated/vendored output and
- * binary assets are skipped.
- */
-const TEXT_EXTENSIONS = new Set([
-  "sql",
-  "yml",
-  "yaml",
-  "md",
-  "csv",
-  "json",
-  "txt",
-  "sh",
-  "py",
-]);
-
-/** Directories that are generated, vendored, or irrelevant to a dbt build. */
-const SKIP_DIR_PREFIXES = [
-  "target/",
-  "dbt_packages/",
-  "dbt_internal_packages/",
-  "logs/",
-  ".git/",
-];
-
-export function normalizeSubdir(subdirectory?: string): string {
-  if (!subdirectory) return "";
-  return subdirectory.replace(/^\/+|\/+$/g, "");
-}
-
-function hasTextExtension(path: string): boolean {
-  const base = path.split("/").pop() ?? "";
-  if (base === ".gitkeep") return true;
-  const dot = base.lastIndexOf(".");
-  const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : "";
-  return TEXT_EXTENSIONS.has(ext);
-}
-
-export function isImportable(path: string): boolean {
-  if (SKIP_DIR_PREFIXES.some(prefix => path.startsWith(prefix))) return false;
-  // Mako renders profiles.yml itself; never import a committed one.
-  if (path === "profiles.yml" || path.endsWith("/profiles.yml")) return false;
-  return hasTextExtension(path);
-}
-
-export interface FetchedRepoFile {
-  path: string;
-  content: string;
-  /** Git blob SHA of the file on the branch (for working-tree diffing). */
-  blobSha: string;
-}
-
-export interface FetchedRepoFiles {
-  /** Commit SHA at the branch head when the tree was read. */
-  sha: string;
-  files: FetchedRepoFile[];
-  /** Files skipped because they exceeded MAX_FILE_BYTES. */
-  skippedLarge: string[];
-}
-
-/**
- * Read all importable dbt files from a repo branch (relative to an optional
- * sub-directory). Used both for first import and for re-sync.
- */
-export async function fetchRepoDbtFiles(
-  binding: Pick<
-    IDbtRepoBinding,
-    "owner" | "repo" | "branch" | "subdirectory" | "installationId"
-  >,
-): Promise<FetchedRepoFiles> {
-  const { owner, repo, branch } = binding;
-  const subdir = normalizeSubdir(binding.subdirectory);
-  const token = await resolveRepoToken(binding.installationId);
-
-  const sha = await getBranchHeadSha(owner, repo, branch, token);
-  const tree = await getRepoTree(owner, repo, sha, token);
-  if (tree.truncated) {
-    throw new Error(
-      "Repository tree is too large to import (GitHub truncated the listing)",
-    );
-  }
-
-  const prefix = subdir ? `${subdir}/` : "";
-  const blobs = tree.entries.filter(
-    e =>
-      e.type === "blob" &&
-      (prefix ? e.path.startsWith(prefix) : true) &&
-      isImportable(prefix ? e.path.slice(prefix.length) : e.path),
-  );
-
-  if (blobs.length > MAX_FILES) {
-    throw new Error(
-      `Repository has ${blobs.length} importable files (limit ${MAX_FILES})`,
-    );
-  }
-
-  const skippedLarge: string[] = [];
-  const files: FetchedRepoFile[] = [];
-
-  // Fetch blob contents with bounded concurrency.
-  for (let i = 0; i < blobs.length; i += BLOB_CONCURRENCY) {
-    const batch = blobs.slice(i, i + BLOB_CONCURRENCY);
-    const results = await Promise.all(
-      batch.map(async entry => {
-        const relPath = prefix ? entry.path.slice(prefix.length) : entry.path;
-        if (entry.size !== undefined && entry.size > MAX_FILE_BYTES) {
-          return { path: relPath, content: null as string | null, blobSha: "" };
-        }
-        const content = await getBlobContent(owner, repo, entry.sha, token);
-        if (Buffer.byteLength(content, "utf8") > MAX_FILE_BYTES) {
-          return { path: relPath, content: null as string | null, blobSha: "" };
-        }
-        return { path: relPath, content, blobSha: entry.sha };
-      }),
-    );
-    for (const r of results) {
-      if (r.content === null) skippedLarge.push(r.path);
-      else files.push({ path: r.path, content: r.content, blobSha: r.blobSha });
-    }
-  }
-
-  return { sha, files, skippedLarge };
-}
+export { isImportable, normalizeSubdir } from "./dbt-paths";
 
 export interface SyncResult {
   sha: string;
@@ -165,107 +35,39 @@ export interface SyncResult {
 }
 
 /**
- * Pull the latest state of `branch` into the project's committed base tree
- * for that branch: upsert changed files, soft-delete files no longer on the
- * branch, and stamp sync SHAs (the project binding when it is the default
+ * Pull the latest state of `branch` from the remote into the project's git
+ * store and stamp sync SHAs (the project binding when it is the default
  * branch, plus every checkout pointing at the branch).
- *
- * Always safe: drafts (uncommitted per-user work) live in a separate overlay
- * and are never touched by a sync.
  */
 export async function syncProjectBranchFromRepo(
   project: IDbtProject,
   branch: string,
-  updatedBy: string,
+  _updatedBy: string,
 ): Promise<SyncResult> {
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
-  // Read fields explicitly: `repo` is a Mongoose subdocument on hydrated
-  // docs, and spreading one drops its schema fields (they live on the
-  // prototype), which would fetch from "undefined/undefined".
-  const { sha, files, skippedLarge } = await fetchRepoDbtFiles({
-    owner: project.repo.owner,
-    repo: project.repo.repo,
-    subdirectory: project.repo.subdirectory,
-    installationId: project.repo.installationId,
-    branch,
-  });
+  const repoDir = await ensureProjectRepo(project);
+  const remote = await resolveProjectRemote(project.repo);
 
-  const existing = await DbtFile.find({ projectId: project._id, branch })
-    .select("path content is_deleted repoBlobSha")
-    .lean();
-  const existingByPath = new Map(existing.map(f => [f.path, f]));
-  const remotePaths = new Set(files.map(f => f.path));
+  const oldHead = await resolveCommit(repoDir, branchRef(branch));
+  const sha = await fetchBranch(repoDir, remote, branch);
 
   let added = 0;
   let updated = 0;
   let deleted = 0;
-
-  const ops: Array<Promise<unknown>> = [];
-  for (const file of files) {
-    const prev = existingByPath.get(file.path);
-
-    if (!prev || prev.is_deleted) {
-      added++;
-    } else if (prev.content !== file.content) {
-      updated++;
-    } else {
-      // Content unchanged, but still record the blob SHA so diffing works.
-      ops.push(
-        DbtFile.updateOne(
-          { projectId: project._id, branch, path: file.path },
-          { $set: { repoBlobSha: file.blobSha } },
-        ).exec(),
-      );
-      continue;
+  if (oldHead && oldHead !== sha) {
+    for (const change of await diffTrees(repoDir, oldHead, sha)) {
+      if (!toProjectPath(project, change.path)) continue;
+      if (change.status === "added") added++;
+      else if (change.status === "deleted") deleted++;
+      else updated++;
     }
-    ops.push(
-      DbtFile.updateOne(
-        { projectId: project._id, branch, path: file.path },
-        {
-          $set: {
-            content: file.content,
-            updatedBy,
-            is_deleted: false,
-            workspaceId: project.workspaceId,
-            repoBlobSha: file.blobSha,
-          },
-        },
-        { upsert: true, setDefaultsOnInsert: true },
-      ).exec(),
-    );
+  } else if (!oldHead) {
+    added = (await listTree(repoDir, sha)).filter(entry =>
+      toProjectPath(project, entry.path),
+    ).length;
   }
-
-  // Reconcile files that are no longer on the branch. The remote is the source
-  // of truth for the base tree, so a file absent upstream is soft-deleted and
-  // must NOT keep a repoBlobSha (a stale one would surface phantom pending
-  // deletions in per-user status).
-  for (const prev of existing) {
-    if (remotePaths.has(prev.path)) continue;
-
-    if (!prev.is_deleted) {
-      deleted++;
-      ops.push(
-        DbtFile.updateOne(
-          { projectId: project._id, branch, path: prev.path },
-          {
-            $set: { is_deleted: true, updatedBy },
-            $unset: { repoBlobSha: "" },
-          },
-        ).exec(),
-      );
-    } else if (prev.repoBlobSha) {
-      ops.push(
-        DbtFile.updateOne(
-          { projectId: project._id, branch, path: prev.path },
-          { $unset: { repoBlobSha: "" } },
-        ).exec(),
-      );
-    }
-  }
-
-  await Promise.all(ops);
 
   if (branch === project.repo.branch) {
     project.repo.lastSyncedSha = sha;
@@ -278,7 +80,7 @@ export async function syncProjectBranchFromRepo(
     { $set: { lastSyncedSha: sha, lastSyncedAt: new Date() } },
   ).exec();
 
-  return { sha, added, updated, deleted, skippedLarge };
+  return { sha, added, updated, deleted, skippedLarge: [] };
 }
 
 /** Sync the project's default branch (backwards-compatible entry point). */
@@ -292,23 +94,48 @@ export async function syncProjectFromRepo(
   return syncProjectBranchFromRepo(project, project.repo.branch, updatedBy);
 }
 
-/** Build a DbtFile insert payload from fetched repo files (first import). */
-export function repoFilesToInserts(
-  files: FetchedRepoFile[],
-  params: {
-    workspaceId: Types.ObjectId;
-    projectId: Types.ObjectId;
-    branch: string;
-    updatedBy: string;
-  },
-) {
-  return files.map(file => ({
-    workspaceId: params.workspaceId,
-    projectId: params.projectId,
-    branch: params.branch,
-    path: file.path,
-    content: file.content,
-    updatedBy: params.updatedBy,
-    repoBlobSha: file.blobSha,
-  }));
+export interface ImportResult {
+  sha: string;
+  imported: number;
+}
+
+/**
+ * First import of a repo-bound project: fetch the tracked branch and verify
+ * a dbt_project.yml exists at the project root (subdirectory-aware). Throws
+ * a user-presentable error when the repo/branch/subdirectory is not a dbt
+ * project.
+ */
+export async function importProjectFromRepo(
+  project: IDbtProject,
+): Promise<ImportResult> {
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  const repoDir = await ensureProjectRepo(project);
+  const remote = await resolveProjectRemote(project.repo);
+  const sha = await fetchBranch(repoDir, remote, project.repo.branch);
+
+  const files = (await listTree(repoDir, sha)).filter(entry =>
+    toProjectPath(project, entry.path),
+  );
+  if (files.length === 0) {
+    throw new Error("No dbt files found in that repo/branch/subdirectory");
+  }
+  const projectYml = await readBlobAt(
+    repoDir,
+    sha,
+    toRepoPath(project, "dbt_project.yml"),
+  );
+  if (projectYml === null) {
+    throw new Error(
+      "dbt_project.yml not found at the project root — set the correct subdirectory",
+    );
+  }
+
+  project.repo.lastSyncedSha = sha;
+  project.repo.lastSyncedAt = new Date();
+  project.markModified("repo");
+  await project.save();
+
+  return { sha, imported: files.length };
 }

--- a/api/src/dbt/dbt-github-sync.test.ts
+++ b/api/src/dbt/dbt-github-sync.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Types } from "mongoose";
-import {
-  isImportable,
-  normalizeSubdir,
-  repoFilesToInserts,
-  type FetchedRepoFile,
-} from "./dbt-github-sync.service";
+import { isImportable, normalizeSubdir } from "./dbt-paths";
 
 describe("normalizeSubdir", () => {
   it("strips leading/trailing slashes and passes through empty", () => {
@@ -48,54 +42,5 @@ describe("isImportable", () => {
   it("never imports a committed profiles.yml (Mako renders its own)", () => {
     expect(isImportable("profiles.yml")).toBe(false);
     expect(isImportable("nested/profiles.yml")).toBe(false);
-  });
-});
-
-describe("repoFilesToInserts", () => {
-  it("maps fetched files to DbtFile insert docs", () => {
-    const workspaceId = new Types.ObjectId();
-    const projectId = new Types.ObjectId();
-    const files: FetchedRepoFile[] = [
-      { path: "models/a.sql", content: "select 1", blobSha: "sha1" },
-      { path: "dbt_project.yml", content: "name: x", blobSha: "sha2" },
-    ];
-    expect(
-      repoFilesToInserts(files, {
-        workspaceId,
-        projectId,
-        branch: "main",
-        updatedBy: "u1",
-      }),
-    ).toEqual([
-      {
-        workspaceId,
-        projectId,
-        branch: "main",
-        path: "models/a.sql",
-        content: "select 1",
-        updatedBy: "u1",
-        repoBlobSha: "sha1",
-      },
-      {
-        workspaceId,
-        projectId,
-        branch: "main",
-        path: "dbt_project.yml",
-        content: "name: x",
-        updatedBy: "u1",
-        repoBlobSha: "sha2",
-      },
-    ]);
-  });
-
-  it("returns [] for no files", () => {
-    expect(
-      repoFilesToInserts([], {
-        workspaceId: new Types.ObjectId(),
-        projectId: new Types.ObjectId(),
-        branch: "main",
-        updatedBy: "u1",
-      }),
-    ).toEqual([]);
   });
 });

--- a/api/src/dbt/dbt-paths.ts
+++ b/api/src/dbt/dbt-paths.ts
@@ -1,0 +1,76 @@
+/**
+ * Path policy for dbt project trees — which files the IDE/runner surface out
+ * of a project's git tree, and repo-subdirectory mapping helpers.
+ */
+import type { IDbtProject } from "../database/workspace-schema";
+
+/**
+ * Text extensions surfaced from a project tree. dbt projects are
+ * SQL/YAML/CSV/Markdown; .gitkeep is kept so empty model dirs survive.
+ * Generated/vendored output and binary assets are skipped.
+ */
+const TEXT_EXTENSIONS = new Set([
+  "sql",
+  "yml",
+  "yaml",
+  "md",
+  "csv",
+  "json",
+  "txt",
+  "sh",
+  "py",
+]);
+
+/** Directories that are generated, vendored, or irrelevant to a dbt build. */
+const SKIP_DIR_PREFIXES = [
+  "target/",
+  "dbt_packages/",
+  "dbt_internal_packages/",
+  "logs/",
+  ".git/",
+];
+
+export function normalizeSubdir(subdirectory?: string): string {
+  if (!subdirectory) return "";
+  return subdirectory.replace(/^\/+|\/+$/g, "");
+}
+
+function hasTextExtension(path: string): boolean {
+  const base = path.split("/").pop() ?? "";
+  if (base === ".gitkeep") return true;
+  const dot = base.lastIndexOf(".");
+  const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : "";
+  return TEXT_EXTENSIONS.has(ext);
+}
+
+export function isImportable(path: string): boolean {
+  if (SKIP_DIR_PREFIXES.some(prefix => path.startsWith(prefix))) return false;
+  // Mako renders profiles.yml itself; never surface a committed one.
+  if (path === "profiles.yml" || path.endsWith("/profiles.yml")) return false;
+  return hasTextExtension(path);
+}
+
+/** Repo subdirectory prefix ("" or "sub/dir/") for a project. */
+export function subdirPrefix(project: IDbtProject): string {
+  const subdir = normalizeSubdir(project.repo?.subdirectory);
+  return subdir ? `${subdir}/` : "";
+}
+
+/** Project-relative path → full repo path (prefixing the subdirectory). */
+export function toRepoPath(project: IDbtProject, path: string): string {
+  return `${subdirPrefix(project)}${path}`;
+}
+
+/**
+ * Full repo path → project-relative path, or null when the file lives
+ * outside the project subdirectory or is not a surfaced dbt file.
+ */
+export function toProjectPath(
+  project: IDbtProject,
+  repoPath: string,
+): string | null {
+  const prefix = subdirPrefix(project);
+  if (prefix && !repoPath.startsWith(prefix)) return null;
+  const rel = prefix ? repoPath.slice(prefix.length) : repoPath;
+  return isImportable(rel) ? rel : null;
+}

--- a/api/src/dbt/dbt-working-tree.service.ts
+++ b/api/src/dbt/dbt-working-tree.service.ts
@@ -481,9 +481,9 @@ async function mutateWorkingTree(
 
     if (!project.repo) {
       const head = state.headSha;
-      const { sha } = await commitTreeUpdate(state.repoDir, {
-        ref: branchRef(state.branch),
-        expectedOldSha: head ?? ZERO_SHA,
+      // Dangling commit first: a save that doesn't change the tree (re-save
+      // of identical content) must not grow history.
+      const { sha, treeSha } = await commitTreeUpdate(state.repoDir, {
         baseTree: head ?? undefined,
         parents: head ? [head] : [],
         writes: repoPathWrites,
@@ -491,14 +491,16 @@ async function mutateWorkingTree(
         message: mutation.message,
         author,
       });
+      if (head && treeSha === (await treeShaOf(state.repoDir, head))) {
+        return { sha: head };
+      }
+      await updateRef(state.repoDir, branchRef(state.branch), sha, head ?? ZERO_SHA);
       return { sha };
     }
 
     const refs = draftRefsFor(userId);
     const parent = state.workingSha as string;
     const { sha, treeSha } = await commitTreeUpdate(state.repoDir, {
-      ref: refs.tip,
-      expectedOldSha: state.draftTipSha ?? ZERO_SHA,
       baseTree: parent,
       parents: [parent],
       writes: repoPathWrites,
@@ -511,8 +513,13 @@ async function mutateWorkingTree(
       // Reverted to the committed content — no pending change to keep.
       await deleteRef(state.repoDir, refs.tip);
       await deleteRef(state.repoDir, refs.base);
-      return { sha };
+      return { sha: state.headSha as string };
     }
+    if (treeSha === (await treeShaOf(state.repoDir, parent))) {
+      // No-op save against the existing overlay — keep the current tip.
+      return { sha: parent };
+    }
+    await updateRef(state.repoDir, refs.tip, sha, state.draftTipSha ?? ZERO_SHA);
     if (!state.draftTipSha) {
       await updateRef(state.repoDir, refs.base, state.headSha as string);
     }

--- a/api/src/dbt/dbt-working-tree.service.ts
+++ b/api/src/dbt/dbt-working-tree.service.ts
@@ -1,25 +1,61 @@
 /**
- * Per-user dbt working trees.
+ * Per-user dbt working trees — backed entirely by git (no file content in
+ * Mongo).
  *
- * Repo-bound projects keep one COMMITTED base tree per checked-out branch in
- * DbtFile (content mirrors the branch head) and a per-user draft overlay in
- * DbtFileDraft. A user's working tree is draft-over-base for the branch their
- * DbtCheckout points at, so uncommitted work is only ever visible to its
- * author — collaborators see changes when they are committed, like separate
- * git clones.
+ * Every project owns a bare git repository (see dbt-git-store.service.ts).
  *
- * Blank (non-repo) projects keep the original shared model: DbtFile rows with
- * no `branch` are the single working tree every member edits directly.
+ *  - Blank (non-repo) projects: refs/heads/main is the single shared working
+ *    tree every member edits directly; each save is a commit.
+ *  - Repo-bound projects: local branches mirror the GitHub remote and are the
+ *    COMMITTED base trees. A user's uncommitted work is an overlay commit
+ *    chain at refs/mako/drafts/<user> forked from refs/mako/drafts-base/<user>.
+ *    Reads/writes lazily REBASE the overlay onto the head of the user's
+ *    checked-out branch, so uncommitted work follows the user across branch
+ *    switches and a base sync can never clobber it — the same collaboration
+ *    semantics as separate git clones.
+ *
+ * Mongo keeps only pointers/metadata: DbtCheckout (per-user branch pointer)
+ * and the legacy DbtFile/DbtFileDraft collections, which are read exactly
+ * once per project to materialize the git repo (lazy migration) and never
+ * written again.
  */
 
-import { Types } from "mongoose";
 import {
   DbtCheckout,
   DbtFile,
   DbtFileDraft,
   type IDbtProject,
 } from "../database/workspace-schema";
-import { gitBlobSha } from "../integrations/github/git-blob";
+import { loggers } from "../logging";
+import {
+  BLANK_PROJECT_BRANCH,
+  MAX_DBT_FILE_BYTES,
+  ZERO_SHA,
+  authorFor,
+  branchRef,
+  commitTreeUpdate,
+  deleteRef,
+  deleteRepoDir,
+  diffTrees,
+  draftRefsFor,
+  ensureBareRepo,
+  fetchBranch,
+  listTree,
+  readBlobAt,
+  readBlobs,
+  repoDirFor,
+  repoExists,
+  resolveCommit,
+  treeShaOf,
+  updateRef,
+  withCasRetry,
+  type GitAuthor,
+  type TreeFileChange,
+} from "./dbt-git-store.service";
+import { resolveProjectRemote } from "./dbt-git-remote";
+import { toProjectPath, toRepoPath } from "./dbt-paths";
+
+const logger = loggers.api("dbt-working-tree");
 
 export interface WorkingFileMeta {
   path: string;
@@ -35,16 +71,20 @@ export function isRepoProject(project: IDbtProject): boolean {
   return Boolean(project.repo);
 }
 
+// ---------------------------------------------------------------------------
+// Checkouts (Mongo branch pointers — metadata, not content)
+// ---------------------------------------------------------------------------
+
 /**
  * Branch the user's checkout points at. Falls back to the project default
- * branch when the user never switched (implicit checkout). Undefined for
- * blank projects (no git surface).
+ * branch when the user never switched (implicit checkout). Blank projects
+ * always use the local shared branch.
  */
 export async function getCheckoutBranch(
   project: IDbtProject,
   userId: string | undefined,
-): Promise<string | undefined> {
-  if (!project.repo) return undefined;
+): Promise<string> {
+  if (!project.repo) return BLANK_PROJECT_BRANCH;
   if (!userId) return project.repo.branch;
   const checkout = await DbtCheckout.findOne({
     projectId: project._id,
@@ -77,311 +117,445 @@ export async function setCheckoutBranch(
   ).exec();
 }
 
-/** Base-tree filter for a repo project branch (blank projects: branch null). */
-export function baseTreeFilter(
-  project: IDbtProject,
-  branch: string | undefined,
-): Record<string, unknown> {
-  return branch
-    ? { projectId: project._id, branch }
-    : { projectId: project._id, branch: { $in: [null, undefined] } };
-}
+// ---------------------------------------------------------------------------
+// Repo lifecycle + legacy Mongo import
+// ---------------------------------------------------------------------------
 
-/** True when the base tree for a branch has been materialized into Mongo. */
-export async function branchBaseTreeExists(
-  project: IDbtProject,
-  branch: string,
-): Promise<boolean> {
-  const row = await DbtFile.exists({ projectId: project._id, branch });
-  return Boolean(row);
-}
+const MIGRATION_AUTHOR: GitAuthor = {
+  name: "mako-migration",
+  email: "migration@mako.dev",
+};
 
 /**
- * Clone the committed base tree of one branch to another (branch create /
- * atomic promote fork point — content is identical, so no GitHub round-trip).
- * No-op when the target branch already has a base tree.
+ * Ensure the project's bare repository exists. On first touch of a legacy
+ * project, its Mongo file rows (dbt_files base trees + dbt_file_drafts
+ * overlays) are materialized into git — after that the collections are never
+ * read again for this project.
  */
-export async function cloneBranchBaseTree(
-  project: IDbtProject,
-  fromBranch: string,
-  toBranch: string,
-): Promise<void> {
-  if (await branchBaseTreeExists(project, toBranch)) return;
-  const rows = await DbtFile.find({
-    projectId: project._id,
-    branch: fromBranch,
-    is_deleted: { $ne: true },
-  })
-    .select("path content updatedBy repoBlobSha")
-    .lean();
-  if (rows.length === 0) return;
-  await DbtFile.insertMany(
-    rows.map(row => ({
-      workspaceId: project.workspaceId,
-      projectId: project._id,
-      branch: toBranch,
-      path: row.path,
-      content: row.content ?? "",
-      updatedBy: row.updatedBy,
-      repoBlobSha: row.repoBlobSha,
-    })),
-    { ordered: false },
+export async function ensureProjectRepo(project: IDbtProject): Promise<string> {
+  const repoDir = repoDirFor(
+    project.workspaceId.toString(),
+    project._id.toString(),
   );
+  if (repoExists(repoDir)) return repoDir;
+  await ensureBareRepo(repoDir);
+  try {
+    await importLegacyMongoTrees(project, repoDir);
+  } catch (error) {
+    // Leave a clean slate so the next call retries the import.
+    await deleteRepoDir(repoDir).catch(() => {});
+    throw error;
+  }
+  return repoDir;
 }
 
-/** Drop a branch's base tree (after the remote branch was deleted). */
-export async function deleteBranchBaseTree(
-  project: IDbtProject,
-  branch: string,
-): Promise<void> {
-  await DbtFile.deleteMany({ projectId: project._id, branch }).exec();
-}
-
-interface BaseRowLean {
+interface LegacyFileRow {
+  branch?: string;
   path: string;
   content?: string;
   is_deleted?: boolean;
-  repoBlobSha?: string;
-  updatedAt?: Date;
   updatedBy?: string;
 }
 
-interface DraftLean {
-  path: string;
-  content?: string;
-  is_deleted?: boolean;
-  updatedAt?: Date;
+async function importLegacyMongoTrees(
+  project: IDbtProject,
+  repoDir: string,
+): Promise<void> {
+  const rows = (await DbtFile.find({ projectId: project._id })
+    .select("branch path content is_deleted updatedBy")
+    .lean()) as LegacyFileRow[];
+  if (rows.length === 0 && !project.repo) return;
+
+  // Group base rows per branch (blank projects → the shared local branch).
+  const byBranch = new Map<string, LegacyFileRow[]>();
+  for (const row of rows) {
+    const branch = project.repo
+      ? (row.branch ?? project.repo.branch)
+      : BLANK_PROJECT_BRANCH;
+    const list = byBranch.get(branch) ?? [];
+    list.push(row);
+    byBranch.set(branch, list);
+  }
+
+  for (const [branch, branchRows] of byBranch) {
+    const live = branchRows.filter(row => !row.is_deleted);
+    // Soft-deleted rows with retained content stay recoverable: commit them
+    // first, then delete them in a second commit (git history keeps them).
+    const recoverable = branchRows.filter(
+      row => row.is_deleted && (row.content ?? "").length > 0,
+    );
+    const initialWrites = [...live, ...recoverable].map(row => ({
+      path: toRepoPath(project, row.path),
+      content: row.content ?? "",
+    }));
+    if (initialWrites.length === 0) continue;
+    const { sha } = await commitTreeUpdate(repoDir, {
+      ref: branchRef(branch),
+      expectedOldSha: ZERO_SHA,
+      parents: [],
+      writes: initialWrites,
+      deletes: [],
+      message: "Import project files from Mako",
+      author: MIGRATION_AUTHOR,
+    });
+    if (recoverable.length > 0) {
+      await commitTreeUpdate(repoDir, {
+        ref: branchRef(branch),
+        expectedOldSha: sha,
+        baseTree: sha,
+        parents: [sha],
+        writes: [],
+        deletes: recoverable.map(row => toRepoPath(project, row.path)),
+        message: "Remove deleted files (recoverable via history)",
+        author: MIGRATION_AUTHOR,
+      });
+    }
+    logger.info("Imported legacy dbt tree into git", {
+      projectId: project._id.toString(),
+      branch,
+      files: live.length,
+      recoverable: recoverable.length,
+    });
+  }
+
+  // Per-user draft overlays (repo projects only — blank projects had none).
+  if (!project.repo) return;
+  const drafts = await DbtFileDraft.find({ projectId: project._id })
+    .select("userId path content is_deleted")
+    .lean();
+  const byUser = new Map<string, typeof drafts>();
+  for (const draft of drafts) {
+    const list = byUser.get(draft.userId) ?? [];
+    list.push(draft);
+    byUser.set(draft.userId, list);
+  }
+  for (const [userId, userDrafts] of byUser) {
+    const branch = await getCheckoutBranch(project, userId);
+    const head = await resolveCommit(repoDir, branchRef(branch));
+    if (!head) continue;
+    const refs = draftRefsFor(userId);
+    const writes = userDrafts
+      .filter(draft => !draft.is_deleted)
+      .map(draft => ({
+        path: toRepoPath(project, draft.path),
+        content: draft.content ?? "",
+      }));
+    const deletes = userDrafts
+      .filter(draft => draft.is_deleted)
+      .map(draft => toRepoPath(project, draft.path));
+    const { sha, treeSha } = await commitTreeUpdate(repoDir, {
+      ref: refs.tip,
+      expectedOldSha: ZERO_SHA,
+      baseTree: head,
+      parents: [head],
+      writes,
+      deletes,
+      message: "Import uncommitted drafts from Mako",
+      author: authorFor(userId),
+    });
+    if (treeSha === (await treeShaOf(repoDir, head))) {
+      await deleteRef(repoDir, refs.tip);
+      continue;
+    }
+    await updateRef(repoDir, refs.base, head);
+    logger.info("Imported legacy dbt drafts into git", {
+      projectId: project._id.toString(),
+      userId,
+      changes: writes.length + deletes.length,
+      sha,
+    });
+  }
 }
 
-async function loadBaseRows(
-  project: IDbtProject,
-  branch: string | undefined,
-): Promise<BaseRowLean[]> {
-  return DbtFile.find({
-    ...baseTreeFilter(project, branch),
-    is_deleted: { $ne: true },
-  })
-    .select("path content repoBlobSha updatedAt updatedBy")
-    .lean();
+/** Delete the project's git store (project deletion). */
+export async function deleteProjectStore(project: IDbtProject): Promise<void> {
+  await deleteRepoDir(
+    repoDirFor(project.workspaceId.toString(), project._id.toString()),
+  );
 }
 
-async function loadDrafts(
-  project: IDbtProject,
-  userId: string,
-): Promise<DraftLean[]> {
-  return DbtFileDraft.find({ projectId: project._id, userId })
-    .select("path content is_deleted updatedAt")
-    .lean();
+// ---------------------------------------------------------------------------
+// Working-tree state resolution (overlay rebase)
+// ---------------------------------------------------------------------------
+
+export interface WorkingTreeState {
+  repoDir: string;
+  branch: string;
+  /** Head commit of the checked-out branch (null: blank project, no commits). */
+  headSha: string | null;
+  /** Commit whose tree is the user's working tree (draft tip or head). */
+  workingSha: string | null;
+  /** Draft tip when the user has uncommitted changes. */
+  draftTipSha: string | null;
 }
 
 /**
+ * Resolve the user's working tree, lazily rebasing their draft overlay onto
+ * the current head of their checked-out branch. An overlay whose rebase
+ * produces no diff is dropped (a clean tree, like `git status`).
+ */
+export async function resolveWorkingState(
+  project: IDbtProject,
+  userId: string | undefined,
+): Promise<WorkingTreeState> {
+  const repoDir = await ensureProjectRepo(project);
+  const branch = await getCheckoutBranch(project, userId);
+  let headSha = await resolveCommit(repoDir, branchRef(branch));
+
+  if (!headSha && project.repo) {
+    // Local mirror doesn't have this branch yet (fresh instance) — fetch it.
+    const remote = await resolveProjectRemote(project.repo);
+    headSha = await fetchBranch(repoDir, remote, branch);
+  }
+
+  if (!project.repo || !userId) {
+    return { repoDir, branch, headSha, workingSha: headSha, draftTipSha: null };
+  }
+
+  const draftTipSha = await rebaseDraftOntoHead(
+    repoDir,
+    userId,
+    headSha as string,
+  );
+  return {
+    repoDir,
+    branch,
+    headSha,
+    workingSha: draftTipSha ?? headSha,
+    draftTipSha,
+  };
+}
+
+/**
+ * Rebase a user's overlay onto `headSha` if it forked from an older base.
+ * Returns the (possibly new) draft tip, or null when the user has no pending
+ * changes.
+ */
+async function rebaseDraftOntoHead(
+  repoDir: string,
+  userId: string,
+  headSha: string,
+): Promise<string | null> {
+  const refs = draftRefsFor(userId);
+  return withCasRetry(async () => {
+    const tip = await resolveCommit(repoDir, refs.tip);
+    if (!tip) return null;
+    const base = (await resolveCommit(repoDir, refs.base)) ?? headSha;
+    if (base === headSha) return tip;
+
+    const changes = await diffTrees(repoDir, base, tip);
+    if (changes.length === 0) {
+      await deleteRef(repoDir, refs.tip);
+      await deleteRef(repoDir, refs.base);
+      return null;
+    }
+
+    const writes: Array<{ path: string; content: string }> = [];
+    const deletes: string[] = [];
+    for (const change of changes) {
+      if (change.status === "deleted") {
+        deletes.push(change.path);
+      } else {
+        const content = await readBlobAt(repoDir, tip, change.path);
+        writes.push({ path: change.path, content: content ?? "" });
+      }
+    }
+    const { sha, treeSha } = await commitTreeUpdate(repoDir, {
+      ref: refs.tip,
+      expectedOldSha: tip,
+      baseTree: headSha,
+      parents: [headSha],
+      writes,
+      deletes,
+      message: "Rebase uncommitted changes",
+      author: authorFor(userId),
+    });
+    if (treeSha === (await treeShaOf(repoDir, headSha))) {
+      // The branch already contains every overlay change — tree is clean.
+      await deleteRef(repoDir, refs.tip);
+      await deleteRef(repoDir, refs.base);
+      return null;
+    }
+    await updateRef(repoDir, refs.base, headSha);
+    return sha;
+  });
+}
+
+/** The user's pending overlay changes (project-relative), post-rebase. */
+export async function workingTreeChanges(
+  project: IDbtProject,
+  state: WorkingTreeState,
+): Promise<Array<TreeFileChange & { path: string }>> {
+  if (!state.draftTipSha || !state.headSha) return [];
+  const changes = await diffTrees(
+    state.repoDir,
+    state.headSha,
+    state.draftTipSha,
+  );
+  const visible: TreeFileChange[] = [];
+  for (const change of changes) {
+    const rel = toProjectPath(project, change.path);
+    if (rel) visible.push({ ...change, path: rel });
+  }
+  return visible.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/**
  * List the paths of a user's working tree: committed base of their checkout
- * branch, overlaid with their drafts (added files appear, draft-deleted files
- * disappear). Blank projects list the shared tree.
+ * branch, overlaid with their pending changes. Blank projects list the
+ * shared tree.
  */
 export async function listWorkingFiles(
   project: IDbtProject,
   userId: string,
 ): Promise<WorkingFileMeta[]> {
-  if (!project.repo) {
-    return loadBaseRows(project, undefined);
+  const state = await resolveWorkingState(project, userId);
+  if (!state.workingSha) return [];
+  const entries = await listTree(state.repoDir, state.workingSha);
+  const files: WorkingFileMeta[] = [];
+  for (const entry of entries) {
+    if (entry.size > MAX_DBT_FILE_BYTES) continue;
+    const rel = toProjectPath(project, entry.path);
+    if (rel) files.push({ path: rel });
   }
-  const branch = await getCheckoutBranch(project, userId);
-  const [baseRows, drafts] = await Promise.all([
-    loadBaseRows(project, branch),
-    loadDrafts(project, userId),
-  ]);
-  const merged = new Map<string, WorkingFileMeta>();
-  for (const row of baseRows) {
-    merged.set(row.path, {
-      path: row.path,
-      updatedAt: row.updatedAt,
-      updatedBy: row.updatedBy,
-    });
-  }
-  for (const draft of drafts) {
-    if (draft.is_deleted) {
-      merged.delete(draft.path);
-    } else {
-      merged.set(draft.path, {
-        path: draft.path,
-        updatedAt: draft.updatedAt,
-        updatedBy: userId,
-      });
-    }
-  }
-  return [...merged.values()].sort((a, b) => a.path.localeCompare(b.path));
+  return files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
-/** Read one file from the user's working tree (draft wins over base). */
+/** Read one file from the user's working tree. */
 export async function readWorkingFile(
   project: IDbtProject,
   userId: string,
   path: string,
 ): Promise<WorkingFile | null> {
-  if (project.repo) {
-    const draft = await DbtFileDraft.findOne({
-      projectId: project._id,
-      userId,
-      path,
-    }).lean();
-    if (draft) {
-      if (draft.is_deleted) return null;
-      return {
-        path,
-        content: draft.content ?? "",
-        updatedAt: draft.updatedAt,
-        updatedBy: userId,
-      };
-    }
-  }
-  const branch = project.repo
-    ? await getCheckoutBranch(project, userId)
-    : undefined;
-  const base = await DbtFile.findOne({
-    ...baseTreeFilter(project, branch),
-    path,
-    is_deleted: { $ne: true },
-  }).lean();
-  if (!base) return null;
-  return {
-    path,
-    content: base.content ?? "",
-    updatedAt: base.updatedAt,
-    updatedBy: base.updatedBy,
-  };
+  const state = await resolveWorkingState(project, userId);
+  if (!state.workingSha) return null;
+  const content = await readBlobAt(
+    state.repoDir,
+    state.workingSha,
+    toRepoPath(project, path),
+  );
+  if (content === null) return null;
+  return { path, content };
 }
 
 export interface WriteWorkingFileResult {
-  /** Id used for entity-version snapshots (draft or shared file doc). */
-  versionEntityId: Types.ObjectId;
+  /** Commit SHA of the save (draft tip or shared-branch head). */
+  sha: string;
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+interface TreeMutation {
+  writes: Array<{ path: string; content: string }>;
+  deletes: string[];
+  message: string;
 }
 
 /**
- * Write to the user's working tree. Repo projects write a draft overlay
- * (invisible to other users); blank projects write the shared DbtFile row.
- * A draft whose content matches the committed base is dropped (a no-diff
- * buffer is not a pending change), mirroring `git status`.
+ * Apply a mutation to the user's working tree:
+ *  - blank projects commit straight onto the shared branch;
+ *  - repo projects commit onto the user's draft overlay (creating it on
+ *    demand); an overlay whose tree matches the branch head is dropped.
  */
+async function mutateWorkingTree(
+  project: IDbtProject,
+  userId: string,
+  mutation: TreeMutation,
+): Promise<WriteWorkingFileResult> {
+  const author = authorFor(userId);
+  return withCasRetry(async () => {
+    const state = await resolveWorkingState(project, userId);
+    const repoPathWrites = mutation.writes.map(write => ({
+      path: toRepoPath(project, write.path),
+      content: write.content,
+    }));
+    const repoPathDeletes = mutation.deletes.map(path =>
+      toRepoPath(project, path),
+    );
+
+    if (!project.repo) {
+      const head = state.headSha;
+      const { sha } = await commitTreeUpdate(state.repoDir, {
+        ref: branchRef(state.branch),
+        expectedOldSha: head ?? ZERO_SHA,
+        baseTree: head ?? undefined,
+        parents: head ? [head] : [],
+        writes: repoPathWrites,
+        deletes: repoPathDeletes,
+        message: mutation.message,
+        author,
+      });
+      return { sha };
+    }
+
+    const refs = draftRefsFor(userId);
+    const parent = state.workingSha as string;
+    const { sha, treeSha } = await commitTreeUpdate(state.repoDir, {
+      ref: refs.tip,
+      expectedOldSha: state.draftTipSha ?? ZERO_SHA,
+      baseTree: parent,
+      parents: [parent],
+      writes: repoPathWrites,
+      deletes: repoPathDeletes,
+      message: mutation.message,
+      author,
+    });
+    const headTree = await treeShaOf(state.repoDir, state.headSha as string);
+    if (treeSha === headTree) {
+      // Reverted to the committed content — no pending change to keep.
+      await deleteRef(state.repoDir, refs.tip);
+      await deleteRef(state.repoDir, refs.base);
+      return { sha };
+    }
+    if (!state.draftTipSha) {
+      await updateRef(state.repoDir, refs.base, state.headSha as string);
+    }
+    return { sha };
+  });
+}
+
+/** Write to the user's working tree (drafts for repo projects). */
 export async function writeWorkingFile(
   project: IDbtProject,
   userId: string,
   path: string,
   content: string,
 ): Promise<WriteWorkingFileResult> {
-  if (!project.repo) {
-    const file = await DbtFile.findOneAndUpdate(
-      { projectId: project._id, path },
-      {
-        $set: {
-          content,
-          updatedBy: userId,
-          is_deleted: false,
-          workspaceId: project.workspaceId,
-        },
-      },
-      { upsert: true, new: true, setDefaultsOnInsert: true },
-    );
-    return { versionEntityId: file._id };
-  }
-
-  const branch = await getCheckoutBranch(project, userId);
-  const base = await DbtFile.findOne({
-    ...baseTreeFilter(project, branch),
-    path,
-    is_deleted: { $ne: true },
-  })
-    .select("content repoBlobSha")
-    .lean();
-
-  if (base && (base.content ?? "") === content) {
-    // Reverted to the committed content — no pending change to keep.
-    const existing = await DbtFileDraft.findOneAndDelete({
-      projectId: project._id,
-      userId,
-      path,
-    });
-    return { versionEntityId: existing?._id ?? new Types.ObjectId() };
-  }
-
-  const draft = await DbtFileDraft.findOneAndUpdate(
-    { projectId: project._id, userId, path },
-    {
-      $set: {
-        content,
-        is_deleted: false,
-        workspaceId: project.workspaceId,
-      },
-      $setOnInsert: {
-        baseBlobSha: base?.repoBlobSha ?? gitBlobSha(base?.content ?? ""),
-      },
-    },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  return { versionEntityId: draft._id };
+  return mutateWorkingTree(project, userId, {
+    writes: [{ path, content }],
+    deletes: [],
+    message: `Save ${path}`,
+  });
 }
 
 /**
- * Delete a file from the user's working tree. For repo projects a base file
- * becomes a pending draft deletion (staged `git rm`); a draft-only file just
- * drops the draft. Returns false when the path does not exist.
+ * Delete a file from the user's working tree. Returns false when the path
+ * does not exist in it.
  */
 export async function deleteWorkingFile(
   project: IDbtProject,
   userId: string,
   path: string,
 ): Promise<boolean> {
-  if (!project.repo) {
-    const result = await DbtFile.updateOne(
-      { projectId: project._id, path },
-      { $set: { is_deleted: true, updatedBy: userId } },
-    );
-    return result.matchedCount > 0;
-  }
-
-  const branch = await getCheckoutBranch(project, userId);
-  const [base, draft] = await Promise.all([
-    DbtFile.exists({
-      ...baseTreeFilter(project, branch),
-      path,
-      is_deleted: { $ne: true },
-    }),
-    DbtFileDraft.findOne({ projectId: project._id, userId, path })
-      .select("is_deleted")
-      .lean(),
-  ]);
-
-  if (base) {
-    await DbtFileDraft.updateOne(
-      { projectId: project._id, userId, path },
-      {
-        $set: {
-          content: "",
-          is_deleted: true,
-          workspaceId: project.workspaceId,
-        },
-      },
-      { upsert: true },
-    ).exec();
-    return true;
-  }
-  if (draft && !draft.is_deleted) {
-    // Draft-only file (added, never committed): removing it needs no pending
-    // deletion — just discard the draft.
-    await DbtFileDraft.deleteOne({
-      projectId: project._id,
-      userId,
-      path,
-    }).exec();
-    return true;
-  }
-  return false;
+  const existing = await readWorkingFile(project, userId, path);
+  if (existing === null) return false;
+  await mutateWorkingTree(project, userId, {
+    writes: [],
+    deletes: [path],
+    message: `Delete ${path}`,
+  });
+  return true;
 }
 
 /**
- * Rename within the user's working tree. Repo projects express the rename as
- * draft ops (delete old path + add new path); blank projects move the shared
- * row. Returns an error string on conflicts, null on success.
+ * Rename within the user's working tree (one commit: add new + delete old).
+ * Returns an error string on conflicts, null on success.
  */
 export async function renameWorkingFile(
   project: IDbtProject,
@@ -389,50 +563,63 @@ export async function renameWorkingFile(
   from: string,
   to: string,
 ): Promise<string | null> {
-  if (!project.repo) {
-    const existing = await DbtFile.findOne({
-      projectId: project._id,
-      path: to,
-      is_deleted: { $ne: true },
-    });
-    if (existing) return `"${to}" already exists`;
-    await DbtFile.deleteOne({ projectId: project._id, path: to });
-    const result = await DbtFile.updateOne(
-      { projectId: project._id, path: from, is_deleted: { $ne: true } },
-      { $set: { path: to, updatedBy: userId } },
-    );
-    return result.matchedCount === 0 ? "File not found" : null;
-  }
-
   const [source, target] = await Promise.all([
     readWorkingFile(project, userId, from),
     readWorkingFile(project, userId, to),
   ]);
   if (!source) return "File not found";
   if (target) return `"${to}" already exists`;
-  await writeWorkingFile(project, userId, to, source.content);
-  await deleteWorkingFile(project, userId, from);
+  await mutateWorkingTree(project, userId, {
+    writes: [{ path: to, content: source.content }],
+    deletes: [from],
+    message: `Rename ${from} → ${to}`,
+  });
   return null;
 }
 
-/** Discard all of a user's drafts for a project (`git checkout -- .`). */
+/**
+ * Discard all of a user's pending changes (`git checkout -- .`). Returns the
+ * number of discarded file changes.
+ */
 export async function discardUserDrafts(
   project: IDbtProject,
   userId: string,
 ): Promise<number> {
-  const result = await DbtFileDraft.deleteMany({
-    projectId: project._id,
-    userId,
-  }).exec();
-  return result.deletedCount ?? 0;
+  if (!project.repo) return 0;
+  const state = await resolveWorkingState(project, userId);
+  const changes = await workingTreeChanges(project, state);
+  const refs = draftRefsFor(userId);
+  await deleteRef(state.repoDir, refs.tip);
+  await deleteRef(state.repoDir, refs.base);
+  return changes.length;
 }
+
+/**
+ * Seed multiple files into a project in one commit (project scaffold /
+ * dev seeds). Blank projects only.
+ */
+export async function seedProjectFiles(
+  project: IDbtProject,
+  userId: string,
+  files: Array<{ path: string; content: string }>,
+): Promise<WriteWorkingFileResult> {
+  return mutateWorkingTree(project, userId, {
+    writes: files,
+    deletes: [],
+    message: "Scaffold dbt project",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Full-tree contents (runner materialization)
+// ---------------------------------------------------------------------------
 
 /**
  * Full file contents of a working tree, for materializing dbt runs:
  *  - `userId` set → that user's overlay on their checkout branch (IDE/agent
  *    ad-hoc commands see the caller's uncommitted work).
- *  - only `branch` set → the committed base tree of that branch (deploy jobs
- *    and CI build exactly what is committed).
+ *  - only `branch` set → the committed tree of that branch (deploy jobs and
+ *    CI build exactly what is committed).
  *  - neither → the project default branch's committed tree (blank projects:
  *    the shared tree).
  */
@@ -440,27 +627,34 @@ export async function loadWorkingTreeContents(
   project: IDbtProject,
   opts: { userId?: string; branch?: string } = {},
 ): Promise<Array<{ path: string; content: string }>> {
-  if (!project.repo) {
-    const rows = await loadBaseRows(project, undefined);
-    return rows.map(row => ({ path: row.path, content: row.content ?? "" }));
-  }
-  const branch =
-    opts.branch ??
-    (opts.userId
-      ? await getCheckoutBranch(project, opts.userId)
-      : project.repo.branch);
-  const baseRows = await loadBaseRows(project, branch);
-  const files = new Map<string, string>(
-    baseRows.map(row => [row.path, row.content ?? ""]),
-  );
-  if (opts.userId) {
-    const drafts = await loadDrafts(project, opts.userId);
-    for (const draft of drafts) {
-      if (draft.is_deleted) files.delete(draft.path);
-      else files.set(draft.path, draft.content ?? "");
+  const repoDir = await ensureProjectRepo(project);
+
+  let treeish: string | null;
+  if (opts.branch) {
+    treeish = await resolveCommit(repoDir, branchRef(opts.branch));
+    if (!treeish && project.repo) {
+      const remote = await resolveProjectRemote(project.repo);
+      treeish = await fetchBranch(repoDir, remote, opts.branch);
     }
+  } else {
+    const state = await resolveWorkingState(project, opts.userId);
+    treeish = state.workingSha;
   }
-  return [...files.entries()]
-    .map(([path, content]) => ({ path, content }))
+  if (!treeish) return [];
+
+  const entries = (await listTree(repoDir, treeish)).filter(
+    entry =>
+      entry.size <= MAX_DBT_FILE_BYTES &&
+      toProjectPath(project, entry.path) !== null,
+  );
+  const blobs = await readBlobs(
+    repoDir,
+    entries.map(entry => entry.blobSha),
+  );
+  return entries
+    .map(entry => ({
+      path: toProjectPath(project, entry.path) as string,
+      content: blobs.get(entry.blobSha) ?? "",
+    }))
     .sort((a, b) => a.path.localeCompare(b.path));
 }

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -19,6 +19,9 @@ import {
 import { Hono } from "hono";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
 
 // Mutable caller role for the RBAC matrix (hoisted so the mock factory sees it).
 const ctx = vi.hoisted(() => ({ role: "owner" as string | null }));
@@ -83,11 +86,11 @@ vi.mock("../integrations/github/github-api", () => ({
   listInstallationRepos: vi.fn(),
 }));
 vi.mock("../dbt/dbt-github-sync.service", () => ({
-  fetchRepoDbtFiles: vi.fn(),
-  repoFilesToInserts: vi.fn(),
+  importProjectFromRepo: vi.fn(),
   syncProjectBranchFromRepo: vi.fn(),
 }));
 vi.mock("../dbt/dbt-github-git.service", () => ({
+  closeProjectPullRequest: vi.fn(),
   commitAndPush: vi.fn(),
   commitToNewBranch: vi.fn(),
   createProjectBranch: vi.fn(),
@@ -95,10 +98,12 @@ vi.mock("../dbt/dbt-github-git.service", () => ({
   getGitStatus: vi.fn(),
   getProjectFileDiff: vi.fn(),
   listProjectBranches: vi.fn(),
+  listProjectPullRequests: vi.fn(),
   mergeProjectPullRequest: vi.fn(),
   openProjectPullRequest: vi.fn(),
   ProtectedBranchError: class ProtectedBranchError extends Error {},
   switchProjectBranch: vi.fn(),
+  updateProjectPullRequest: vi.fn(),
 }));
 vi.mock("../services/realtime.service", () => ({
   publishRealtimeEvent: vi.fn(),
@@ -168,14 +173,21 @@ async function createProjectAsOwner(): Promise<string> {
   return json.project._id;
 }
 
+let gitRoot: string;
+
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create();
   await mongoose.connect(mongo.getUri());
+  // File contents live in per-project bare git repos under DBT_GIT_ROOT.
+  gitRoot = await mkdtemp(path.join(tmpdir(), "mako-dbt-routes-test-"));
+  process.env.DBT_GIT_ROOT = gitRoot;
 });
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongo.stop();
+  await rm(gitRoot, { recursive: true, force: true });
+  delete process.env.DBT_GIT_ROOT;
 });
 
 beforeEach(async () => {
@@ -242,11 +254,13 @@ describe("project CRUD", () => {
   it("creates, lists, gets, patches, and deletes a project", async () => {
     const projectId = await createProjectAsOwner();
 
-    // The starter scaffold is materialized on create.
-    const fileCount = await mongoose.connection
-      .collection("dbt_files")
-      .countDocuments({ projectId: new Types.ObjectId(projectId) });
-    expect(fileCount).toBeGreaterThan(0);
+    // The starter scaffold is committed into the project's git store.
+    const filesRes = await req("GET", `/projects/${projectId}/files`);
+    expect(filesRes.status).toBe(200);
+    const files = (await filesRes.json()) as {
+      files: Array<{ path: string }>;
+    };
+    expect(files.files.map(f => f.path)).toContain("dbt_project.yml");
 
     const list = await (await req("GET", "/projects")).json();
     expect(list.projects).toHaveLength(1);

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -16,8 +16,6 @@ import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import {
   DbtCheckout,
-  DbtFile,
-  DbtFileDraft,
   DbtJob,
   DbtProject,
   DbtRun,
@@ -42,8 +40,7 @@ import {
   listInstallationRepos,
 } from "../integrations/github/github-api";
 import {
-  fetchRepoDbtFiles,
-  repoFilesToInserts,
+  importProjectFromRepo,
   syncProjectBranchFromRepo,
 } from "../dbt/dbt-github-sync.service";
 import {
@@ -63,12 +60,14 @@ import {
   updateProjectPullRequest,
 } from "../dbt/dbt-github-git.service";
 import {
+  deleteProjectStore,
   deleteWorkingFile,
   discardUserDrafts,
   getCheckoutBranch,
   listWorkingFiles,
   readWorkingFile,
   renameWorkingFile,
+  seedProjectFiles,
   writeWorkingFile,
 } from "../dbt/dbt-working-tree.service";
 import { publishRealtimeEvent } from "../services/realtime.service";
@@ -95,11 +94,6 @@ import {
 } from "../dbt/dbt-run.service";
 import { validateScheduledConsoleSchedule } from "../services/scheduled-query-schedule.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
-import {
-  createVersion,
-  getLatestVersionNumber,
-  getUserDisplayName,
-} from "../services/entity-version.service";
 
 const logger = loggers.api("dbt");
 
@@ -364,15 +358,7 @@ dbtRoutes.post("/projects", async (c: AuthenticatedContext) => {
     });
 
     const scaffold = buildStarterScaffold(body.name);
-    await DbtFile.insertMany(
-      scaffold.map(file => ({
-        workspaceId: project.workspaceId,
-        projectId: project._id,
-        path: file.path,
-        content: file.content,
-        updatedBy: userId,
-      })),
-    );
+    await seedProjectFiles(project, userId, scaffold);
 
     publishDbtEvent(c, {
       type: "dbt.project.updated",
@@ -497,11 +483,10 @@ dbtRoutes.delete("/projects/:projectId", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "dbt project not found" }, 404);
     }
     await Promise.all([
-      DbtFile.deleteMany({ projectId: project._id }),
-      DbtFileDraft.deleteMany({ projectId: project._id }),
       DbtCheckout.deleteMany({ projectId: project._id }),
       DbtJob.deleteMany({ projectId: project._id }),
       DbtRun.deleteMany({ projectId: project._id }),
+      deleteProjectStore(project),
     ]);
     await project.deleteOne();
     publishDbtEvent(c, {
@@ -753,29 +738,6 @@ dbtRoutes.post("/projects/import-github", async (c: AuthenticatedContext) => {
     const info = await getRepoInfo(body.repo.owner, body.repo.repo, token);
     const branch = body.repo.branch || info.defaultBranch;
 
-    const binding = {
-      owner: body.repo.owner,
-      repo: body.repo.repo,
-      branch,
-      subdirectory: body.repo.subdirectory,
-      installationId: body.repo.installationId,
-    };
-    const { sha, files, skippedLarge } = await fetchRepoDbtFiles(binding);
-
-    if (files.length === 0) {
-      return badRequest(
-        c,
-        "No dbt files found in that repo/branch/subdirectory",
-      );
-    }
-    const hasProjectYml = files.some(f => f.path === "dbt_project.yml");
-    if (!hasProjectYml) {
-      return badRequest(
-        c,
-        "dbt_project.yml not found at the project root — set the correct subdirectory",
-      );
-    }
-
     const userId = getUserId(c);
     const project = await DbtProject.create({
       workspaceId: new Types.ObjectId(workspaceId),
@@ -789,12 +751,10 @@ dbtRoutes.post("/projects/import-github", async (c: AuthenticatedContext) => {
       repo: {
         provider: "github" as const,
         installationId: body.repo.installationId,
-        owner: binding.owner,
-        repo: binding.repo,
-        branch: binding.branch,
+        owner: body.repo.owner,
+        repo: body.repo.repo,
+        branch,
         subdirectory: body.repo.subdirectory,
-        lastSyncedSha: sha,
-        lastSyncedAt: new Date(),
       },
       // New imports protect the repo's default branch out of the box: prod
       // changes go through a PR (commit-to-branch → open PR → merge).
@@ -802,14 +762,24 @@ dbtRoutes.post("/projects/import-github", async (c: AuthenticatedContext) => {
       createdBy: userId,
     });
 
-    await DbtFile.insertMany(
-      repoFilesToInserts(files, {
-        workspaceId: project.workspaceId,
-        projectId: project._id,
-        branch: binding.branch,
-        updatedBy: userId,
-      }),
-    );
+    // Clone the tracked branch into the project's git store; a repo that
+    // fails validation (no dbt files / no dbt_project.yml) is rolled back.
+    let imported: number;
+    try {
+      const result = await importProjectFromRepo(project);
+      imported = result.imported;
+    } catch (importError) {
+      await Promise.all([
+        deleteProjectStore(project),
+        project.deleteOne(),
+      ]).catch(() => {});
+      return badRequest(
+        c,
+        importError instanceof Error
+          ? importError.message
+          : "Failed to import repository",
+      );
+    }
 
     publishDbtEvent(c, {
       type: "dbt.project.updated",
@@ -818,8 +788,8 @@ dbtRoutes.post("/projects/import-github", async (c: AuthenticatedContext) => {
     return c.json({
       success: true,
       project,
-      imported: files.length,
-      skippedLarge,
+      imported,
+      skippedLarge: [],
     });
   } catch (error) {
     if ((error as { code?: number }).code === 11000) {
@@ -1442,30 +1412,9 @@ dbtRoutes.put(
       }
 
       const userId = getUserId(c);
-      const { versionEntityId } = await writeWorkingFile(
-        project,
-        userId,
-        path,
-        body.content,
-      );
-
-      // Version snapshot (entity-version pattern) — undo/version history.
-      try {
-        const latest = await getLatestVersionNumber(versionEntityId, "dbt-file");
-        await createVersion({
-          entityType: "dbt-file",
-          entityId: versionEntityId,
-          workspaceId: project.workspaceId,
-          snapshot: { path, content: body.content },
-          savedBy: userId,
-          savedByName: await getUserDisplayName(userId),
-          comment: `Save ${path} (v${latest + 1})`,
-        });
-      } catch (versionError) {
-        logger.warn("dbt file version snapshot failed", {
-          error: versionError,
-        });
-      }
+      // Every save is a git commit (draft overlay for repo projects, the
+      // shared branch for blank projects) — history lives in git.
+      await writeWorkingFile(project, userId, path, body.content);
 
       await DbtProject.updateOne(
         { _id: project._id },

--- a/api/src/scripts/seed-dbt-engine-demo.ts
+++ b/api/src/scripts/seed-dbt-engine-demo.ts
@@ -102,8 +102,11 @@ async function main(): Promise<void> {
   await mongoose.connect(uri, { serverSelectionTimeoutMS: 15000 });
 
   const { User } = await import("../database/schema");
-  const { DatabaseConnection, DbtProject, DbtFile } = await import(
+  const { DatabaseConnection, DbtProject } = await import(
     "../database/workspace-schema"
+  );
+  const { writeWorkingFile } = await import(
+    "../dbt/dbt-working-tree.service"
   );
   const { workspaceService } = await import("../services/workspace.service");
 
@@ -196,19 +199,11 @@ async function main(): Promise<void> {
   }
 
   for (const file of PROJECT_FILES) {
-    await DbtFile.findOneAndUpdate(
-      { projectId: project._id, path: file.path },
-      {
-        $set: {
-          workspaceId: workspace._id,
-          projectId: project._id,
-          path: file.path,
-          content: file.content,
-          updatedBy: user._id.toString(),
-          is_deleted: false,
-        },
-      },
-      { upsert: true, new: true, setDefaultsOnInsert: true },
+    await writeWorkingFile(
+      project,
+      user._id.toString(),
+      file.path,
+      file.content,
     );
   }
   console.log(`[seed-dbt-demo] Seeded ${PROJECT_FILES.length} dbt files.`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

"Nothing in Mongo, all in git" — dbt project file contents move out of MongoDB entirely into a per-project **bare git repository** on disk (`DBT_GIT_ROOT`, default `api/.data/dbt-git`, `/data/dbt-git` in production).

- **Blank projects**: `refs/heads/main` is the shared working tree; every save is a real git commit (free history, authorship, diffs). Identical-content re-saves are deduped (no history growth).
- **Repo-bound projects**: local branches mirror GitHub via real `git fetch` / `git push --force-with-lease` authenticated with the App installation token (`http.extraheader`). Per-user uncommitted work lives as draft overlay refs (`refs/mako/drafts/<user>` + `refs/mako/drafts-base/<user>`) that lazily rebase onto the checkout branch head — same collaboration semantics as before (drafts invisible to others, carried across branch switches, never clobbered by sync).
- **Deleted**: the `DbtFile`/`DbtFileDraft` Mongo mirror as a write target, the GitHub Git Data API commit/tree/blob plumbing, per-save `entity_versions` snapshots (git history replaces them), and the 3,000-file import ceiling.
- **Lazy migration**: on first touch of a legacy project, its Mongo base trees + drafts are materialized into git (`ensureProjectRepo`); soft-deleted rows with retained content are committed-then-deleted so they stay recoverable via `git log`.
- **Recoverable files** are now git-native (`git log --diff-filter=D`); commits land on the fresh remote head (fetch-before-commit) so concurrent outside pushes no longer conflict.
- Mongo keeps only metadata: projects, jobs, runs, checkouts. API surface unchanged — zero frontend changes needed.

## New modules

- `api/src/dbt/dbt-git-store.service.ts` — bare-repo plumbing (hermetic `git` spawns, CAS ref updates, batch blob reads, tree commits, remote transport).
- `api/src/dbt/dbt-git-remote.ts` — remote URL/auth resolution (mockable seam; tests use local bare repos as the "GitHub" remote).
- `api/src/dbt/dbt-paths.ts` — importable-file policy + subdirectory mapping.

## Walkthrough

[dbt_git_store_ide_demo.mp4](https://cursor.com/agents/bc-e175e233-e4e3-4923-bb89-b2624bc75007/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_git_store_ide_demo.mp4)
IDE demo on the git store: edit `stg_artists.sql`, save, compile, run model (success + tests pass), create `stg_albums.sql`, run history with a green Nightly build.

[Compiled SQL after edit](https://cursor.com/agents/bc-e175e233-e4e3-4923-bb89-b2624bc75007/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompiled_sql_after_edit.webp)
[Run history with successful Nightly build](https://cursor.com/agents/bc-e175e233-e4e3-4923-bb89-b2624bc75007/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_history_nightly_build.webp)

Every UI action landed as a real git commit in the project's bare repo:

```
$ git --git-dir=api/.data/dbt-git/<ws>/<project>.git log --oneline main
2894a35 Save models/staging/stg_albums.sql
d033efe Save models/staging/stg_artists.sql
b035078 Delete packages.yml
56c3ab0 Rename README.md → docs/README.md
f505831 Save models/staging/stg_artists.sql
96431bf Save models/staging/schema.yml
ecd83ef Scaffold dbt project
```

## Testing

- `pnpm --filter api run test:dbt` — 158 passed. The git integration suite (`dbt-github-git.integration.test.ts`, 23 tests) now runs against a **real local bare repo remote** (actual fetch/push/lease code paths), covering draft isolation, sync safety, partial commits, branch protection/promote, checkouts, branch deletion guards, recoverable files, PR merge + checkout relocation, lazy Mongo migration, and overlay hygiene.
- `pnpm --filter api run lint`, `pnpm --filter app run typecheck` — clean.
- Manual E2E in the running app (video above): project create → scaffold committed to git → edit/save (one commit per save, no-op saves deduped) → compile & `build` against local Chinook Postgres (model + 2 tests pass, table materialized) → rename/delete → scheduled-job run through the Inngest executor (success).

## Ops note

`DBT_GIT_ROOT` must point at durable storage in production (it holds blank-project content and unpushed drafts; repo-bound base trees are rebuildable from GitHub). Documented in `.env.example` and `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e175e233-e4e3-4923-bb89-b2624bc75007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e175e233-e4e3-4923-bb89-b2624bc75007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

