### PR TITLE
fix(mcp): server-wide Always allow + auto-run read tools

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -5246,12 +5246,22 @@ export const McpOAuthFlow = mongoose.model<IMcpOAuthFlow>(
 
 export type McpGrantDecision = "always_allow" | "always_deny";
 
+/**
+ * Sentinel toolName for a per-user, server-wide grant. Applies to every tool
+ * on the server that the admin ceiling still permits (ask/block ceilings win).
+ */
+export const MCP_SERVER_WIDE_GRANT_TOOL = "*";
+
 export interface IMcpToolGrant extends Document {
   _id: Types.ObjectId;
   workspaceId: Types.ObjectId;
   serverId: Types.ObjectId;
   /** Grants are always per-user, even on shared workspace credentials. */
   userId: string;
+  /**
+   * Raw MCP tool name, or {@link MCP_SERVER_WIDE_GRANT_TOOL} (`"*"`) for a
+   * server-wide Always allow / Block decision.
+   */
   toolName: string;
   decision: McpGrantDecision;
   lastUsedAt?: Date;

--- a/api/src/routes/mcp.routes.ts
+++ b/api/src/routes/mcp.routes.ts
@@ -19,6 +19,7 @@ import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
 import {
   type IMcpServer,
+  MCP_SERVER_WIDE_GRANT_TOOL,
   McpConnectionConfig,
   McpServer,
   McpToolGrant,
@@ -847,6 +848,10 @@ mcpRoutes.openapi(
 );
 
 const GrantSchema = z.object({
+  /**
+   * Raw MCP tool name, or `"*"` for a server-wide Always allow / Block grant
+   * (applies to every tool the admin ceiling still permits).
+   */
   toolName: z.string().min(1),
   decision: z.enum(["always_allow", "always_deny"]),
 });
@@ -935,26 +940,46 @@ mcpRoutes.openapi(
         return c.json({ success: false, error: "Invalid request body" }, 400);
       }
       const { toolName, decision } = parsed.data;
+      const isServerWide = toolName === MCP_SERVER_WIDE_GRANT_TOOL;
 
-      const cachedTool = server.cachedTools.find(t => t.name === toolName);
-      if (!cachedTool) {
-        return c.json({ success: false, error: "Unknown tool" }, 404);
-      }
-      // The admin restriction is a ceiling: users can always choose stricter
-      // (always_deny/Block is always permitted), but "Always allow" requires
-      // an "always" ceiling.
-      const ceiling = mcpToolRestriction(server, cachedTool);
-      if (decision === "always_allow" && ceiling !== "always") {
-        return c.json(
-          {
-            success: false,
-            error:
-              ceiling === "block"
-                ? "This tool has been blocked by a workspace admin."
-                : "A workspace admin restricted this tool to Ask — it cannot be always-allowed.",
-          },
-          403,
+      if (!isServerWide) {
+        const cachedTool = server.cachedTools.find(t => t.name === toolName);
+        if (!cachedTool) {
+          return c.json({ success: false, error: "Unknown tool" }, 404);
+        }
+        // The admin restriction is a ceiling: users can always choose stricter
+        // (always_deny/Block is always permitted), but "Always allow" requires
+        // an "always" ceiling.
+        const ceiling = mcpToolRestriction(server, cachedTool);
+        if (decision === "always_allow" && ceiling !== "always") {
+          return c.json(
+            {
+              success: false,
+              error:
+                ceiling === "block"
+                  ? "This tool has been blocked by a workspace admin."
+                  : "A workspace admin restricted this tool to Ask — it cannot be always-allowed.",
+            },
+            403,
+          );
+        }
+      } else if (decision === "always_allow") {
+        // Server-wide Always allow only covers tools with an "always" ceiling;
+        // ask/block tools still prompt or stay hidden. Require at least one
+        // always-allowable tool so the grant isn't a silent no-op.
+        const hasAlwaysCeiling = server.cachedTools.some(
+          t => mcpToolRestriction(server, t) === "always",
         );
+        if (!hasAlwaysCeiling) {
+          return c.json(
+            {
+              success: false,
+              error:
+                "No tools on this server can be always-allowed — a workspace admin restricted them to Ask or Block.",
+            },
+            403,
+          );
+        }
       }
 
       await McpToolGrant.updateOne(
@@ -967,6 +992,7 @@ mcpRoutes.openapi(
         serverId: server._id.toString(),
         toolName,
         decision,
+        serverWide: isServerWide,
       });
       return c.json({ success: true });
     } catch (error) {

--- a/api/src/services/mcp-client.service.test.ts
+++ b/api/src/services/mcp-client.service.test.ts
@@ -232,10 +232,10 @@ function testCryptoRoundTrip() {
 
 /**
  * Grants → approval flow, against in-memory Mongo:
- * read tools never need approval; write tools need approval until an
- * always_allow grant exists; always_deny tools skip the prompt and refuse
- * at execute time; destructive tools stay prompt-only unless the admin
- * unlocked grants.
+ * read tools auto-run (no grant); write tools need approval until an
+ * always_allow grant (tool or server-wide `*`) exists; always_deny tools
+ * skip the prompt and refuse at execute time; destructive tools stay
+ * prompt-only unless the admin unlocked grants.
  */
 async function testGrantsAndNeedsApproval() {
   const replSet = await MongoMemoryReplSet.create({
@@ -271,6 +271,12 @@ async function testGrantsAndNeedsApproval() {
           inputSchema: { type: "object", properties: {} },
         },
         {
+          name: "lead_update",
+          description: "Update a lead",
+          annotations: { readOnlyHint: false, destructiveHint: false },
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
           name: "lead_delete",
           description: "Delete a lead",
           annotations: { destructiveHint: true },
@@ -292,7 +298,7 @@ async function testGrantsAndNeedsApproval() {
       });
 
     let chatTools = await loadTools();
-    assert.equal(chatTools.allToolNames.length, 3);
+    assert.equal(chatTools.allToolNames.length, 4);
     assert.deepEqual(chatTools.readOnlyToolNames, [
       "mcp_close_crm_lead_search",
     ]);
@@ -310,23 +316,49 @@ async function testGrantsAndNeedsApproval() {
       return fn === true;
     };
 
-    // Claude model: EVERY tool prompts on first use — reads included —
-    // until the user chooses a permission.
-    assert.equal(await needsApproval("mcp_close_crm_lead_search"), true);
+    // Read tools auto-run; write/destructive still prompt on first use.
+    assert.equal(await needsApproval("mcp_close_crm_lead_search"), false);
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), true);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), true);
     assert.equal(await needsApproval("mcp_close_crm_lead_delete"), true);
 
-    // "Always allow" grant on the read tool: no more prompts.
+    // Server-wide Always allow covers every always-ceiling write tool.
     await McpToolGrant.create({
       workspaceId,
       serverId: server._id,
       userId,
-      toolName: "lead_search",
+      toolName: "*",
       decision: "always_allow",
     });
-    assert.equal(await needsApproval("mcp_close_crm_lead_search"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false);
+    // Destructive still prompts — default ceiling is "ask".
+    assert.equal(await needsApproval("mcp_close_crm_lead_delete"), true);
 
-    // "Always allow" grant on the write tool: no more prompts.
+    // Tool-level Block beats a server-wide Always allow.
+    await McpToolGrant.create({
+      workspaceId,
+      serverId: server._id,
+      userId,
+      toolName: "lead_update",
+      decision: "always_deny",
+    });
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false);
+    const updateTool = chatTools.tools["mcp_close_crm_lead_update"];
+    assert.ok(updateTool.execute);
+    const updateDenied = (await updateTool.execute(
+      {},
+      { toolCallId: "t", messages: [], experimental_context: undefined },
+    )) as { success: boolean; denied?: boolean };
+    assert.equal(updateDenied.success, false);
+    assert.equal(updateDenied.denied, true);
+
+    // Clear the server-wide grant; per-tool Always allow still works.
+    await McpToolGrant.deleteOne({
+      serverId: server._id,
+      userId,
+      toolName: "*",
+    });
     await McpToolGrant.create({
       workspaceId,
       serverId: server._id,
@@ -334,7 +366,9 @@ async function testGrantsAndNeedsApproval() {
       toolName: "lead_create",
       decision: "always_allow",
     });
+    chatTools = await loadTools();
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false); // still blocked
 
     // Destructive tool: defaults to an "ask" ceiling, so an always_allow
     // grant is IGNORED until an admin explicitly relaxes that tool.
@@ -390,6 +424,12 @@ async function testGrantsAndNeedsApproval() {
       { _id: server._id },
       { $set: { "toolPolicy.restrictions": { lead_delete: "always" } } },
     );
+    // Drop the tool-level block so lead_update is promptable again.
+    await McpToolGrant.deleteOne({
+      serverId: server._id,
+      userId,
+      toolName: "lead_update",
+    });
     chatTools = await loadTools();
 
     // "Always deny": no prompt, and execute refuses without contacting the
@@ -397,6 +437,7 @@ async function testGrantsAndNeedsApproval() {
     await McpToolGrant.updateOne(
       { serverId: server._id, userId, toolName: "lead_create" },
       { $set: { decision: "always_deny" } },
+      { upsert: true },
     );
     chatTools = await loadTools();
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
@@ -409,7 +450,7 @@ async function testGrantsAndNeedsApproval() {
     assert.equal(denied.success, false);
     assert.equal(denied.denied, true);
 
-    // Grants are per-user: a different user still gets prompted.
+    // Grants are per-user: a different user still gets prompted on writes.
     const otherUserTools = await buildMcpToolsForChat({
       workspaceId: workspaceId.toString(),
       userId: "user-2",
@@ -424,6 +465,18 @@ async function testGrantsAndNeedsApproval() {
           )
         : otherFn,
       true,
+    );
+    // Reads still auto-run for the other user.
+    const otherSearch = otherUserTools.tools["mcp_close_crm_lead_search"];
+    const otherSearchFn = otherSearch.needsApproval;
+    assert.equal(
+      typeof otherSearchFn === "function"
+        ? await otherSearchFn(
+            {},
+            { toolCallId: "t", messages: [], experimental_context: undefined },
+          )
+        : otherSearchFn,
+      false,
     );
 
     // User-performer servers without the user's credential are skipped.

--- a/api/src/services/mcp-client.service.ts
+++ b/api/src/services/mcp-client.service.ts
@@ -10,8 +10,10 @@
  *  - Tool *executions* open a short-lived client per call (connect → call →
  *    close). No pooling — every call is bound to exactly one workspace/user
  *    credential, so credentials can never bleed across tenants.
- *  - Write-risk tiers + per-user grants drive the AI SDK's native
- *    `needsApproval` human-in-the-loop flow (allow once / always allow).
+ *  - Risk tiers + per-user grants (per-tool or server-wide `*`) drive the
+ *    AI SDK's native `needsApproval` flow (allow once / always allow).
+ *    Read-tier tools with an open admin ceiling auto-run; writes prompt
+ *    until granted.
  */
 
 import { createMCPClient } from "@ai-sdk/mcp";
@@ -22,7 +24,9 @@ import { Types } from "mongoose";
 import {
   type IMcpCachedTool,
   type IMcpServer,
+  type McpGrantDecision,
   type McpToolRestriction,
+  MCP_SERVER_WIDE_GRANT_TOOL,
   McpConnectionConfig,
   McpServer,
   McpToolGrant,
@@ -361,19 +365,53 @@ async function resolveActiveServers(
 }
 
 /**
- * Approval decision for one tool call, following the Claude-connectors
- * model: the admin restriction is a *ceiling*, and the user's per-tool
- * choice (grant) picks a setting up to that ceiling.
+ * Resolve the effective per-user grant for a tool.
  *
- * Every tool — reads included — prompts on first use until the user decides
- * (Claude behavior: access is granted by the individual, never implicitly).
+ * Precedence: tool-specific grant > server-wide (`*`) grant > none.
+ * A tool-level Block always wins over a server-wide Always allow.
+ */
+export async function resolveMcpToolGrant(params: {
+  serverId: Types.ObjectId | string;
+  userId: string | undefined;
+  toolName: string;
+}): Promise<{ decision: McpGrantDecision; toolName: string } | null> {
+  const { serverId, userId, toolName } = params;
+  if (!userId) return null;
+
+  const grants = await McpToolGrant.find({
+    serverId,
+    userId,
+    toolName: { $in: [toolName, MCP_SERVER_WIDE_GRANT_TOOL] },
+  }).lean();
+
+  const toolGrant = grants.find(g => g.toolName === toolName);
+  if (toolGrant) {
+    return { decision: toolGrant.decision, toolName: toolGrant.toolName };
+  }
+  const serverGrant = grants.find(
+    g => g.toolName === MCP_SERVER_WIDE_GRANT_TOOL,
+  );
+  if (serverGrant) {
+    return {
+      decision: serverGrant.decision,
+      toolName: serverGrant.toolName,
+    };
+  }
+  return null;
+}
+
+/**
+ * Approval decision for one tool call, following the Claude-connectors
+ * model: the admin restriction is a *ceiling*, and the user's grant
+ * (per-tool or server-wide `*`) picks a setting up to that ceiling.
  *
  * Resolution:
  *  - blocked tools never get here (filtered at build time)
- *  - user chose Block (always_deny) → no prompt; execute() refuses
- *  - ceiling "ask" → always prompt (user's Always allow can't apply)
- *  - user chose Always allow → auto-run
- *  - no choice yet → prompt
+ *  - user chose Block (always_deny, tool or `*`) → no prompt; execute() refuses
+ *  - ceiling "ask" → always prompt (Always allow grants can't apply)
+ *  - read-tier tools with an "always" ceiling → auto-run (no grant needed)
+ *  - user chose Always allow (tool or `*`) → auto-run
+ *  - no choice yet on a write tool → prompt
  */
 async function mcpNeedsApproval(params: {
   server: IMcpServer;
@@ -382,20 +420,20 @@ async function mcpNeedsApproval(params: {
 }): Promise<boolean> {
   const { server, tool, userId } = params;
   const ceiling = mcpToolRestriction(server, tool);
-
-  const grant = userId
-    ? await McpToolGrant.findOne({
-        serverId: server._id,
-        userId,
-        toolName: tool.name,
-      }).lean()
-    : null;
+  const grant = await resolveMcpToolGrant({
+    serverId: server._id,
+    userId,
+    toolName: tool.name,
+  });
 
   if (grant?.decision === "always_deny") {
     // No approval prompt: execute() returns the denial to the model.
     return false;
   }
   if (ceiling === "ask") return true;
+  // Read tools with an open ceiling don't need a grant — matches the product
+  // docs and stops Close-style connectors from prompting on every search.
+  if (mcpToolRiskTier(server, tool) === "read") return false;
   return grant?.decision !== "always_allow";
 }
 
@@ -468,13 +506,11 @@ export async function buildMcpToolsForChat(params: {
             };
           }
 
-          const grant = userId
-            ? await McpToolGrant.findOne({
-                serverId: server._id,
-                userId,
-                toolName: cachedTool.name,
-              }).lean()
-            : null;
+          const grant = await resolveMcpToolGrant({
+            serverId: server._id,
+            userId,
+            toolName: cachedTool.name,
+          });
 
           if (grant?.decision === "always_deny") {
             logger.info("MCP tool call denied by user grant", {
@@ -482,6 +518,7 @@ export async function buildMcpToolsForChat(params: {
               userId,
               serverId: server._id.toString(),
               toolName: cachedTool.name,
+              grantToolName: grant.toolName,
             });
             return {
               success: false,
@@ -514,7 +551,11 @@ export async function buildMcpToolsForChat(params: {
             });
             if (grant) {
               void McpToolGrant.updateOne(
-                { _id: grant._id },
+                {
+                  serverId: server._id,
+                  userId,
+                  toolName: grant.toolName,
+                },
                 { $set: { lastUsedAt: new Date() } },
               ).catch(() => undefined);
             }

--- a/app/src/components/McpApprovalCard.tsx
+++ b/app/src/components/McpApprovalCard.tsx
@@ -6,13 +6,15 @@
  *          { input preview }
  *          [ Always allow ⏎ | v ]  [ Deny esc ]
  *
- * "Always allow" persists a per-user grant (each user decides only for
- * themselves) and is offered only when the workspace admin's restriction
- * ceiling for the tool permits it — otherwise "Allow once ⏎" is primary.
+ * "Always allow" persists a per-user grant for this tool. The overflow menu
+ * also offers "Always allow all tools from <server>" (server-wide `*` grant).
+ * Both are offered only when the workspace admin's restriction ceiling for
+ * the tool permits Always allow — otherwise "Allow once ⏎" is primary.
  * Enter triggers the primary action, Escape denies.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
+  Alert,
   Box,
   Button,
   ButtonGroup,
@@ -32,6 +34,9 @@ import {
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useMcpStore } from "../store/mcpStore";
+
+/** Sentinel matching api MCP_SERVER_WIDE_GRANT_TOOL. */
+const SERVER_WIDE_GRANT = "*";
 
 export interface McpApprovalResponseArgs {
   approvalId: string;
@@ -111,6 +116,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
   const saveGrant = useMcpStore(s => s.saveGrant);
   const [busy, setBusy] = useState<"once" | "always" | "deny" | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [grantError, setGrantError] = useState<string | null>(null);
   const busyRef = useRef(busy);
   busyRef.current = busy;
 
@@ -131,10 +137,15 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
     }
   }, [pendingForInfo, currentWorkspace]);
 
-  const respond = async (approved: boolean, always: boolean) => {
+  const respond = async (
+    approved: boolean,
+    always: boolean,
+    scope: "tool" | "server" = "tool",
+  ) => {
     if (busyRef.current) return;
     setBusy(always ? "always" : approved ? "once" : "deny");
     setMenuAnchor(null);
+    setGrantError(null);
     try {
       if (always && approved && currentWorkspace && toolInfo) {
         // Persist the grant first so the server-side needsApproval check
@@ -142,12 +153,20 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
         await saveGrant(
           currentWorkspace.id,
           toolInfo.serverId,
-          toolInfo.toolName,
+          scope === "server" ? SERVER_WIDE_GRANT : toolInfo.toolName,
           "always_allow",
         );
       }
-    } catch {
-      // Grant persistence failing shouldn't block the one-time approval.
+    } catch (error) {
+      // Grant persistence failing shouldn't block the one-time approval, but
+      // surface it — otherwise "Always allow" looks like it stuck when it didn't.
+      if (always && approved) {
+        setGrantError(
+          error instanceof Error
+            ? error.message
+            : "Could not save Always allow — this call will still run once.",
+        );
+      }
     } finally {
       onRespond({ approvalId, approved });
       setBusy(null);
@@ -178,7 +197,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
         if (isTextInput && inputText.trim().length > 0) return;
         event.preventDefault();
         event.stopPropagation();
-        void respond(true, primaryIsAlways);
+        void respond(true, primaryIsAlways, "tool");
       } else if (event.key === "Escape") {
         event.preventDefault();
         void respond(false, false);
@@ -276,6 +295,16 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
             {secondChip}
           </Stack>
 
+          {pending && !canAlwaysAllow && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mt: 0.5 }}
+            >
+              Workspace policy requires approval each time for this tool.
+            </Typography>
+          )}
+
           {inputPreview && (
             <Box
               component="pre"
@@ -296,6 +325,12 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
             >
               {inputPreview}
             </Box>
+          )}
+
+          {grantError && (
+            <Alert severity="warning" sx={{ mt: 1, py: 0 }}>
+              {grantError}
+            </Alert>
           )}
 
           {pending && (
@@ -320,7 +355,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
               >
                 <Button
                   disabled={busy !== null}
-                  onClick={() => void respond(true, primaryIsAlways)}
+                  onClick={() => void respond(true, primaryIsAlways, "tool")}
                   startIcon={
                     busy === (primaryIsAlways ? "always" : "once") ? (
                       <CircularProgress size={12} color="inherit" />
@@ -335,7 +370,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
                       : "mcp-approval-allow-once"
                   }
                 >
-                  {primaryIsAlways ? "Always allow" : "Allow once"}
+                  {primaryIsAlways ? "Always allow this tool" : "Allow once"}
                 </Button>
                 {primaryIsAlways && (
                   <Button
@@ -361,6 +396,15 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
                 >
                   Allow once
                 </MenuItem>
+                {canAlwaysAllow && serverName && (
+                  <MenuItem
+                    dense
+                    onClick={() => void respond(true, true, "server")}
+                    data-testid="mcp-approval-always-allow-server"
+                  >
+                    Always allow all tools from {serverName}
+                  </MenuItem>
+                )}
               </Menu>
               <Button
                 variant="outlined"

--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -801,9 +801,10 @@ function ServerDetail({
   };
 
   /**
-   * The user's own per-tool permission (Claude-style): Always allow / Ask /
-   * Block, stored as a grant ("Ask" simply clears it — the tool prompts on
-   * next use). Capped by the admin ceiling via disabled options.
+   * The user's own permission (Claude-style): Always allow / Ask / Block,
+   * stored as a grant ("Ask" simply clears it — the tool prompts on next
+   * use). `toolName` may be `"*"` for a server-wide grant. Capped by the
+   * admin ceiling via disabled options.
    */
   const handleSetUserPermission = async (
     toolName: string,
@@ -811,19 +812,37 @@ function ServerDetail({
     grantId?: string,
   ) => {
     if (!currentWorkspace) return;
-    if (value === "ask") {
-      if (grantId) {
-        await revokeGrant(currentWorkspace.id, server.id, grantId);
+    try {
+      if (value === "ask") {
+        if (grantId) {
+          await revokeGrant(currentWorkspace.id, server.id, grantId);
+        }
+        return;
       }
-      return;
+      await saveGrant(
+        currentWorkspace.id,
+        server.id,
+        toolName,
+        value === "always_allow" ? "always_allow" : "always_deny",
+      );
+    } catch (error) {
+      onNotify(
+        error instanceof Error ? error.message : "Failed to update permission",
+        "error",
+      );
     }
-    await saveGrant(
-      currentWorkspace.id,
-      server.id,
-      toolName,
-      value === "always_allow" ? "always_allow" : "always_deny",
-    );
   };
+
+  const serverWideGrant = myGrants.find(g => g.toolName === "*");
+  const serverWideValue =
+    serverWideGrant?.decision === "always_allow"
+      ? "always_allow"
+      : serverWideGrant?.decision === "always_deny"
+        ? "block"
+        : "ask";
+  const canServerWideAlwaysAllow = server.cachedTools.some(
+    t => t.restriction === "always",
+  );
 
   const handleDelete = async () => {
     if (!currentWorkspace) return;
@@ -1049,10 +1068,59 @@ function ServerDetail({
               color="text.secondary"
               sx={{ display: "block", mb: 1 }}
             >
-              These choices apply only to you. Tools ask on first use until you
-              decide — pick a permission here or from the approval prompt in
-              chat.
+              These choices apply only to you. Read tools run without prompting.
+              Write tools ask until you Always allow — per tool below, or for
+              the whole server.
             </Typography>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              useFlexGap
+              sx={{
+                mb: 1,
+                py: 0.75,
+                px: 1,
+                borderRadius: 1,
+                bgcolor: "action.hover",
+                flexWrap: "wrap",
+                rowGap: 0.5,
+              }}
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" fontWeight={600}>
+                  All tools on {server.name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Server-wide Always allow covers every tool the admin still
+                  permits. Per-tool Block below overrides it. Destructive tools
+                  stay Ask unless an admin unlocks them.
+                </Typography>
+              </Box>
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <Select
+                  value={serverWideValue}
+                  disabled={!currentWorkspace}
+                  onChange={e =>
+                    void handleSetUserPermission(
+                      "*",
+                      e.target.value as "always_allow" | "ask" | "block",
+                      serverWideGrant?.id,
+                    )
+                  }
+                  sx={{ fontSize: 13 }}
+                >
+                  <MenuItem
+                    value="always_allow"
+                    disabled={!canServerWideAlwaysAllow}
+                  >
+                    Always allow
+                  </MenuItem>
+                  <MenuItem value="ask">Ask (default)</MenuItem>
+                  <MenuItem value="block">Block all</MenuItem>
+                </Select>
+              </FormControl>
+            </Stack>
             <Stack spacing={0.25}>
               {server.cachedTools.map(tool => {
                 const grant = myGrants.find(g => g.toolName === tool.name);
@@ -1063,6 +1131,14 @@ function ServerDetail({
                       ? "block"
                       : "ask";
                 const blockedByAdmin = tool.restriction === "block";
+                const inheritedAlways =
+                  !grant &&
+                  serverWideGrant?.decision === "always_allow" &&
+                  tool.restriction === "always" &&
+                  tool.riskTier !== "read";
+                const ceilingOverridesGrant =
+                  grant?.decision === "always_allow" &&
+                  tool.restriction === "ask";
                 return (
                   <Stack
                     key={tool.name}
@@ -1079,13 +1155,30 @@ function ServerDetail({
                       "&:hover": { bgcolor: "action.hover" },
                     }}
                   >
-                    <Typography
-                      variant="body2"
-                      sx={{ fontFamily: "monospace", flex: 1, minWidth: 0 }}
-                      noWrap
-                    >
-                      {tool.name}
-                    </Typography>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontFamily: "monospace" }}
+                        noWrap
+                      >
+                        {tool.name}
+                      </Typography>
+                      {tool.riskTier === "read" && value === "ask" && (
+                        <Typography variant="caption" color="text.secondary">
+                          Read — runs without prompting
+                        </Typography>
+                      )}
+                      {inheritedAlways && (
+                        <Typography variant="caption" color="text.secondary">
+                          Covered by server-wide Always allow
+                        </Typography>
+                      )}
+                      {ceilingOverridesGrant && (
+                        <Typography variant="caption" color="warning.main">
+                          Always allow saved, but admin Ask still prompts
+                        </Typography>
+                      )}
+                    </Box>
                     {blockedByAdmin ? (
                       <Typography variant="caption" color="text.disabled">
                         Blocked by admin

--- a/app/src/pages/settings/SettingsMcp.tsx
+++ b/app/src/pages/settings/SettingsMcp.tsx
@@ -5,7 +5,7 @@ export default function SettingsMcp() {
   return (
     <SettingsLayout
       title="MCP Servers"
-      description="Connect Model Context Protocol servers (Close CRM, or any MCP-compatible service) to give the agent tools for external systems. Write actions ask for your approval unless you choose Always allow."
+      description="Connect Model Context Protocol servers (Close CRM, or any MCP-compatible service) to give the agent tools for external systems. Read tools run freely; write actions ask for approval unless you Always allow a tool or the whole server."
     >
       <McpServersSection />
     </SettingsLayout>

--- a/docs/src/content/docs/mcp-connectors.md
+++ b/docs/src/content/docs/mcp-connectors.md
@@ -45,19 +45,20 @@ Within an allowed scope, each discovered tool is assigned a **risk tier**:
 
 ## Approval flow
 
-MCP tool calls use a Claude-style human-in-the-loop approval, surfaced as an **approval card** in chat with an input preview and risk badge. Three choices:
+MCP tool calls use a Claude-style human-in-the-loop approval, surfaced as an **approval card** in chat with an input preview and risk badge. Choices:
 
 - **Allow once** — run this call now.
-- **Always allow** — run now and persist an `always_allow` grant so future calls of this tool skip the prompt.
+- **Always allow this tool** — run now and persist an `always_allow` grant so future calls of **this tool** skip the prompt.
+- **Always allow all tools from this server** — same, but stores a server-wide `*` grant covering every tool the admin ceiling still permits (per-tool Block overrides it).
 - **Deny / Block** — refuse this call; a persisted `always_deny` grant refuses future calls at execution without prompting.
 
 Default behavior by tier:
 
-- **read** tools auto-run (no prompt).
-- **write** tools prompt unless you've granted **always allow**.
-- **destructive** tools always prompt and can only be unlocked by a workspace admin.
+- **read** tools auto-run (no prompt) when the admin ceiling is Always.
+- **write** tools prompt unless you've granted **always allow** (per-tool or server-wide).
+- **destructive** tools always prompt by default (admin ceiling Ask) and can only be unlocked by a workspace admin setting that tool's restriction to Always.
 
-Grants are per-user and per-tool. Manage or revoke them under **Settings → MCP Servers**.
+Grants are per-user. Manage or revoke them under **Settings → MCP Servers** (including a server-wide Always allow control). Admin restrictions are a *ceiling*: if a tool is set to Ask, your Always allow grant is ignored and the prompt still appears.
 
 Tools are namespaced `mcp_<server>_<tool>` in the agent runtime, and are treated as cross-cutting across modes. The [plan gate](/skills/) keeps only read-tier MCP tools available during planning.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Mako chat, clicking **Always allow** on an MCP tool still led to more approval prompts. Root causes in product code (not Cursor IDE):

1. **Grants were per-tool only** — approving `lead_search` did nothing for `lead_create`. Close-style connectors have many tools, so users felt "Always allow" never stuck.
2. **Read tools prompted on every first use** — code required a grant for every tool, while docs said reads auto-run.
3. **Silent grant-save failures** — if the admin ceiling was Ask (common for destructive tools), the card still approved the call once but swallowed the 403, so the next call prompted again with no explanation.
4. **Admin Ask ceiling overrides Always allow** — by design, but Settings didn't show that the saved grant was ineffective.

## Approach

| Change | Effect |
| --- | --- |
| Server-wide grant `toolName: "*"` | One Always allow covers every tool the admin ceiling still permits |
| `resolveMcpToolGrant` precedence | Tool-specific grant > `*` > none; tool Block beats server Always allow |
| Read-tier auto-run | `mcpNeedsApproval` returns false for read tools with an open (`always`) ceiling |
| Approval card | Primary = "Always allow **this tool**"; menu adds "Always allow all tools from \<server\>"; surfaces grant-save errors |
| Settings → Your tool permissions | Server-wide Always allow / Ask / Block control + inherited / overridden hints |
| Docs | Aligned with actual behavior |

Admin ceilings unchanged: destructive tools still default to Ask and cannot be always-allowed until an admin unlocks them.

## Test plan

- [x] `pnpm --filter api exec tsx src/services/mcp-client.service.test.ts`
- [x] `pnpm --filter api run lint`
- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint`
- [ ] Manual: connect Close (or custom MCP), confirm read tools don't prompt; Always allow this tool skips that tool; Always allow all tools from server skips other write tools; destructive still prompts unless admin unlocks

## Note

[#682](https://github.com/mako-ai/mako/pull/682) was an incorrect Cursor IDE `permissions.json` change — please close it; this PR is the real fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35752433-6127-4efb-8392-d3f112508c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35752433-6127-4efb-8392-d3f112508c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

