### PR TITLE
docs: cover Jul 10 infra changes — preview dev project, prod canary router, deploy.sh overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,11 @@ pnpm migrate create "name" # Create a new migration file with timestamp
 
 ```bash
 pnpm cf:login              # Login to Cloudflare
-pnpm cf:deploy             # Deploy to Cloudflare Workers
+pnpm cf:deploy             # Deploy the PR preview router Worker
+pnpm cf:app:test           # Test the production app router Worker (app.mako.ai)
+pnpm cf:app:check          # Dry-run deploy of the production app router
+pnpm cf:app:deploy         # Deploy the production app router (see cloudflare/app-router/README.md)
+pnpm cf:app:deploy:canary  # Deploy the canary app router (app-canary.mako.ai)
 pnpm preview-db:*          # Manage preview databases (create, destroy, list, seed)
 ```
 

--- a/INNGEST_DEV_CONFIG.md
+++ b/INNGEST_DEV_CONFIG.md
@@ -3,7 +3,7 @@
 This repo runs dashboard materialization in three different environments:
 
 - `local`: app on `http://localhost:5173`, API on `http://localhost:8080`, Inngest dev server on `http://localhost:8288`
-- `pr`: preview deploys on `https://pr-<number>.mako.ai`
+- `pr`: preview deploys on `https://pr-<number>.mako.ai` (deployed to the dedicated `mako-ai-dev` GCP project, using bucket `mako-ai-dev-dashboard-artifacts`)
 - `production`: `https://app.mako.ai`
 
 ## Inngest
@@ -144,5 +144,5 @@ lower `CDC_MATERIALIZE_CONCURRENCY_PER_FLOW` instead of the global cap.
 | -------------- | -------------- | --------------------------------------- | ------------------------- | ---------------------- |
 | Local default  | filesystem     | n/a                                     | local dev server          | disabled by `NODE_ENV` |
 | Local with GCS | gcs            | `dashboard-artifacts/local-<your-name>` | local dev server          | disabled by `NODE_ENV` |
-| PR preview     | gcs            | `dashboard-artifacts/pr-<number>`       | `INNGEST_ENV=pr-<number>` | disabled               |
+| PR preview     | gcs (dev bucket) | `dashboard-artifacts/pr-<number>`     | `INNGEST_ENV=pr-<number>` | disabled               |
 | Production     | gcs            | `dashboard-artifacts/prod`              | default environment       | enabled                |

--- a/docs/src/content/docs/deployment.md
+++ b/docs/src/content/docs/deployment.md
@@ -68,6 +68,15 @@ MAKO_DEPLOY_RUNTIME_SERVICE_ACCOUNT=runtime-sa@mako-ai-prod.iam.gserviceaccount.
 The dashboard artifact bucket defaults to `<project-id>-dashboard-artifacts`
 and can be overridden with `MAKO_DEPLOY_DASHBOARD_BUCKET`.
 
+### Service authentication
+
+Production Cloud Run services are deployed with `--allow-unauthenticated`:
+authentication happens at the application layer (sessions and `revops_*` API
+keys), not Cloud Run IAM. Public ingress is required because Inngest registers
+against the service's direct `*.run.app/api/inngest` endpoint rather than
+going through the Cloudflare app router, so a newly created production
+service must accept unauthenticated traffic before the Inngest sync runs.
+
 ### Environment Variables
 
 Set these in Cloud Run's environment configuration (or via `cloud-run-env.yaml`):

--- a/docs/src/content/docs/deployment.md
+++ b/docs/src/content/docs/deployment.md
@@ -53,6 +53,21 @@ The script:
 5. Builds Docker image and pushes to Google Artifact Registry
 6. Deploys to Cloud Run
 
+By default the script targets the project configured in `.env`. Operators can
+point a deploy at a different environment without editing `.env` by setting
+`MAKO_DEPLOY_*` overrides:
+
+```bash
+MAKO_DEPLOY_PROJECT_ID=mako-ai-prod \
+MAKO_DEPLOY_REGION=europe-west1 \
+MAKO_DEPLOY_REPOSITORY=mako \
+MAKO_DEPLOY_RUNTIME_SERVICE_ACCOUNT=runtime-sa@mako-ai-prod.iam.gserviceaccount.com \
+./deploy.sh
+```
+
+The dashboard artifact bucket defaults to `<project-id>-dashboard-artifacts`
+and can be overridden with `MAKO_DEPLOY_DASHBOARD_BUCKET`.
+
 ### Environment Variables
 
 Set these in Cloud Run's environment configuration (or via `cloud-run-env.yaml`):
@@ -195,9 +210,14 @@ artifacts, delete stale artifacts, and generate signed read URLs.
 - If `DASHBOARD_ARTIFACT_STORE` is not set, Mako falls back to `filesystem`.
 - Your deploy workflow must also pass the artifact storage env vars to Cloud
   Run, or later deploys can revert the backend to local disk.
-- Preview environments should use a unique prefix such as
-  `dashboard-artifacts/pr-123` so all previews can safely share the same
-  bucket.
+- PR previews deploy to the dedicated dev project (`mako-ai-dev`), with their
+  own Artifact Registry repo and dashboard bucket
+  (`mako-ai-dev-dashboard-artifacts`); production is untouched by preview
+  deploys. Each preview still uses a unique prefix such as
+  `dashboard-artifacts/pr-123` so previews can safely share the dev bucket.
+- Previews do not get `REDIS_URL`: the production Memorystore instance is only
+  reachable inside the prod VPC, so preview APIs fall back to in-process
+  pub/sub.
 
 ## Billing (Optional)
 
@@ -230,4 +250,26 @@ Stripe promotion codes/coupons can be applied at checkout. The Stripe Checkout U
 
 ## Cloudflare Workers
 
-The `cloudflare/` directory contains Cloudflare Workers configuration for edge routing and proxy functionality.
+The `cloudflare/` directory contains two Workers:
+
+- **PR preview router** (`cloudflare/`): routes `pr-<number>.mako.ai` to the
+  corresponding Cloud Run preview deployment. See `cloudflare/README.md`.
+- **Production app router** (`cloudflare/app-router/`): keeps `app.mako.ai`
+  independent of any single Cloud Run project. It proxies request/response
+  streams without buffering, supports a maintenance mode that keeps accepting
+  external webhooks, and serves a separate `app-canary.mako.ai` route so a new
+  production origin can be rehearsed and rolled back without touching CDC
+  code. Cutover and rollback are KV route-object updates. See
+  `cloudflare/app-router/README.md` for cutover controls.
+
+Useful scripts:
+
+```bash
+pnpm cf:deploy             # Deploy the PR preview router
+pnpm cf:app:test           # Run app-router unit tests
+pnpm cf:app:check          # Dry-run deploy of the production app router
+pnpm cf:app:check:canary   # Dry-run deploy of the canary app router
+pnpm cf:app:deploy         # Deploy the production app router
+pnpm cf:app:deploy:canary  # Deploy the canary app router
+pnpm cf:app:tail           # Tail production app-router logs
+```


### PR DESCRIPTION
Covers doc drift from yesterday's infra merges:

- **#693** (PR previews → dedicated `mako-ai-dev` project): deployment.md preview notes now describe the dev project, dev dashboard bucket, and the no-REDIS_URL fallback; INNGEST_DEV_CONFIG.md environment rows updated.
- **#694** (mako-ai-prod runtime cutover prep): deployment.md documents the new `MAKO_DEPLOY_*` override vars for `deploy.sh` and expands the Cloudflare Workers section to cover both the PR preview router and the new production app router + canary (`app-canary.mako.ai`), pointing at `cloudflare/app-router/README.md` for cutover controls.
- **CLAUDE.md**: adds the new `cf:app:*` scripts to the Infrastructure & Deployment command list.

No doc surface needed for #690/#691 (internal analytics surface telemetry + desktop version bump). Source-verified against `deploy.sh`, `.github/workflows/deploy-app.yml`, `package.json`, and `cloudflare/app-router/README.md`.

Automated docs-maintenance run (Aura).