### PR TITLE
fix(apps): BigQuery parquet materialization fails at schema probe

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -509,6 +509,7 @@ export function createServerAppTools({
           const waitMs = Math.min(Math.max(waitSeconds ?? 120, 0), 600) * 1000;
           const deadline = Date.now() + waitMs;
           let status: string = queued.status;
+          let lastError: string | null | undefined = queued.error;
           // Poll the doc until the background build terminates or the wait
           // elapses (the build keeps running server-side either way).
           while (
@@ -522,6 +523,7 @@ export function createServerAppTools({
               : null;
             if (!st) break;
             status = st.status;
+            lastError = st.error;
           }
           if (status === "ready") {
             // Bump version + poke so an attached browser reloads the artifact
@@ -550,7 +552,9 @@ export function createServerAppTools({
               success: false,
               binding: { name },
               status: "error",
-              error: "Materialization failed. Check the binding query.",
+              error: lastError
+                ? `Materialization failed: ${lastError}`
+                : "Materialization failed. Check the binding query.",
             };
           }
           return {

--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -22,6 +22,7 @@ import { databaseRegistry } from "../databases/registry";
 import { isLocalBigQueryEmulator } from "../utils/bigquery-emulator";
 import {
   type PreviewPageInfo,
+  applySqlRowLimit,
   buildBigQueryCursor,
   buildPreviewPage,
   checkPreviewQuerySafety,
@@ -842,15 +843,23 @@ export class DatabaseConnectionService {
       }
     }
 
+    // BigQuery must never go through prepareSqlBatchQuery: LIMIT/OFFSET batching
+    // is unsupported there (it throws "BigQuery batch queries must use native
+    // page tokens"). This fallback path is reached when the native dry-run
+    // schema probe returns no columns (e.g. an empty dry-run schema), so probe
+    // with a dialect-safe single-row execution rather than throwing and failing
+    // the entire materialization.
     const probeQuery =
-      typeof query === "string"
-        ? prepareSqlBatchQuery({
-            query,
-            databaseType: database.type,
-            batchSize: 1,
-            offset: 0,
-          }).query
-        : query;
+      typeof query !== "string"
+        ? query
+        : database.type === "bigquery"
+          ? applySqlRowLimit({ query, databaseType: database.type, limit: 1 })
+          : prepareSqlBatchQuery({
+              query,
+              databaseType: database.type,
+              batchSize: 1,
+              offset: 0,
+            }).query;
 
     const probe = await this.executeQuery(database, probeQuery, {
       databaseId: options.databaseId,


### PR DESCRIPTION
## Summary

Parquet binding materialization against **BigQuery** connections fails with:

> `BigQuery batch queries must use native page tokens`

This is a misdiagnosis-prone bug: that error string is **Mako's own guard** in `prepareSqlBatchQuery` ([query-pagination.service.ts](api/src/services/query-pagination.service.ts)), *not* a BigQuery API error. There is **no batch-priority / job-demotion code** anywhere — the actual result fetch (`executeBigQueryStreamingQuery`) already uses native `pageToken`s correctly. The failure happens **before any rows are fetched**, in the schema-probe step.

### Root cause

The materializer's schema probe (`getStreamingQueryFields`) first runs a native BigQuery **dry run** (`getBigQueryQuerySchema`). When the dry run returns `success: true` but an **empty** `schema.fields` array, `getStreamingQueryFields` falls through and builds a fallback probe query with `prepareSqlBatchQuery(...)`, which **throws unconditionally for BigQuery** (LIMIT/OFFSET batching is unsupported there). In strict schema-probe mode (`buildQueryParquetFile`), that thrown error fails the whole build — so even a trivial 1-row binding fails, and parquet-backed apps serve stale artifacts while scheduled refreshes silently fail.

The generic result-fetch fallback is *not* reachable for BigQuery (the dispatch special-cases `bigquery` string queries into the native path), which is why the same SQL runs fine via the interactive query path — only the materializer's probe fallthrough trips the guard.

### Changes

1. **`getStreamingQueryFields`** ([database-connection.service.ts](api/src/services/database-connection.service.ts)) — for BigQuery, build the fallback probe with `applySqlRowLimit` (dialect-safe `SELECT * FROM (...) LIMIT 1`, already used elsewhere in this file for BigQuery) instead of `prepareSqlBatchQuery`. An empty dry-run schema now recovers by inferring fields from one native row rather than throwing.
2. **`materialize_binding` tool** ([server-app-tools.ts](api/src/agent-lib/tools/server-app-tools.ts)) — surface the underlying `parquetLastError` (`Materialization failed: <cause>`) instead of discarding it behind the generic `"Materialization failed. Check the binding query."`

### Testing

- `tsc --noEmit` clean for both edited files (remaining package `tsc` errors are pre-existing `*.test.ts` issues, untouched here).
- Not driven against the live customer BigQuery connections — that workspace's connector isn't authorized in this environment. The fix converts a guaranteed-throw fallthrough into a working native probe, so it is correct regardless of which specific query trips the empty-schema condition.

### Follow-up (optional, not in this PR)

Harden `getBigQueryQuerySchema` to treat an empty `schema.fields` as an explicit probe miss rather than a silent `success: true, columns: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)