### PR TITLE
docs: cover new skill tools (list_skills, get_relevant_skills) and build:ci

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ pnpm docs:dev              # Documentation site (Astro)
 
 ```bash
 pnpm build                 # Lint + build all packages in workspace
+pnpm build:ci              # Compile only, no lint (what CI runs before USE_PREBUILT=1 docker build)
 pnpm start                 # Start production server (serves both API and static frontend)
 pnpm app:build             # Build frontend only (outputs to app/dist)
 pnpm api:build             # Build backend only (TypeScript compilation)

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -76,12 +76,14 @@ This persists across all conversations. The more you use Mako, the less explaini
 
 Beyond the always-on self-directive, Mako supports **skills** — named, workspace-scoped playbooks that load only when their trigger fires. Good for per-country queries, multi-step procedures, or rare schema gotchas that shouldn't clutter the always-on memory.
 
-| Tool            | What It Does                                                |
-| --------------- | ----------------------------------------------------------- |
-| `save_skill`    | Create or overwrite a named playbook                        |
-| `delete_skill`  | Retract a skill that turned out to be wrong                 |
-| `load_skill`    | Explicitly load a skill mid-turn when the index hints at it |
-| `search_skills` | Free-text fallback when the auto-injected index misses      |
+| Tool                  | What It Does                                                |
+| --------------------- | ----------------------------------------------------------- |
+| `save_skill`          | Create or overwrite a named playbook                        |
+| `delete_skill`        | Retract a skill that turned out to be wrong                 |
+| `list_skills`         | Compact index of every skill — names and triggers, no bodies |
+| `get_relevant_skills` | Rank skills against a task and pull the top bodies on demand |
+| `load_skill`          | Explicitly load a skill mid-turn when the index hints at it |
+| `search_skills`       | Free-text fallback when the auto-injected index misses      |
 
 Every turn, Mako injects a compact index of every skill plus the top-3 auto-retrieved bodies (entity overlap 0.6 + semantic similarity 0.4). See [Skills](/skills/) for the full model, admin UI, and REST API.
 

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -252,7 +252,7 @@ Workspace skills — named playbooks the agent can author and load on demand. Se
 | `POST`   | `/api/workspaces/:wid/skills/:id/suppress`          | Toggle the `suppressed` flag                  |
 | `DELETE` | `/api/workspaces/:wid/skills/:id`                   | Permanently delete a skill                    |
 
-All endpoints require authentication and workspace access. Agent-side CRUD is available through the `save_skill`, `delete_skill`, `load_skill`, and `search_skills` tools — see [AI Agent](/ai-agent/#targeted-playbooks-skills).
+All endpoints require authentication and workspace access. Agent-side access is available through the `save_skill`, `delete_skill`, `list_skills`, `get_relevant_skills`, `load_skill`, and `search_skills` tools — see [AI Agent](/ai-agent/#targeted-playbooks-skills).
 
 ### Skill Response Shape
 

--- a/docs/src/content/docs/skills.md
+++ b/docs/src/content/docs/skills.md
@@ -22,12 +22,15 @@ Skills survive across sessions and are shared across all members of the workspac
 
 ## Agent Tools
 
-| Tool            | What It Does                                                                                  |
-| --------------- | --------------------------------------------------------------------------------------------- |
-| `save_skill`    | Upsert a skill by name. Reusing the same name overwrites the body (one undo step is retained) |
-| `delete_skill`  | Retract a skill permanently. Use when a skill turned out to be wrong                          |
-| `load_skill`    | Explicitly load a skill from the index mid-turn. Bumps `useCount` for retrieval reinforcement |
-| `search_skills` | Free-text search over all skills in the workspace. Fallback when the index doesn't surface it |
+| Tool                  | What It Does                                                                                  |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| `save_skill`          | Upsert a skill by name. Reusing the same name overwrites the body (one undo step is retained) |
+| `delete_skill`        | Retract a skill permanently. Use when a skill turned out to be wrong                          |
+| `list_skills`         | Compact index of every skill (workspace + system): name, trigger, scope — no bodies           |
+| `get_relevant_skills` | Rank skills against a task and return the top bodies — the same retrieval the auto-injection uses each turn, plus near-misses |
+| `load_skill`          | Explicitly load a skill from the index mid-turn. Bumps `useCount` for retrieval reinforcement |
+| `read_skill_resource` | Read a tier-3 `references/*.md` file that a system skill points to                            |
+| `search_skills`       | Free-text search over all skills in the workspace. Fallback when the index doesn't surface it |
 
 `save_skill` accepts:
 


### PR DESCRIPTION
Follow-up to #705 and #702.

**#705** (agent↔MCP tool bridge) added `list_skills` and `get_relevant_skills` to `CORE_ALWAYS_TOOL_NAMES` — they're in-product agent tools now, not MCP-only. The skill-tool tables still listed only the four older tools:

- `docs/src/content/docs/skills.md` — Agent Tools table: added `list_skills`, `get_relevant_skills`, and `read_skill_resource` (the latter existed since #465 but was never listed)
- `docs/src/content/docs/ai-agent.md` — same table in the Targeted Playbooks section
- `docs/src/content/docs/api-reference.md` — agent-side tools cross-link sentence

**#702** (build-once CI): `CLAUDE.md` now lists `pnpm build:ci` (compile only, no lint) next to `pnpm build`, matching the new `.cursor/rules/90-build-deploy.mdc` guidance.

Descriptions source-verified against `api/src/agent-lib/tools/skill-tools.ts`, `api/src/agents/modes/registry.ts`, and `package.json`.

Notes on the rest of the Jul 13 window (no doc action needed):
- #705's mcp-server.md changes shipped with the PR itself
- #701 (security headers/CORS) — internal hardening, no documented behavior contradicted
- #700 (BigQuery parquet regression fix) — restores documented behavior in apps.md, docs already correct
- #702/#703 — deployment.md updated in-PR; toolbar compaction is UI-only