### PR TITLE
fix(close): include API error details in sync logs

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { CloseConnector } from "./connector";
+import { CloseConnector, formatCloseApiErrorResponse } from "./connector";
 import { buildCloseSearchFieldSelection } from "./schema";
 
 function createConnector() {
@@ -9,6 +9,24 @@ function createConnector() {
     type: "close",
     config: { api_key: "test-key" },
   } as any);
+}
+
+function testCloseApiErrorResponseIsFormattedForLogs() {
+  const error = Object.assign(new Error("Request failed with status code 400"), {
+    isAxiosError: true,
+    response: {
+      status: 400,
+      data: {
+        error: "Invalid field selection",
+        "field-errors": { _fields: ["Unsupported field"] },
+      },
+    },
+  });
+
+  assert.equal(
+    formatCloseApiErrorResponse(error),
+    '{"error":"Invalid field selection","field-errors":{"_fields":["Unsupported field"]}}',
+  );
 }
 
 function testUserWebhookEventsAreSupported() {
@@ -590,6 +608,7 @@ async function testExistingWebhookFetchesDetailWhenListOmitsSignatureKey() {
 }
 
 async function main() {
+  testCloseApiErrorResponseIsFormattedForLogs();
   testUserWebhookEventsAreSupported();
   testUserWebhookEventsAreMapped();
   testUserWebhookPayloadIsExtractedForProcessing();

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -26,6 +26,26 @@ import { loggers } from "../../logging";
 
 const logger = loggers.connector("close");
 
+const MAX_CLOSE_ERROR_RESPONSE_LENGTH = 2_000;
+
+export function formatCloseApiErrorResponse(
+  error: unknown,
+): string | undefined {
+  if (!axios.isAxiosError(error) || error.response?.data === undefined) {
+    return undefined;
+  }
+
+  const responseData = error.response.data;
+  const serialized =
+    typeof responseData === "string"
+      ? responseData
+      : JSON.stringify(responseData);
+
+  return serialized.length > MAX_CLOSE_ERROR_RESPONSE_LENGTH
+    ? `${serialized.slice(0, MAX_CLOSE_ERROR_RESPONSE_LENGTH)}...`
+    : serialized;
+}
+
 // Close.com activity types
 const CLOSE_ACTIVITY_TYPES = [
   { name: "Email", label: "Email", description: "Email communications" },
@@ -696,6 +716,7 @@ export class CloseConnector extends BaseConnector {
                         error: axios.isAxiosError(error)
                           ? error.message
                           : String(error),
+                        responseBody: formatCloseApiErrorResponse(error),
                       });
                       return Promise.reject(error);
                     },


### PR DESCRIPTION
**Issue:**  
N/A — production Close sync investigation.

**Deploy preview:**

- N/A — server-side execution-log change only.

**Risk tier:** auto-labeled by the merge gate (`risk:low|medium|high`). Escalate if necessary; never remove a risk label.

# What does this change?

Adds Close API error bodies to sync execution logs so failed requests show the real provider error.

- Caps the saved body at 2,000 characters.
- Does not log request headers or credentials.

# Evidence

- **Non-regression** — [Focused Close connector test](https://github.com/Mavrick91/mako/blob/codex/diagnose-close-400/api/src/connectors/close/connector.test.ts#L14-L31); full API lint and build passed locally.
- **Conformance** — The test verifies a Close `400` body is formatted for the execution log. Live verification needs the production flow after merge.
- **Performance** — N/A — formatting runs only when a Close request fails.
- **Security** — Only the response body is logged and capped at 2,000 characters. Request headers and API credentials are not logged.

# How to test this PR?

1. Run a Close flow that returns an API error.
2. Open the failed execution logs.
3. Find `Close API request failed`.
4. Confirm `responseBody` contains Close's error details and no API key or request headers.

# What could go wrong?

- A provider error may contain field values; the body is capped at 2,000 characters.
- Revert this PR to remove the extra log field.
- No migration or data rollback is needed.
