### PR TITLE
feat(dbt): Preview model data via dbt show (#740)

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -1344,20 +1344,6 @@ export const createDbtServerTools = (
               : undefined,
             timeoutMs: 3 * 60 * 1000,
           });
-          // The preview table arrives as info-level log line(s) (ShowNode);
-          // anchor on the "Previewing" marker to drop dbt startup boilerplate,
-          // falling back to all info lines if the marker text ever changes.
-          const infoLines = result.logs
-            .filter(log => log.level === "info")
-            .map(log => log.line);
-          const markerIdx = infoLines.findIndex(line =>
-            line.includes("Previewing"),
-          );
-          const preview = (
-            markerIdx >= 0 ? infoLines.slice(markerIdx) : infoLines
-          )
-            .join("\n")
-            .slice(0, 8000);
           if (!result.success) {
             const reason = result.logs
               .filter(log => log.level === "error")
@@ -1369,9 +1355,29 @@ export const createDbtServerTools = (
               logs: summarizeLogs(result.logs),
             };
           }
+          // Prefer structured columns/rows from ShowNode; fall back to the
+          // scraped info-log text so older capture paths still return something.
+          if (result.preview) {
+            return {
+              success: true,
+              preview: result.preview,
+              logs: summarizeLogs(result.logs),
+            };
+          }
+          const infoLines = result.logs
+            .filter(log => log.level === "info")
+            .map(log => log.line);
+          const markerIdx = infoLines.findIndex(line =>
+            line.includes("Previewing"),
+          );
+          const previewText = (
+            markerIdx >= 0 ? infoLines.slice(markerIdx) : infoLines
+          )
+            .join("\n")
+            .slice(0, 8000);
           return {
             success: true,
-            preview,
+            preview: previewText,
             logs: summarizeLogs(result.logs),
           };
         } catch (error) {

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -31,6 +31,7 @@ import {
   dbtEngineEnabled,
   engineCompile,
   enginePrepare,
+  engineShow,
 } from "./dbt-engine.service";
 import {
   computePackagesHash,
@@ -39,6 +40,7 @@ import {
   savePackagesCache,
 } from "./dbt-cache.service";
 import { warmDirsEnabled, withProjectDir } from "./workspace-dir.service";
+import { parseShowPreview, type DbtShowPreview } from "./show-preview";
 import { loggers } from "../logging";
 
 const logger = loggers.app();
@@ -141,6 +143,8 @@ export interface AdhocDbtResult {
   logs: DbtLogLine[];
   stepResults: ReturnType<typeof parseStepResults>;
   compiledSql?: string;
+  /** Structured `dbt show` rows for the editor preview grid. */
+  preview?: DbtShowPreview;
   raw: DbtRunResult;
 }
 
@@ -224,23 +228,29 @@ export async function runAdhocDbtCommand(params: {
   const packagesHash = computePackagesHash(snapshot.files);
   const caches = await loadDbtCaches(cacheScope, packagesHash);
 
-  // Resident-engine fast path: an offline `compile --select X` reuses an
-  // in-memory manifest (no interpreter cold start, no full re-parse) — the
-  // dbt Cloud "develop" feel. Held under the same adhoc warm-dir mutex so the
-  // tree can't mutate while the engine reads it. Any failure (engine down,
-  // package macros needing an install we don't have, introspective compile)
-  // falls through to the subprocess path below, so correctness never depends
-  // on the engine. Gated by DBT_ENGINE_ENABLED (default off).
+  // Resident-engine fast path: offline `compile` / `show` reuse an in-memory
+  // manifest (no interpreter cold start, no full re-parse) — the dbt Cloud
+  // "develop" feel. Held under the same adhoc warm-dir mutex so the tree can't
+  // mutate while the engine reads it. Any failure falls through to the
+  // subprocess path below. Gated by DBT_ENGINE_ENABLED (default off).
+  const showSelect = extractShowSelect(parsed);
+  const engineSelect =
+    parsed.subcommand === "compile"
+      ? params.select
+      : parsed.subcommand === "show"
+        ? showSelect
+        : undefined;
   if (
     dbtEngineEnabled() &&
     warmDirsEnabled() &&
-    parsed.subcommand === "compile" &&
-    params.select &&
+    engineSelect &&
+    (parsed.subcommand === "compile" || parsed.subcommand === "show") &&
     // The engine path does not apply --vars; skip it when the environment sets
     // vars so var() resolves correctly via the subprocess path below.
     Object.keys(snapshot.environment.vars ?? {}).length === 0
   ) {
-    const select = params.select;
+    const select = engineSelect;
+    const showLimit = extractShowLimit(parsed) ?? 100;
     try {
       const engineResult = await withProjectDir(adhocDirScope, async dir => {
         const { keyfileEnv } = await materializeDbtProject(dir, {
@@ -264,17 +274,27 @@ export async function runAdhocDbtCommand(params: {
           projectDir: dir,
         };
         // Re-parse to pick up edits (cheap via partial parse), then reuse the
-        // warm manifest to compile.
+        // warm manifest to compile / show.
         await enginePrepare(ctx, session);
-        return engineCompile(ctx, session, select);
+        if (parsed.subcommand === "show") {
+          return {
+            kind: "show" as const,
+            result: await engineShow(ctx, session, {
+              select,
+              limit: showLimit,
+            }),
+          };
+        }
+        return {
+          kind: "compile" as const,
+          result: await engineCompile(ctx, session, select),
+        };
       });
-      if (engineResult.ok) {
-        // info (not debug) so the hit rate is visible in prod once the engine
-        // flag is on — pairs with the fallback warns below for a hit/miss rate.
+      if (engineResult.kind === "compile" && engineResult.result.ok) {
         logger.info("dbt engine compile hit", {
           event: "dbt_engine_compile",
           outcome: "hit",
-          elapsedMs: engineResult.elapsed_ms,
+          elapsedMs: engineResult.result.elapsed_ms,
           projectId: cacheScope.projectId,
           environment: cacheScope.environment,
         });
@@ -283,7 +303,7 @@ export async function runAdhocDbtCommand(params: {
           exitCode: 0,
           logs: [],
           stepResults: [],
-          compiledSql: engineResult.compiled_sql ?? undefined,
+          compiledSql: engineResult.result.compiled_sql ?? undefined,
           raw: {
             success: true,
             commandResults: [],
@@ -292,17 +312,51 @@ export async function runAdhocDbtCommand(params: {
           },
         };
       }
-      logger.warn("dbt engine compile failed; falling back to subprocess", {
-        event: "dbt_engine_compile",
-        outcome: "fallback",
-        reason: "compile_failed",
-        error: engineResult.error,
-        projectId: cacheScope.projectId,
-        environment: cacheScope.environment,
-      });
+      if (engineResult.kind === "show" && engineResult.result.ok) {
+        logger.info("dbt engine show hit", {
+          event: "dbt_engine_show",
+          outcome: "hit",
+          elapsedMs: engineResult.result.elapsed_ms,
+          projectId: cacheScope.projectId,
+          environment: cacheScope.environment,
+        });
+        return {
+          success: true,
+          exitCode: 0,
+          logs: [],
+          stepResults: [],
+          preview: {
+            columns: engineResult.result.columns,
+            rows: engineResult.result.rows,
+          },
+          raw: {
+            success: true,
+            commandResults: [],
+            artifacts: {},
+            projectChanged: false,
+          },
+        };
+      }
+      logger.warn(
+        `dbt engine ${parsed.subcommand} failed; falling back to subprocess`,
+        {
+          event:
+            parsed.subcommand === "show"
+              ? "dbt_engine_show"
+              : "dbt_engine_compile",
+          outcome: "fallback",
+          reason: `${parsed.subcommand}_failed`,
+          error: engineResult.result.error,
+          projectId: cacheScope.projectId,
+          environment: cacheScope.environment,
+        },
+      );
     } catch (error) {
       logger.warn("dbt engine unavailable; falling back to subprocess", {
-        event: "dbt_engine_compile",
+        event:
+          parsed.subcommand === "show"
+            ? "dbt_engine_show"
+            : "dbt_engine_compile",
         outcome: "fallback",
         reason: "unavailable",
         error: String(error),
@@ -377,12 +431,38 @@ export async function runAdhocDbtCommand(params: {
   }
 
   const commandResult = raw.commandResults[0];
+  const logs = commandResult?.logLines ?? [];
   return {
     success: raw.success,
     exitCode: commandResult?.exitCode ?? 1,
-    logs: commandResult?.logLines ?? [],
+    logs,
     stepResults: parseStepResults(commandResult?.runResults),
     compiledSql: findCompiledSql(raw, params.select),
+    preview: parsed.subcommand === "show" ? parseShowPreview(logs) : undefined,
     raw,
   };
+}
+
+/** `--select` / `-s` value from a validated `show` command, if present. */
+function extractShowSelect(parsed: ParsedDbtCommand): string | undefined {
+  if (parsed.subcommand !== "show") return undefined;
+  for (let i = 1; i < parsed.argv.length; i++) {
+    const token = parsed.argv[i];
+    if (token === "--select" || token === "-s") {
+      return parsed.argv[i + 1];
+    }
+  }
+  return undefined;
+}
+
+/** `--limit` value from a validated `show` command (default handled by caller). */
+function extractShowLimit(parsed: ParsedDbtCommand): number | undefined {
+  if (parsed.subcommand !== "show") return undefined;
+  for (let i = 1; i < parsed.argv.length; i++) {
+    if (parsed.argv[i] === "--limit") {
+      const n = Number(parsed.argv[i + 1]);
+      return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+    }
+  }
+  return undefined;
 }

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -23,6 +23,7 @@ import { loggers } from "../logging";
 import type { ParsedDbtCommand } from "./commands";
 import type { RenderedProfile } from "./adapter-map";
 import { buildDbtBaseEnv, resolveDbtBin } from "./dbt-bin";
+import { ensureShowJsonOutput } from "./show-preview";
 
 const logger = loggers.app();
 
@@ -30,6 +31,12 @@ export interface DbtLogLine {
   ts: Date;
   level: string;
   line: string;
+  /**
+   * Present on ShowNode events from `dbt show --output json` — the raw
+   * `data.preview` JSON string (array of row objects). Used to build a
+   * structured preview grid without scraping ASCII tables.
+   */
+  showPreview?: string;
 }
 
 export interface DbtRunRequest {
@@ -171,14 +178,27 @@ interface DbtJsonLogEvent {
   };
 }
 
+interface DbtJsonLogEventWithData extends DbtJsonLogEvent {
+  info?: DbtJsonLogEvent["info"] & { name?: string };
+  data?: { preview?: unknown };
+}
+
 function parseLogLine(raw: string): DbtLogLine {
   try {
-    const event = JSON.parse(raw) as DbtJsonLogEvent;
+    const event = JSON.parse(raw) as DbtJsonLogEventWithData;
     if (event.info) {
+      const preview = event.data?.preview;
+      const showPreview =
+        event.info.name === "ShowNode" && typeof preview === "string"
+          ? preview
+          : event.info.name === "ShowNode" && preview != null
+            ? JSON.stringify(preview)
+            : undefined;
       return {
         ts: event.info.ts ? new Date(event.info.ts) : new Date(),
         level: event.info.level ?? "info",
         line: event.info.msg ?? raw,
+        ...(showPreview !== undefined ? { showPreview } : {}),
       };
     }
   } catch {
@@ -787,9 +807,13 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
         vars: request.vars,
       });
 
+      // `dbt show` defaults to an ASCII table; force JSON so ShowNode carries
+      // a structured `data.preview` we can grid-render in the editor.
+      const commandArgv = ensureShowJsonOutput(command.argv);
+
       const args = [
         ...resolved.prefixArgs,
-        ...command.argv,
+        ...commandArgv,
         ...extraArgs,
         "--profiles-dir",
         projectDir,
@@ -830,7 +854,7 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       }
 
       commandResults.push({
-        command: command.argv.join(" "),
+        command: commandArgv.join(" "),
         exitCode,
         logLines,
         runResults,

--- a/api/src/dbt/show-preview.test.ts
+++ b/api/src/dbt/show-preview.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { ensureShowJsonOutput, parseShowPreview } from "./show-preview";
+
+describe("ensureShowJsonOutput", () => {
+  it("appends --output json for show when missing", () => {
+    expect(
+      ensureShowJsonOutput(["show", "--select", "stg_orders", "--limit", "5"]),
+    ).toEqual([
+      "show",
+      "--select",
+      "stg_orders",
+      "--limit",
+      "5",
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("leaves an explicit --output alone", () => {
+    expect(
+      ensureShowJsonOutput(["show", "--select", "x", "--output", "table"]),
+    ).toEqual(["show", "--select", "x", "--output", "table"]);
+  });
+
+  it("does not modify non-show commands", () => {
+    expect(ensureShowJsonOutput(["run", "--select", "x"])).toEqual([
+      "run",
+      "--select",
+      "x",
+    ]);
+  });
+});
+
+describe("parseShowPreview", () => {
+  it("parses ShowNode row objects into columns/rows", () => {
+    const preview = parseShowPreview([
+      {
+        line: "Previewing node 'model.jaffle.stg_orders'",
+        showPreview: JSON.stringify([
+          { id: 1, status: "completed" },
+          { id: 2, status: "pending", extra: true },
+        ]),
+      },
+    ]);
+    expect(preview).toEqual({
+      columns: ["id", "status", "extra"],
+      rows: [
+        [1, "completed", null],
+        [2, "pending", true],
+      ],
+    });
+  });
+
+  it("returns empty columns/rows for an empty preview array", () => {
+    expect(
+      parseShowPreview([{ line: "Previewing", showPreview: "[]" }]),
+    ).toEqual({ columns: [], rows: [] });
+  });
+
+  it("falls back to a JSON array embedded in the log line", () => {
+    expect(
+      parseShowPreview([
+        { line: `Previewing stg_orders [{"a": 1}, {"a": 2, "b": "z"}]` },
+      ]),
+    ).toEqual({
+      columns: ["a", "b"],
+      rows: [
+        [1, null],
+        [2, "z"],
+      ],
+    });
+  });
+
+  it("returns undefined when nothing parseable is present", () => {
+    expect(
+      parseShowPreview([{ line: "Running with dbt=1.9.0" }]),
+    ).toBeUndefined();
+  });
+});

--- a/api/src/dbt/show-preview.ts
+++ b/api/src/dbt/show-preview.ts
@@ -1,0 +1,114 @@
+/**
+ * Parse structured row previews from `dbt show` JSON log events.
+ *
+ * With `--log-format json --output json`, dbt emits a ShowNode event whose
+ * `data.preview` is a JSON array of row objects. We capture that on
+ * {@link DbtLogLine.showPreview} in the runner and turn it into columns/rows
+ * for the editor data grid.
+ */
+
+export interface DbtShowPreview {
+  columns: string[];
+  rows: unknown[][];
+}
+
+export interface ShowPreviewLogLine {
+  line: string;
+  /** Raw `data.preview` string from a ShowNode JSON log event. */
+  showPreview?: string;
+}
+
+/**
+ * Extract the first ShowNode preview payload from command logs.
+ * Prefer structured `showPreview`; fall back to scanning the human message
+ * for a JSON array (defensive — older capture paths).
+ */
+export function parseShowPreview(
+  logs: ShowPreviewLogLine[],
+): DbtShowPreview | undefined {
+  for (const log of logs) {
+    const raw = log.showPreview?.trim();
+    if (raw) {
+      const parsed = tryParsePreviewJson(raw);
+      if (parsed) return parsed;
+    }
+  }
+
+  // Fallback: agent-style scrape — look for a JSON array in info lines after
+  // the "Previewing" marker (rare; structured capture should win).
+  const infoLines = logs.map(log => log.line);
+  const markerIdx = infoLines.findIndex(line => line.includes("Previewing"));
+  const candidates =
+    markerIdx >= 0 ? infoLines.slice(markerIdx) : infoLines.slice(-5);
+  for (const line of candidates) {
+    const start = line.indexOf("[");
+    const end = line.lastIndexOf("]");
+    if (start < 0 || end <= start) continue;
+    const parsed = tryParsePreviewJson(line.slice(start, end + 1));
+    if (parsed) return parsed;
+  }
+
+  return undefined;
+}
+
+function tryParsePreviewJson(raw: string): DbtShowPreview | undefined {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!Array.isArray(value)) return undefined;
+
+    if (value.length === 0) {
+      return { columns: [], rows: [] };
+    }
+
+    // dbt --output json: array of row objects
+    if (isPlainObject(value[0])) {
+      const rows = value as Array<Record<string, unknown>>;
+      const columns: string[] = [];
+      const seen = new Set<string>();
+      for (const row of rows) {
+        for (const key of Object.keys(row)) {
+          if (!seen.has(key)) {
+            seen.add(key);
+            columns.push(key);
+          }
+        }
+      }
+      return {
+        columns,
+        rows: rows.map(row => columns.map(col => row[col] ?? null)),
+      };
+    }
+
+    // Already a matrix: [[...], [...]]
+    if (Array.isArray(value[0])) {
+      const matrix = value as unknown[][];
+      const width = Math.max(0, ...matrix.map(r => r.length));
+      const columns = Array.from({ length: width }, (_, i) => `col_${i}`);
+      return { columns, rows: matrix };
+    }
+
+    // Scalar list — single column
+    return {
+      columns: ["value"],
+      rows: value.map(v => [v]),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Ensure a validated `show` argv requests JSON row output so ShowNode carries
+ * a parseable `data.preview`. No-op when `--output` is already set.
+ */
+export function ensureShowJsonOutput(argv: string[]): string[] {
+  if (argv[0] !== "show") return argv;
+  for (let i = 1; i < argv.length; i++) {
+    if (argv[i] === "--output" || argv[i] === "-o") return argv;
+  }
+  return [...argv, "--output", "json"];
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -2418,6 +2418,7 @@ dbtRoutes.post(
           subcommand: validated.subcommand,
           stepResults: result.stepResults,
           logs: noteDeferUnavailable(result.logs, !!defer, deferState),
+          ...(result.preview ? { preview: result.preview } : {}),
         },
       });
     } catch (error) {

--- a/app/src/components/DbtFileEditor.test.tsx
+++ b/app/src/components/DbtFileEditor.test.tsx
@@ -44,13 +44,22 @@ vi.mock("./EntityBreadcrumbs", () => ({
 import DbtFileEditor from "./DbtFileEditor";
 import { useDbtStore } from "../store/dbtStore";
 
-const runCommandMock = vi.fn(async () => ({
-  ok: true,
-  exitCode: 0,
-  subcommand: "build",
-  stepResults: [],
-  logs: [],
-}));
+const runCommandMock = vi.fn(
+  async (): Promise<{
+    ok: boolean;
+    exitCode: number;
+    subcommand: string;
+    stepResults: never[];
+    logs: never[];
+    preview?: { columns: string[]; rows: unknown[][] };
+  }> => ({
+    ok: true,
+    exitCode: 0,
+    subcommand: "build",
+    stepResults: [],
+    logs: [],
+  }),
+);
 const compileModelMock = vi.fn(async () => ({
   ok: true,
   exitCode: 0,
@@ -150,6 +159,38 @@ describe("DbtFileEditor", () => {
         false,
       ),
     );
+  });
+
+  it("Preview runs dbt show --select <model> --limit 100", async () => {
+    const user = userEvent.setup();
+    runCommandMock.mockResolvedValueOnce({
+      ok: true,
+      exitCode: 0,
+      subcommand: "show",
+      stepResults: [],
+      logs: [],
+      preview: { columns: ["id"], rows: [[1]] },
+    });
+    render(<DbtFileEditor tabId="t1" projectId="p1" path="models/foo.sql" />);
+
+    const previewButton = await screen.findByRole("button", {
+      name: /preview this model/i,
+    });
+    await waitFor(() =>
+      expect((previewButton as HTMLButtonElement).disabled).toBe(false),
+    );
+    await user.click(previewButton);
+
+    await waitFor(() =>
+      expect(runCommandMock).toHaveBeenCalledWith(
+        "ws1",
+        "p1",
+        "show --select foo --limit 100",
+        "dev",
+        false,
+      ),
+    );
+    expect(await screen.findByText(/Preview · 1 row/i)).toBeTruthy();
   });
 
   it("renders a markdown preview by default for .md files and toggles to the editor", async () => {

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -39,6 +39,7 @@ import {
   CheckCircle2 as OkIcon,
   ChevronDown as CollapseIcon,
   ChevronUp as ExpandIcon,
+  Eye as PreviewIcon,
   Hammer as CompileIcon,
   Play as RunIcon,
   Terminal as CommandIcon,
@@ -53,6 +54,7 @@ import {
   type DbtCompileResult,
   type DbtCommandRunResult,
   type DbtRunLogLine,
+  type DbtShowPreview,
 } from "../store/dbtStore";
 import {
   registerDbtJinjaLanguage,
@@ -179,6 +181,76 @@ function StepResultsTable({
           </Box>
         ))}
       </tbody>
+    </Box>
+  );
+}
+
+/** Compact data grid for `dbt show` preview rows (Studio-style Preview). */
+function PreviewResultsTable({ preview }: { preview: DbtShowPreview }) {
+  const { columns, rows } = preview;
+  if (columns.length === 0 && rows.length === 0) {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        Preview returned 0 rows.
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ overflow: "auto" }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mb: 0.5 }}
+      >
+        Preview · {rows.length} row{rows.length === 1 ? "" : "s"}
+      </Typography>
+      <Box
+        component="table"
+        sx={{
+          width: "100%",
+          fontSize: "0.75rem",
+          borderCollapse: "collapse",
+          whiteSpace: "nowrap",
+          "& td, & th": {
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            p: 0.5,
+            textAlign: "left",
+            maxWidth: 280,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          },
+          "& th": { fontWeight: 600, color: "text.secondary" },
+        }}
+      >
+        <thead>
+          <tr>
+            {columns.map(col => (
+              <th key={col}>{col}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri}>
+              {columns.map((col, ci) => {
+                const value = row[ci];
+                const text =
+                  value === null || value === undefined
+                    ? ""
+                    : typeof value === "object"
+                      ? JSON.stringify(value)
+                      : String(value);
+                return (
+                  <td key={col} title={text}>
+                    {text}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </Box>
     </Box>
   );
 }
@@ -495,11 +567,10 @@ export default function DbtFileEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, projectId, environment, modelName, file?.loaded]);
 
-  // Build/Run/Test the active model with dbt graph operators. `scope` maps to
-  // the `+` selectors: "" = node only, "down" = node+ (children), "up" =
-  // +node (parents), "both" = +node+ (both directions).
+  // Build/Run/Test/Preview the active model. For build/run/test, `scope` maps
+  // to dbt `+` selectors; Preview (`show`) always targets the single model.
   const runNodeSelection = useCallback(
-    async (verb: DbtRunVerb, scope: DbtSelectScope) => {
+    async (verb: DbtRunVerb, scope: DbtSelectScope = "") => {
       if (!workspaceId || !modelName) return;
       const cmd = buildDbtNodeCommand(verb, modelName, scope, { fullRefresh });
       if (
@@ -521,7 +592,11 @@ export default function DbtFileEditor({
         defer,
       );
       setCommandResult(res);
-      if (res && res.stepResults.length === 0) setPanelTab("commands");
+      // Preview success lands on the data grid; empty step summaries (and
+      // failed previews) fall back to the Commands log tab.
+      if (res && !res.preview && res.stepResults.length === 0) {
+        setPanelTab("commands");
+      }
       manualBusyRef.current = false;
       setBusy(null);
     },
@@ -588,6 +663,7 @@ export default function DbtFileEditor({
   );
 
   const resultSteps = commandResult?.stepResults;
+  const previewResult = commandResult?.preview;
   const commandLogs = commandResult?.logs ?? compileResult?.logs ?? [];
 
   // Status pill mirrors dbt Studio: it reflects the live compile state of the
@@ -692,6 +768,19 @@ export default function DbtFileEditor({
               </IconButton>
             </span>
           </Tooltip>
+          <Tooltip title="Preview this model's data (dbt show — no materialization)">
+            <span>
+              <IconButton
+                size="small"
+                color="primary"
+                aria-label="Preview this model"
+                disabled={busy !== null}
+                onClick={() => void runNodeSelection("show")}
+              >
+                <PreviewIcon size={15} />
+              </IconButton>
+            </span>
+          </Tooltip>
           <Tooltip title="Build / Run / Test this model (with upstream/downstream selectors)">
             <span>
               <IconButton
@@ -779,11 +868,13 @@ export default function DbtFileEditor({
 
       {panelTab === "results" && (
         <Box sx={{ p: 1 }}>
-          {!resultSteps || resultSteps.length === 0 ? (
+          {previewResult ? (
+            <PreviewResultsTable preview={previewResult} />
+          ) : !resultSteps || resultSteps.length === 0 ? (
             <Typography variant="caption" color="text.secondary">
               {busy === "run" || busy === "command"
                 ? "Running…"
-                : "Run a model or command to see node results."}
+                : "Preview or run a model to see results."}
             </Typography>
           ) : (
             <StepResultsTable steps={resultSteps} />

--- a/app/src/lib/dbt-node-selection.test.ts
+++ b/app/src/lib/dbt-node-selection.test.ts
@@ -44,4 +44,16 @@ describe("buildDbtNodeCommand", () => {
       buildDbtNodeCommand("build", "fct_orders", "", { fullRefresh: false }),
     ).toBe("build --select fct_orders");
   });
+
+  it("builds show with --limit and ignores graph scope / full-refresh", () => {
+    expect(buildDbtNodeCommand("show", "stg_orders", "both")).toBe(
+      "show --select stg_orders --limit 100",
+    );
+    expect(
+      buildDbtNodeCommand("show", "stg_orders", "down", {
+        fullRefresh: true,
+        limit: 25,
+      }),
+    ).toBe("show --select stg_orders --limit 25");
+  });
 });

--- a/app/src/lib/dbt-node-selection.ts
+++ b/app/src/lib/dbt-node-selection.ts
@@ -1,6 +1,6 @@
 /**
  * dbt node-selection helpers — build `--select` strings with graph operators
- * for the Build/Run/Test menu. Pure + unit-tested.
+ * for the Build/Run/Test/Preview menu. Pure + unit-tested.
  *
  * Scope maps to dbt's `+` operators:
  *   ""     → node only          (model)
@@ -11,8 +11,11 @@
  * @see https://docs.getdbt.com/reference/node-selection/graph-operators
  */
 
-export type DbtRunVerb = "build" | "run" | "test";
+export type DbtRunVerb = "build" | "run" | "test" | "show";
 export type DbtSelectScope = "" | "down" | "up" | "both";
+
+/** Default row cap for Preview (`dbt show --limit`). */
+export const DBT_SHOW_DEFAULT_LIMIT = 100;
 
 export function buildDbtSelectArg(
   modelName: string,
@@ -28,8 +31,13 @@ export function buildDbtNodeCommand(
   verb: DbtRunVerb,
   modelName: string,
   scope: DbtSelectScope,
-  options?: { fullRefresh?: boolean },
+  options?: { fullRefresh?: boolean; limit?: number },
 ): string {
+  // Preview is always the single node — graph operators don't apply to show.
+  if (verb === "show") {
+    const limit = options?.limit ?? DBT_SHOW_DEFAULT_LIMIT;
+    return `show --select ${modelName} --limit ${limit}`;
+  }
   // --full-refresh only applies to commands that (re)build tables; `test`
   // rejects the flag.
   const fullRefresh =

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -295,12 +295,19 @@ export interface DbtCompileResult {
   logs: DbtRunLogLine[];
 }
 
+/** Structured `dbt show` payload for the editor preview grid. */
+export interface DbtShowPreview {
+  columns: string[];
+  rows: unknown[][];
+}
+
 export interface DbtCommandRunResult {
   ok: boolean;
   exitCode: number;
   subcommand: string;
   stepResults: DbtStepResult[];
   logs: DbtRunLogLine[];
+  preview?: DbtShowPreview;
 }
 
 export interface DbtLineageNode {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Studio-style **Preview** action to the Transforms file editor so users can see a model's actual rows — not just the Run/Build execution summary.

Closes #740.

## What changed

- **Editor:** Preview button (eye icon) next to Build/Run/Test runs `dbt show --select <model> --limit 100` and renders a data grid in the Results panel.
- **API / runner:** `dbt show` forces `--output json`; ShowNode `data.preview` is captured on log lines and parsed into `{ columns, rows }`. Returned on `POST .../command` as `result.preview`.
- **Engine:** When `DBT_ENGINE_ENABLED`, `show` can hit the warm `engineShow` path (same pattern as compile).
- **Agent:** `dbt_show` prefers the structured preview payload, with the previous text scrape as fallback.

## Test plan

- [x] `pnpm --filter api run test:dbt` (includes `show-preview.test.ts`)
- [x] `pnpm --filter app run test:unit` (includes Preview button + node-selection tests)
- [x] `pnpm --filter api run lint`
- [x] `pnpm --filter app run typecheck && lint`
- [ ] Manual: open a model → Preview → rows appear in Results without materializing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

