### PR TITLE
feat(dbt): default defer on for personal/dev + Build changed

### DIFF
--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -45,7 +45,11 @@ import {
   type DbtRunLogLine,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
-import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
+import {
+  resolveDevEnvName,
+  resolveProdLikeEnvName,
+  shouldDeferByDefault,
+} from "../lib/dbt-env";
 import EntityLoadErrorState, {
   EntityLoadingState,
 } from "./EntityLoadErrorState";
@@ -158,6 +162,13 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
       );
     }
   }, [project, environment, user?.id]);
+
+  // Match the editor/agent: defer on by default for non-prod when a prod
+  // manifest exists. Re-applies when env or manifest availability changes.
+  useEffect(() => {
+    if (!project || !environment) return;
+    setDefer(shouldDeferByDefault(project, environment));
+  }, [project, environment]);
 
   // Picking an environment is a per-user setting shared with the editor and
   // agent builds — persist it.
@@ -321,9 +332,14 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
             />
             <Tooltip
               title={
-                `Resolve unselected refs against the last ` +
-                `"${resolveProdLikeEnvName(project) ?? "prod"}" build ` +
-                "(dbt --defer). Change the defer target in Project settings."
+                project.lastProdManifestKey
+                  ? `Resolve unselected refs against the last ` +
+                    `"${resolveProdLikeEnvName(project) ?? "prod"}" build ` +
+                    "(dbt --defer). On by default for non-prod environments. " +
+                    "Change the defer target in Project settings."
+                  : `No "${resolveProdLikeEnvName(project) ?? "prod"}" ` +
+                    "manifest yet — run a job against that environment once " +
+                    "to enable defer."
               }
             >
               <FormControlLabel
@@ -331,6 +347,7 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
                   <Checkbox
                     size="small"
                     checked={defer}
+                    disabled={!project.lastProdManifestKey}
                     onChange={e => setDefer(e.target.checked)}
                   />
                 }

--- a/app/src/components/DbtFileEditor.test.tsx
+++ b/app/src/components/DbtFileEditor.test.tsx
@@ -152,6 +152,54 @@ describe("DbtFileEditor", () => {
     );
   });
 
+  it("defaults defer on for non-prod when a prod manifest exists and offers Build changed", async () => {
+    const user = userEvent.setup();
+    useDbtStore.setState({
+      projects: [
+        {
+          _id: "p1",
+          name: "P",
+          dbtVersion: "1.9",
+          environments: [{ name: "dev" }, { name: "prod" }],
+          defaultEnvironment: "dev",
+          lastProdManifestKey: "artifacts/prod-manifest",
+        },
+      ] as never,
+    });
+
+    render(<DbtFileEditor tabId="t1" projectId="p1" path="models/foo.sql" />);
+
+    const deferCheckbox = await screen.findByRole("checkbox", {
+      name: /defer to prod/i,
+    });
+    await waitFor(() =>
+      expect((deferCheckbox as HTMLInputElement).checked).toBe(true),
+    );
+
+    const runButton = await screen.findByRole("button", {
+      name: /build, run, or test this model/i,
+    });
+    await waitFor(() =>
+      expect((runButton as HTMLButtonElement).disabled).toBe(false),
+    );
+    await user.click(runButton);
+
+    const buildChanged = await screen.findByRole("menuitem", {
+      name: /build changed/i,
+    });
+    await user.click(buildChanged);
+
+    await waitFor(() =>
+      expect(runCommandMock).toHaveBeenCalledWith(
+        "ws1",
+        "p1",
+        "build --select state:modified+",
+        "dev",
+        true,
+      ),
+    );
+  });
+
   it("renders a markdown preview by default for .md files and toggles to the editor", async () => {
     const user = userEvent.setup();
     useDbtStore.setState({

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -61,6 +61,7 @@ import {
 import { dbtVersionLabel } from "../lib/dbt-versions";
 import {
   buildDbtNodeCommand,
+  DBT_BUILD_CHANGED_COMMAND,
   type DbtRunVerb,
   type DbtSelectScope,
 } from "../lib/dbt-node-selection";
@@ -72,7 +73,11 @@ import {
   modelNamesFromPaths,
   type Problem,
 } from "../lib/dbt-editor-logic";
-import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
+import {
+  resolveDevEnvName,
+  resolveProdLikeEnvName,
+  shouldDeferByDefault,
+} from "../lib/dbt-env";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 import EntityLoadErrorState, {
@@ -372,6 +377,14 @@ export default function DbtFileEditor({
     }
   }, [project, environment, user?.id]);
 
+  // Align with the agent: defer to the last prod manifest by default when
+  // iterating in a non-prod (personal/dev) environment. Re-applies when the
+  // env or prod-manifest availability changes; the user can still uncheck.
+  useEffect(() => {
+    if (!project || !environment) return;
+    setDefer(shouldDeferByDefault(project, environment));
+  }, [project, environment]);
+
   // Picking an environment is a per-user setting: persist it so the console,
   // the agent's builds, and other windows follow the same choice.
   const handleEnvironmentChange = useCallback(
@@ -569,6 +582,37 @@ export default function DbtFileEditor({
     runCommand,
     saveNow,
   ]);
+
+  /** Slim-CI style: build only models changed vs the last prod manifest. */
+  const runBuildChanged = useCallback(async () => {
+    if (!workspaceId) return;
+    const cmd = fullRefresh
+      ? `${DBT_BUILD_CHANGED_COMMAND} --full-refresh`
+      : DBT_BUILD_CHANGED_COMMAND;
+    if (
+      environment === "prod" &&
+      !window.confirm(`Run "dbt ${cmd}" against the prod environment?`)
+    ) {
+      return;
+    }
+    saveNow();
+    manualBusyRef.current = true;
+    setBusy("command");
+    setPanelOpen(true);
+    setPanelTab("results");
+    const res = await runCommand(
+      workspaceId,
+      projectId,
+      cmd,
+      environment || undefined,
+      // state:modified+ only makes sense with a prod state dir.
+      true,
+    );
+    setCommandResult(res);
+    if (res && res.stepResults.length === 0) setPanelTab("commands");
+    manualBusyRef.current = false;
+    setBusy(null);
+  }, [workspaceId, projectId, environment, fullRefresh, runCommand, saveNow]);
 
   const errorCount = useMemo(
     () => problems?.filter(p => p.severity === "error").length ?? 0,
@@ -917,8 +961,12 @@ export default function DbtFileEditor({
       </Tooltip>
       <Tooltip
         title={
-          `Resolve unselected refs against the last "${prodEnvName}" build ` +
-          "(dbt --defer). Change the defer target in Project settings."
+          project?.lastProdManifestKey
+            ? `Resolve unselected refs against the last "${prodEnvName}" build ` +
+              "(dbt --defer). On by default for non-prod environments. " +
+              "Change the defer target in Project settings."
+            : `No "${prodEnvName}" manifest yet — run a job against that ` +
+              "environment once to enable defer."
         }
       >
         <FormControlLabel
@@ -926,7 +974,11 @@ export default function DbtFileEditor({
             <Checkbox
               size="small"
               checked={defer}
+              disabled={!project?.lastProdManifestKey}
               onChange={e => setDefer(e.target.checked)}
+              inputProps={{
+                "aria-label": `Defer to ${prodEnvName}`,
+              }}
               sx={{ p: 0.25 }}
             />
           }
@@ -1044,6 +1096,23 @@ export default function DbtFileEditor({
       anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
       transformOrigin={{ vertical: "top", horizontal: "left" }}
     >
+      {project?.lastProdManifestKey ? (
+        <>
+          <ListSubheader sx={{ lineHeight: 2, fontSize: "0.7rem" }}>
+            Changed vs {prodEnvName}
+          </ListSubheader>
+          <MenuItem
+            dense
+            onClick={() => {
+              setRunMenuAnchor(null);
+              void runBuildChanged();
+            }}
+          >
+            Build changed (state:modified+)
+          </MenuItem>
+          <Divider />
+        </>
+      ) : null}
       {RUN_VERBS.flatMap(({ verb, label }, vi) => [
         vi > 0 ? <Divider key={`${verb}-div`} /> : null,
         <ListSubheader

--- a/app/src/lib/dbt-env.test.ts
+++ b/app/src/lib/dbt-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveProdLikeEnvName } from "./dbt-env";
+import { resolveProdLikeEnvName, shouldDeferByDefault } from "./dbt-env";
 
 const envs = (...names: string[]) => names.map(name => ({ name }));
 
@@ -31,5 +31,30 @@ describe("resolveProdLikeEnvName", () => {
         defaultEnvironment: "main",
       }),
     ).toBe("main");
+  });
+});
+
+describe("shouldDeferByDefault", () => {
+  const project = {
+    environments: envs("dev", "prod"),
+    defaultEnvironment: "dev",
+    lastProdManifestKey: "artifacts/prod-manifest",
+  };
+
+  it("defers for non-prod targets when a prod manifest exists", () => {
+    expect(shouldDeferByDefault(project, "dev")).toBe(true);
+  });
+
+  it("does not defer against the prod-like environment", () => {
+    expect(shouldDeferByDefault(project, "prod")).toBe(false);
+  });
+
+  it("does not defer when no prod manifest has been stored yet", () => {
+    expect(
+      shouldDeferByDefault(
+        { ...project, lastProdManifestKey: undefined },
+        "dev",
+      ),
+    ).toBe(false);
   });
 });

--- a/app/src/lib/dbt-env.ts
+++ b/app/src/lib/dbt-env.ts
@@ -3,6 +3,14 @@
  * prod-like environment resolution.
  */
 
+/** Fields needed to decide whether ad-hoc builds should `--defer` to prod. */
+export type DbtDeferProject = {
+  environments?: Array<{ name: string }>;
+  defaultEnvironment?: string;
+  prodEnvironment?: string;
+  lastProdManifestKey?: string;
+};
+
 /**
  * The environment treated as "production" (the defer target). Mirrors the
  * server's resolveProdLikeEnvironmentName: an explicit `prodEnvironment`
@@ -52,6 +60,20 @@ export function resolveDevEnvName(
     ? environments.find(env => env.ownerUserId === userId)
     : undefined;
   return personal?.name ?? project.defaultEnvironment;
+}
+
+/**
+ * Whether ad-hoc editor/console/agent builds should default to
+ * `--defer --state <last prod manifest>`. Mirrors the server agent helper
+ * `shouldDeferByDefault`: defer when a prod manifest exists and the target
+ * environment is not the prod-like one (personal/dev iteration).
+ */
+export function shouldDeferByDefault(
+  project: DbtDeferProject,
+  environmentName: string | undefined,
+): boolean {
+  if (!environmentName || !project.lastProdManifestKey) return false;
+  return environmentName !== resolveProdLikeEnvName(project);
 }
 
 /**

--- a/app/src/lib/dbt-node-selection.test.ts
+++ b/app/src/lib/dbt-node-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDbtNodeCommand,
   buildDbtSelectArg,
+  DBT_BUILD_CHANGED_COMMAND,
   type DbtSelectScope,
 } from "./dbt-node-selection";
 
@@ -43,5 +44,11 @@ describe("buildDbtNodeCommand", () => {
     expect(
       buildDbtNodeCommand("build", "fct_orders", "", { fullRefresh: false }),
     ).toBe("build --select fct_orders");
+  });
+});
+
+describe("DBT_BUILD_CHANGED_COMMAND", () => {
+  it("selects state:modified+ for Slim-CI style local builds", () => {
+    expect(DBT_BUILD_CHANGED_COMMAND).toBe("build --select state:modified+");
   });
 });

--- a/app/src/lib/dbt-node-selection.ts
+++ b/app/src/lib/dbt-node-selection.ts
@@ -36,3 +36,9 @@ export function buildDbtNodeCommand(
     options?.fullRefresh && verb !== "test" ? " --full-refresh" : "";
   return `${verb} --select ${buildDbtSelectArg(modelName, scope)}${fullRefresh}`;
 }
+
+/**
+ * Slim-CI style selection: only models changed vs the defer-state prod
+ * manifest (plus their downstream). Used by the editor "Build changed" action.
+ */
+export const DBT_BUILD_CHANGED_COMMAND = "build --select state:modified+";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes personal/dev iteration match the agent’s defer behavior, and adds a Slim-CI-style **Build changed** action in the editor.

## What changed

- **`shouldDeferByDefault`** (`app/src/lib/dbt-env.ts`) — same rule as the agent: defer when a prod manifest exists and the target env is not prod-like.
- **Editor + console** — Defer checkbox turns **on by default** for non-prod; disabled (with tooltip) until a prod manifest exists.
- **Run menu** — when a prod manifest exists, **Build changed (`state:modified+`)** runs `build --select state:modified+` with defer forced on (optional `--full-refresh` from the existing checkbox).

No API changes — runner/jobs/Slim CI already support `--defer --state` and `state:modified+`.

## Test plan

- [x] `pnpm --filter app run typecheck && lint`
- [x] Unit tests for `shouldDeferByDefault`, Build changed command, editor defer default + menu action
- [ ] Manual: after a prod job succeeds, open a model in `dev` → Defer checked; Run menu → Build changed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

