### PR TITLE
feat(dbt): inferred column-level lineage in the DAG view

### DIFF
--- a/api/src/dbt/column-lineage.test.ts
+++ b/api/src/dbt/column-lineage.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildNameMatchColumnEdges,
+  mergeCatalogColumns,
+} from "./column-lineage";
+
+describe("mergeCatalogColumns", () => {
+  it("fills missing types from the catalog and appends undocumented columns", () => {
+    expect(
+      mergeCatalogColumns(
+        [
+          { name: "id", description: "pk" },
+          { name: "status", type: "text" },
+        ],
+        {
+          columns: {
+            id: { type: "integer" },
+            created_at: { type: "timestamp", comment: "when" },
+          },
+        },
+      ),
+    ).toEqual([
+      { name: "id", description: "pk", type: "integer" },
+      { name: "status", type: "text" },
+      { name: "created_at", type: "timestamp", description: "when" },
+    ]);
+  });
+});
+
+describe("buildNameMatchColumnEdges", () => {
+  it("matches columns case-insensitively across table edges", () => {
+    const edges = buildNameMatchColumnEdges(
+      [
+        {
+          id: "source.raw.orders",
+          columns: [{ name: "ID" }, { name: "amount" }],
+        },
+        {
+          id: "model.jaffle.stg_orders",
+          columns: [{ name: "id" }, { name: "status" }],
+        },
+        {
+          id: "model.jaffle.fct_orders",
+          columns: [{ name: "id" }, { name: "status" }],
+        },
+      ],
+      [
+        { source: "source.raw.orders", target: "model.jaffle.stg_orders" },
+        {
+          source: "model.jaffle.stg_orders",
+          target: "model.jaffle.fct_orders",
+        },
+      ],
+    );
+    expect(edges).toEqual([
+      {
+        sourceNodeId: "source.raw.orders",
+        sourceColumn: "ID",
+        targetNodeId: "model.jaffle.stg_orders",
+        targetColumn: "id",
+        confidence: "name_match",
+      },
+      {
+        sourceNodeId: "model.jaffle.stg_orders",
+        sourceColumn: "id",
+        targetNodeId: "model.jaffle.fct_orders",
+        targetColumn: "id",
+        confidence: "name_match",
+      },
+      {
+        sourceNodeId: "model.jaffle.stg_orders",
+        sourceColumn: "status",
+        targetNodeId: "model.jaffle.fct_orders",
+        targetColumn: "status",
+        confidence: "name_match",
+      },
+    ]);
+  });
+
+  it("returns no edges when columns do not overlap", () => {
+    expect(
+      buildNameMatchColumnEdges(
+        [
+          { id: "a", columns: [{ name: "x" }] },
+          { id: "b", columns: [{ name: "y" }] },
+        ],
+        [{ source: "a", target: "b" }],
+      ),
+    ).toEqual([]);
+  });
+});

--- a/api/src/dbt/column-lineage.ts
+++ b/api/src/dbt/column-lineage.ts
@@ -1,0 +1,106 @@
+/**
+ * Inferred column-level lineage for the Transforms DAG.
+ *
+ * dbt Core manifests do not ship true column→column edges. v1 infers edges by
+ * matching column names (case-insensitive) across each table-level parent_map
+ * edge. Callers should label these as inferred, not guaranteed.
+ */
+
+export interface LineageColumn {
+  name: string;
+  type?: string;
+  description?: string;
+}
+
+export interface LineageTableEdge {
+  source: string;
+  target: string;
+}
+
+export interface ColumnLineageEdge {
+  sourceNodeId: string;
+  sourceColumn: string;
+  targetNodeId: string;
+  targetColumn: string;
+  confidence: "name_match";
+}
+
+export interface CatalogNodeColumns {
+  columns?: Record<string, { type?: string; comment?: string | null }>;
+}
+
+/**
+ * Merge warehouse types from `catalog.json` into YAML/docs columns. Catalog-
+ * only columns (undocumented in schema.yml) are appended so name-match lineage
+ * can still connect them.
+ */
+export function mergeCatalogColumns(
+  columns: LineageColumn[],
+  catalogEntry: CatalogNodeColumns | undefined,
+): LineageColumn[] {
+  if (!catalogEntry?.columns) return columns;
+  const byName = new Map(
+    columns.map(col => [col.name.toLowerCase(), { ...col }]),
+  );
+  for (const [rawName, meta] of Object.entries(catalogEntry.columns)) {
+    const key = rawName.toLowerCase();
+    const existing = byName.get(key);
+    if (existing) {
+      if (!existing.type && meta.type) existing.type = meta.type;
+      if (!existing.description && meta.comment) {
+        existing.description = meta.comment;
+      }
+    } else {
+      byName.set(key, {
+        name: rawName,
+        type: meta.type || undefined,
+        description: meta.comment || undefined,
+      });
+    }
+  }
+  return Array.from(byName.values());
+}
+
+/**
+ * For each table edge parent→child, emit a column edge for every shared
+ * column name (case-insensitive). Uses the child's casing for the target
+ * and the parent's casing for the source.
+ */
+export function buildNameMatchColumnEdges(
+  nodes: Array<{ id: string; columns?: LineageColumn[] }>,
+  tableEdges: LineageTableEdge[],
+): ColumnLineageEdge[] {
+  const columnsByNode = new Map<string, Map<string, string>>();
+  for (const node of nodes) {
+    const map = new Map<string, string>();
+    for (const col of node.columns ?? []) {
+      if (!col.name) continue;
+      const key = col.name.toLowerCase();
+      if (!map.has(key)) map.set(key, col.name);
+    }
+    columnsByNode.set(node.id, map);
+  }
+
+  const edges: ColumnLineageEdge[] = [];
+  const seen = new Set<string>();
+  for (const edge of tableEdges) {
+    const parentCols = columnsByNode.get(edge.source);
+    const childCols = columnsByNode.get(edge.target);
+    if (!parentCols || !childCols) continue;
+    for (const [key, parentName] of parentCols) {
+      const childName = childCols.get(key);
+      if (!childName) continue;
+      const id = `${edge.source}.${key}->${edge.target}.${key}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      edges.push({
+        sourceNodeId: edge.source,
+        sourceColumn: parentName,
+        targetNodeId: edge.target,
+        targetColumn: childName,
+        confidence: "name_match",
+      });
+    }
+  }
+  return edges;
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -108,6 +108,11 @@ import {
 import { validateScheduledConsoleSchedule } from "../services/scheduled-query-schedule.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 import {
+  buildNameMatchColumnEdges,
+  mergeCatalogColumns,
+  type CatalogNodeColumns,
+} from "../dbt/column-lineage";
+import {
   createVersion,
   getLatestVersionNumber,
   getUserDisplayName,
@@ -2477,11 +2482,29 @@ function mapColumns(
   columns: Record<string, ManifestColumn> | undefined,
 ): Array<{ name: string; type?: string; description?: string }> {
   if (!columns) return [];
-  return Object.values(columns).map(col => ({
-    name: col.name ?? "",
-    type: col.data_type ?? undefined,
-    description: col.description || undefined,
-  }));
+  return Object.values(columns)
+    .map(col => ({
+      name: col.name ?? "",
+      type: col.data_type ?? undefined,
+      description: col.description || undefined,
+    }))
+    .filter(col => col.name);
+}
+
+async function readArtifactJson<T>(key: string | undefined): Promise<T | null> {
+  if (!key) return null;
+  const store = getDashboardArtifactStore();
+  const stream = await store.openReadStream(key);
+  if (!stream) return null;
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as T;
+  } catch {
+    return null;
+  }
 }
 
 dbtRoutes.get(
@@ -2503,21 +2526,27 @@ dbtRoutes.get(
       if (!run?.artifactKeys?.manifest) {
         return c.json({
           success: true,
-          lineage: { nodes: [], edges: [], generatedAt: null },
+          lineage: {
+            nodes: [],
+            edges: [],
+            columnEdges: [],
+            generatedAt: null,
+          },
         });
       }
-      const store = getDashboardArtifactStore();
-      const stream = await store.openReadStream(run.artifactKeys.manifest);
-      if (!stream) {
+      const manifest = await readArtifactJson<ManifestForLineage>(
+        run.artifactKeys.manifest,
+      );
+      if (!manifest) {
         return c.json({ success: false, error: "Manifest not found" }, 404);
       }
-      const chunks: Buffer[] = [];
-      for await (const chunk of stream) {
-        chunks.push(Buffer.from(chunk as Buffer));
-      }
-      const manifest = JSON.parse(
-        Buffer.concat(chunks).toString("utf8"),
-      ) as ManifestForLineage;
+
+      // Optional catalog.json from the same run — warehouse types + columns
+      // that were never documented in schema.yml.
+      const catalog = await readArtifactJson<{
+        nodes?: Record<string, CatalogNodeColumns>;
+        sources?: Record<string, CatalogNodeColumns>;
+      }>(run.artifactKeys.catalog ?? undefined);
 
       const statusByUniqueId = new Map(
         (run.stepResults ?? []).map(step => [step.uniqueId, step.status]),
@@ -2550,7 +2579,10 @@ dbtRoutes.get(
           description: node.description || undefined,
           materialized: node.config?.materialized,
           tags: node.tags?.length ? node.tags : undefined,
-          columns: mapColumns(node.columns),
+          columns: mergeCatalogColumns(
+            mapColumns(node.columns),
+            catalog?.nodes?.[id],
+          ),
         });
       }
       for (const [id, source] of Object.entries(manifest.sources ?? {})) {
@@ -2561,7 +2593,10 @@ dbtRoutes.get(
             : (source.name ?? id),
           resourceType: "source",
           description: source.description || undefined,
-          columns: mapColumns(source.columns),
+          columns: mergeCatalogColumns(
+            mapColumns(source.columns),
+            catalog?.sources?.[id],
+          ),
         });
       }
       // Exposures are leaf consumers (dashboards/apps) — render them as
@@ -2590,9 +2625,16 @@ dbtRoutes.get(
         }
       }
 
+      const columnEdges = buildNameMatchColumnEdges(nodes, edges);
+
       return c.json({
         success: true,
-        lineage: { nodes, edges, generatedAt: run.createdAt },
+        lineage: {
+          nodes,
+          edges,
+          columnEdges,
+          generatedAt: run.createdAt,
+        },
       });
     } catch (error) {
       return serverError(c, error, "Failed to build dbt lineage");

--- a/app/src/components/DbtLineageView.tsx
+++ b/app/src/components/DbtLineageView.tsx
@@ -36,6 +36,7 @@ import "@xyflow/react/dist/style.css";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
   useDbtStore,
+  type DbtColumnLineageEdge,
   type DbtLineage,
   type DbtLineageNode,
 } from "../store/dbtStore";
@@ -188,6 +189,47 @@ function resolveSelector(
   return result;
 }
 
+function ColumnEdgeList({
+  title,
+  edges,
+  nodeNameById,
+  direction,
+}: {
+  title: string;
+  edges: DbtColumnLineageEdge[];
+  nodeNameById: Map<string, string>;
+  direction: "upstream" | "downstream";
+}) {
+  return (
+    <Box sx={{ mb: 1 }}>
+      <Typography
+        variant="caption"
+        sx={{ fontWeight: 600, display: "block", mb: 0.25 }}
+      >
+        {title}
+      </Typography>
+      {edges.map(edge => {
+        const otherId =
+          direction === "upstream" ? edge.sourceNodeId : edge.targetNodeId;
+        const otherName = nodeNameById.get(otherId) ?? otherId;
+        const label =
+          direction === "upstream"
+            ? `${otherName}.${edge.sourceColumn} → ${edge.targetColumn}`
+            : `${edge.sourceColumn} → ${otherName}.${edge.targetColumn}`;
+        return (
+          <Typography
+            key={`${edge.sourceNodeId}.${edge.sourceColumn}->${edge.targetNodeId}.${edge.targetColumn}`}
+            variant="caption"
+            sx={{ display: "block", fontFamily: "monospace", mb: 0.25 }}
+          >
+            {label}
+          </Typography>
+        );
+      })}
+    </Box>
+  );
+}
+
 export default function DbtLineageView({ projectId }: { projectId: string }) {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
@@ -224,7 +266,10 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     const edges = lineage.edges.filter(
       e => selected.has(e.source) && selected.has(e.target),
     );
-    return { ...lineage, nodes, edges };
+    const columnEdges = (lineage.columnEdges ?? []).filter(
+      e => selected.has(e.sourceNodeId) && selected.has(e.targetNodeId),
+    );
+    return { ...lineage, nodes, edges, columnEdges };
   }, [lineage, appliedSelector]);
 
   const applySelector = useCallback(() => {
@@ -235,6 +280,32 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     setSelectorText("");
     setAppliedSelector("");
   }, []);
+
+  const nodeNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const node of visibleLineage?.nodes ?? []) {
+      map.set(node.id, node.name);
+    }
+    return map;
+  }, [visibleLineage]);
+
+  /** Column edges touching the selected node (upstream + downstream). */
+  const selectedColumnEdges = useMemo(() => {
+    if (!selectedNodeId || !visibleLineage?.columnEdges) return [];
+    return visibleLineage.columnEdges.filter(
+      e =>
+        e.sourceNodeId === selectedNodeId || e.targetNodeId === selectedNodeId,
+    );
+  }, [visibleLineage, selectedNodeId]);
+
+  /** Table edges that carry at least one inferred column match for the selection. */
+  const columnLinkedTableEdges = useMemo(() => {
+    const keys = new Set<string>();
+    for (const edge of selectedColumnEdges) {
+      keys.add(`${edge.sourceNodeId}->${edge.targetNodeId}`);
+    }
+    return keys;
+  }, [selectedColumnEdges]);
 
   const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
     if (!visibleLineage || visibleLineage.nodes.length === 0) {
@@ -283,16 +354,40 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
       };
     });
 
-    const flowEdges: Edge[] = visibleLineage.edges.map(edge => ({
-      id: `${edge.source}->${edge.target}`,
-      source: edge.source,
-      target: edge.target,
-      animated: false,
-      style: { stroke: theme.palette.divider },
-    }));
+    const flowEdges: Edge[] = visibleLineage.edges.map(edge => {
+      const key = `${edge.source}->${edge.target}`;
+      const columnLinked = columnLinkedTableEdges.has(key);
+      const matchCount = selectedColumnEdges.filter(
+        e => e.sourceNodeId === edge.source && e.targetNodeId === edge.target,
+      ).length;
+      return {
+        id: key,
+        source: edge.source,
+        target: edge.target,
+        animated: columnLinked,
+        label: columnLinked
+          ? `${matchCount} col${matchCount === 1 ? "" : "s"}`
+          : undefined,
+        style: {
+          stroke: columnLinked
+            ? theme.palette.primary.main
+            : theme.palette.divider,
+          strokeWidth: columnLinked ? 2 : 1,
+        },
+        labelStyle: columnLinked
+          ? { fill: theme.palette.primary.main, fontSize: 10 }
+          : undefined,
+      };
+    });
 
     return { nodes: flowNodes, edges: flowEdges };
-  }, [visibleLineage, theme, selectedNodeId]);
+  }, [
+    visibleLineage,
+    theme,
+    selectedNodeId,
+    columnLinkedTableEdges,
+    selectedColumnEdges,
+  ]);
 
   const handleNodeClick = useCallback((_event: unknown, node: Node) => {
     setSelectedNodeId(node.id);
@@ -301,6 +396,15 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
   const selectedNode: DbtLineageNode | undefined = useMemo(
     () => visibleLineage?.nodes.find(n => n.id === selectedNodeId),
     [visibleLineage, selectedNodeId],
+  );
+
+  const upstreamColumnEdges = useMemo(
+    () => selectedColumnEdges.filter(e => e.targetNodeId === selectedNodeId),
+    [selectedColumnEdges, selectedNodeId],
+  );
+  const downstreamColumnEdges = useMemo(
+    () => selectedColumnEdges.filter(e => e.sourceNodeId === selectedNodeId),
+    [selectedColumnEdges, selectedNodeId],
   );
 
   if (loading) {
@@ -526,6 +630,43 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
                   </Box>
                 ))}
               </Box>
+            </>
+          )}
+
+          {(upstreamColumnEdges.length > 0 ||
+            downstreamColumnEdges.length > 0) && (
+            <>
+              <Divider sx={{ my: 1 }} />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600, display: "block" }}
+              >
+                Column lineage (inferred)
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 0.75 }}
+              >
+                Same-name matches across parent_map — not SQL-proven.
+              </Typography>
+              {upstreamColumnEdges.length > 0 && (
+                <ColumnEdgeList
+                  title="Upstream"
+                  edges={upstreamColumnEdges}
+                  nodeNameById={nodeNameById}
+                  direction="upstream"
+                />
+              )}
+              {downstreamColumnEdges.length > 0 && (
+                <ColumnEdgeList
+                  title="Downstream"
+                  edges={downstreamColumnEdges}
+                  nodeNameById={nodeNameById}
+                  direction="downstream"
+                />
+              )}
             </>
           )}
 

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -317,9 +317,19 @@ export interface DbtLineageNode {
   owner?: string;
 }
 
+/** Inferred same-name column edge across a table-level parent→child link. */
+export interface DbtColumnLineageEdge {
+  sourceNodeId: string;
+  sourceColumn: string;
+  targetNodeId: string;
+  targetColumn: string;
+  confidence: "name_match";
+}
+
 export interface DbtLineage {
   nodes: DbtLineageNode[];
   edges: Array<{ source: string; target: string }>;
+  columnEdges?: DbtColumnLineageEdge[];
   generatedAt: string | null;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **column-level lineage** to the Transforms DAG (Turntable-style) without SQL parsing.

dbt Core manifests only have table-level `parent_map`. This PR infers column edges by matching column names across each parent→child link, optionally enriched with `catalog.json` types.

## What changed

- **API** (`GET .../lineage`): returns `columnEdges[]` with `{ sourceNodeId, sourceColumn, targetNodeId, targetColumn, confidence: "name_match" }`. Merges catalog columns/types when the same run has a catalog artifact.
- **Helpers** (`api/src/dbt/column-lineage.ts`): pure `buildNameMatchColumnEdges` + `mergeCatalogColumns` with unit tests.
- **UI** (`DbtLineageView`): selecting a node highlights table edges that carry column matches (animated + “N cols” label) and lists upstream/downstream column edges in the side panel, clearly labeled as inferred.

## Caveat

Same-name matching is a v1 heuristic — renames and expressions won’t show. True CLL would need compiled-SQL parsing later.

## Test plan

- [x] `pnpm --filter api run test:dbt` / `column-lineage.test.ts`
- [x] `pnpm --filter api run lint`
- [x] `pnpm --filter app run typecheck && lint`
- [ ] Manual: run a project with documented overlapping columns → Lineage → select a model → see column lineage list + highlighted edges
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c117836-54e1-4b03-89f1-34393f3f3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

