### PR TITLE
fix(acp): provider-aware HITL + Desktop outdated sticky banner

### DIFF
--- a/app/src/components/AcpDesktopOutdatedBanner.tsx
+++ b/app/src/components/AcpDesktopOutdatedBanner.tsx
@@ -1,0 +1,59 @@
+import { Alert, Link, Typography } from "@mui/material";
+import {
+  ACP_REQUIRED_DESKTOP_VERSION,
+  acpDesktopOutdatedSummary,
+  acpIsDesktopOutdatedForEnsureWarm,
+  acpSupportsWorkspaceMcp,
+} from "../lib/acp-capabilities";
+import type { AcpStatus } from "../lib/acp-types";
+
+const CANARY_URL =
+  "https://github.com/mako-ai/mako/releases/tag/desktop-canary";
+
+/**
+ * Single sticky “Desktop outdated” banner for Chat + Settings.
+ * Shown when Local Agent lacks MCP attach and/or ensure/warm (bridge &lt; 7).
+ */
+export function AcpDesktopOutdatedBanner(props: {
+  status: AcpStatus | null | undefined;
+  /** Compact Chat strip vs Settings block. */
+  compact?: boolean;
+  /**
+   * Force-show even when only MCP baseline is missing (no acpBridge / &lt; 2).
+   * Default: show for ensure/warm gap OR missing MCP support when status exists.
+   */
+  force?: boolean;
+}) {
+  const { status, compact, force } = props;
+  if (!status) return null;
+
+  const bridgeOk = acpSupportsWorkspaceMcp(status);
+  const ensureWarmOutdated = acpIsDesktopOutdatedForEnsureWarm(status);
+  const show = force || ensureWarmOutdated || !bridgeOk;
+  if (!show) return null;
+
+  const title = bridgeOk
+    ? `Local Agent needs Desktop ${ACP_REQUIRED_DESKTOP_VERSION}+`
+    : "Local Agent is outdated for Coding Agents";
+
+  return (
+    <Alert severity="warning" sx={{ mb: compact ? 1 : 2 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 0.5 }}>
+        {acpDesktopOutdatedSummary()} Update / warm / model-switch stay disabled
+        until the new Local Agent is running.
+      </Typography>
+      <Typography variant="caption" component="div">
+        Canary:{" "}
+        <Link href={CANARY_URL} target="_blank" rel="noreferrer">
+          desktop-canary
+        </Link>
+        {bridgeOk
+          ? null
+          : " — or for developers: quit Desktop and run pnpm agent:start from the ACP branch."}
+      </Typography>
+    </Alert>
+  );
+}

--- a/app/src/components/AcpPermissionBanner.tsx
+++ b/app/src/components/AcpPermissionBanner.tsx
@@ -1,4 +1,5 @@
 import { Alert, Button, Stack, Typography } from "@mui/material";
+import { acpProviderLabel } from "../lib/acp-provider-label";
 import { useAcpStore } from "../store/acpStore";
 
 function toolLabel(toolCall: unknown): string {
@@ -9,13 +10,15 @@ function toolLabel(toolCall: unknown): string {
     kind?: unknown;
     _meta?: { claudeCode?: { toolName?: unknown } };
   };
+  // Prefer Claude `_meta` when present; Codex often only has title/name/kind.
   const name =
     (typeof tc._meta?.claudeCode?.toolName === "string" &&
       tc._meta.claudeCode.toolName) ||
-    (typeof tc.name === "string" && tc.name) ||
     (typeof tc.title === "string" && tc.title) ||
+    (typeof tc.name === "string" && tc.name) ||
+    (typeof tc.kind === "string" && tc.kind) ||
     "tool";
-  const kind = typeof tc.kind === "string" ? tc.kind : "";
+  const kind = typeof tc.kind === "string" && tc.kind !== name ? tc.kind : "";
   return kind ? `${name} (${kind})` : name;
 }
 
@@ -40,16 +43,14 @@ export function AcpPermissionBanner() {
   const setActiveSession = useAcpStore(s => s.setActiveSession);
   const sessions = useAcpStore(s => s.sessions);
   const selectedProviderId = useAcpStore(s => s.selectedProviderId);
-  const providers = useAcpStore(s => s.status?.providers);
+  const status = useAcpStore(s => s.status);
 
   if (!pending) return null;
 
   const { sessionId, prompt } = pending;
   const providerId =
     sessions.find(x => x.id === sessionId)?.providerId || selectedProviderId;
-  const providerLabel =
-    providers?.find(p => p.id === providerId)?.label ||
-    (providerId === "codex" ? "Codex" : "Claude Code");
+  const providerLabel = acpProviderLabel(providerId, status);
 
   return (
     <Alert

--- a/app/src/components/AcpWorkspaceToolsBanner.tsx
+++ b/app/src/components/AcpWorkspaceToolsBanner.tsx
@@ -6,16 +6,23 @@
 import { useEffect, useState } from "react";
 import { Alert, Button, Stack, Typography } from "@mui/material";
 import {
+  ACP_REQUIRED_DESKTOP_VERSION,
+  acpDesktopOutdatedSummary,
   acpSupportsAdapterEnsure,
   acpSupportsModelWarm,
   acpSupportsWorkspaceMcp,
 } from "../lib/acp-capabilities";
+import {
+  isAcpDesktopOutdatedError,
+  isBareLocalAgentNotFound,
+} from "../lib/acp-user-errors";
 import {
   isLocalAcpModelId,
   localAcpModelIdToProviderId,
 } from "../lib/local-acp-models";
 import { useAcpStore } from "../store/acpStore";
 import { useLocalAgentStore } from "../store/localAgentStore";
+import { AcpDesktopOutdatedBanner } from "./AcpDesktopOutdatedBanner";
 
 export function AcpWorkspaceToolsBanner(props: {
   modelId: string | null | undefined;
@@ -143,8 +150,13 @@ export function AcpWorkspaceToolsBanner(props: {
     setBusyLabel("Installing…");
     try {
       await checkAgent();
+      if (!acpSupportsAdapterEnsure(useAcpStore.getState().status)) {
+        return;
+      }
       await ensureAdapter(providerId, { force: true });
-      await warmProviderModels(providerId);
+      if (acpSupportsModelWarm(useAcpStore.getState().status)) {
+        await warmProviderModels(providerId);
+      }
       await refreshStatus();
     } finally {
       setBusy(false);
@@ -153,16 +165,22 @@ export function AcpWorkspaceToolsBanner(props: {
   };
 
   if (agentStatus === "offline" || statusError) {
+    const outdated =
+      isAcpDesktopOutdatedError(statusError) ||
+      isBareLocalAgentNotFound(statusError);
     return (
       <Alert severity="warning" sx={{ mb: 1 }}>
         <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-          Local Agent required for workspace tools
+          {outdated
+            ? `Local Agent needs Desktop ${ACP_REQUIRED_DESKTOP_VERSION}+`
+            : "Local Agent required for workspace tools"}
         </Typography>
         <Typography variant="body2" sx={{ mb: 1 }}>
-          Start Mako Desktop or run <code>pnpm agent:start</code> on this
-          machine, then enable tools below.
+          {outdated
+            ? acpDesktopOutdatedSummary()
+            : "Start Mako Desktop or run pnpm agent:start on this machine, then enable tools below."}
         </Typography>
-        {statusError ? (
+        {statusError && !outdated && !isBareLocalAgentNotFound(statusError) ? (
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
             {statusError}
           </Typography>
@@ -186,141 +204,142 @@ export function AcpWorkspaceToolsBanner(props: {
 
   if (provider && !provider.adapterFound) {
     return (
-      <Alert
-        severity="warning"
-        sx={{ mb: 1 }}
-        action={
-          canEnsureAdapter ? (
-            <Button
-              size="small"
-              variant="contained"
-              disabled={busy || ensureRunning}
-              onClick={() => void installAdapter()}
-            >
-              {busy || ensureRunning
-                ? busyLabel || ensureLabel || "Installing…"
-                : "Install"}
-            </Button>
-          ) : undefined
-        }
-      >
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-          Install the {provider.label} adapter
-        </Typography>
-        <Typography variant="body2">
-          {canEnsureAdapter
-            ? "Mako can install it on this machine (npm global). One click — no Terminal required."
-            : provider.installHint}
-        </Typography>
-        {!canEnsureAdapter ? (
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            Local Agent is outdated for one-click install — update Desktop to
-            0.3.9+, quit/reopen Mako, then retry.
+      <>
+        <AcpDesktopOutdatedBanner status={acpStatus} compact />
+        <Alert
+          severity="warning"
+          sx={{ mb: 1 }}
+          action={
+            canEnsureAdapter ? (
+              <Button
+                size="small"
+                variant="contained"
+                disabled={busy || ensureRunning}
+                onClick={() => void installAdapter()}
+              >
+                {busy || ensureRunning
+                  ? busyLabel || ensureLabel || "Installing…"
+                  : "Install"}
+              </Button>
+            ) : undefined
+          }
+        >
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+            Install the {provider.label} adapter
           </Typography>
-        ) : null}
-      </Alert>
+          <Typography variant="body2">
+            {canEnsureAdapter
+              ? "Mako can install it on this machine (npm global). One click — no Terminal required."
+              : provider.installHint}
+          </Typography>
+        </Alert>
+      </>
     );
   }
 
   if (provider?.authRequired && !provider.connected) {
     return (
-      <Alert
-        severity="info"
-        sx={{ mb: 1 }}
-        action={
-          <Button
-            size="small"
-            variant="contained"
-            disabled={busy}
-            onClick={() => {
-              setBusy(true);
-              void authenticate(providerId).finally(() => setBusy(false));
-            }}
-          >
-            Sign in
-          </Button>
-        }
-      >
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-          Sign in to {provider.authProduct}
-        </Typography>
-        <Typography variant="body2">
-          Then enable Mako workspace tools (BigQuery, SQL, connections) in one
-          click — no terminal MCP setup.
-        </Typography>
-      </Alert>
+      <>
+        <AcpDesktopOutdatedBanner status={acpStatus} compact />
+        <Alert
+          severity="info"
+          sx={{ mb: 1 }}
+          action={
+            <Button
+              size="small"
+              variant="contained"
+              disabled={busy}
+              onClick={() => {
+                setBusy(true);
+                void authenticate(providerId).finally(() => setBusy(false));
+              }}
+            >
+              Sign in
+            </Button>
+          }
+        >
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+            Sign in to {provider.authProduct}
+          </Typography>
+          <Typography variant="body2">
+            Then enable Mako workspace tools (BigQuery, SQL, connections) in one
+            click — no terminal MCP setup.
+          </Typography>
+        </Alert>
+      </>
     );
   }
 
   if (attached && !error) {
-    if (dismissedReady) return null;
+    if (dismissedReady) {
+      return <AcpDesktopOutdatedBanner status={acpStatus} compact />;
+    }
     return (
-      <Alert
-        severity="success"
-        sx={{ mb: 1 }}
-        onClose={() => setDismissedReady(true)}
-      >
-        <Typography variant="body2">
-          Workspace tools connected (<code>mako-workspace</code>). Ask{" "}
-          {provider?.label || "the local agent"} about your data — it should
-          call Mako tools directly (no Terminal MCP setup).
-        </Typography>
-      </Alert>
+      <>
+        <AcpDesktopOutdatedBanner status={acpStatus} compact />
+        <Alert
+          severity="success"
+          sx={{ mb: 1 }}
+          onClose={() => setDismissedReady(true)}
+        >
+          <Typography variant="body2">
+            Workspace tools connected (<code>mako-workspace</code>). Ask{" "}
+            {provider?.label || "the local agent"} about your data — it should
+            call Mako tools directly (no Terminal MCP setup).
+          </Typography>
+        </Alert>
+      </>
     );
   }
 
   return (
-    <Alert
-      severity={error ? "error" : "info"}
-      sx={{ mb: 1 }}
-      action={
-        <Stack direction="row" spacing={1}>
-          <Button
-            size="small"
-            variant="contained"
-            disabled={busy || ensureRunning || !workspaceId || !bridgeOk}
-            onClick={() => void enable()}
-          >
-            {busy || ensureRunning
-              ? busyLabel || ensureLabel || "Connecting…"
-              : "Enable workspace tools"}
-          </Button>
-        </Stack>
-      }
-    >
-      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-        Activate Mako data tools for this local session
-      </Typography>
-      <Typography variant="body2">
-        Mints a short-lived token and attaches authenticated workspace MCP (SQL,
-        connections, consoles) for {provider?.label || "this local agent"}. If
-        it asked for Mako auth, click Enable, then send a new message — or start
-        a New chat.
-      </Typography>
-      {ensureRunning || ensureStatus?.state === "error" ? (
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          {ensureLabel}
+    <>
+      <AcpDesktopOutdatedBanner status={acpStatus} compact />
+      <Alert
+        severity={error ? "error" : "info"}
+        sx={{ mb: 1 }}
+        action={
+          <Stack direction="row" spacing={1}>
+            <Button
+              size="small"
+              variant="contained"
+              disabled={busy || ensureRunning || !workspaceId || !bridgeOk}
+              onClick={() => void enable()}
+            >
+              {busy || ensureRunning
+                ? busyLabel || ensureLabel || "Connecting…"
+                : "Enable workspace tools"}
+            </Button>
+          </Stack>
+        }
+      >
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          Activate Mako data tools for this local session
         </Typography>
-      ) : null}
-      {!bridgeOk ? (
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          Local Agent is outdated for MCP attach — install Desktop 0.3.9+ and
-          fully quit/reopen Mako before enabling tools.
+        <Typography variant="body2">
+          Mints a short-lived token and attaches authenticated workspace MCP
+          (SQL, connections, consoles) for{" "}
+          {provider?.label || "this local agent"}. If it asked for Mako auth,
+          click Enable, then send a new message — or start a New chat.
         </Typography>
-      ) : null}
-      {error &&
-      !/missing ACP route|outdated for this action|One-click Update needs/i.test(
-        error,
-      ) ? (
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          {error}
-        </Typography>
-      ) : null}
-      {!workspaceId ? (
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          Select a workspace first.
-        </Typography>
-      ) : null}
-    </Alert>
+        {ensureRunning || ensureStatus?.state === "error" ? (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {ensureLabel}
+          </Typography>
+        ) : null}
+        {error &&
+        !isAcpDesktopOutdatedError(error) &&
+        !isBareLocalAgentNotFound(error) ? (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        ) : null}
+        {!workspaceId ? (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            Select a workspace first.
+          </Typography>
+        ) : null}
+      </Alert>
+    </>
   );
 }

--- a/app/src/components/CodingAgentsPanel.test.tsx
+++ b/app/src/components/CodingAgentsPanel.test.tsx
@@ -34,6 +34,11 @@ vi.mock("../store/acpStore", () => {
         authMethods: [],
       },
     ],
+    acpBridge: {
+      version: 7,
+      adapterEnsure: true,
+      modelWarm: true,
+    },
   };
   const state = {
     status,

--- a/app/src/components/CodingAgentsPanel.tsx
+++ b/app/src/components/CodingAgentsPanel.tsx
@@ -14,10 +14,19 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { acpSupportsAdapterEnsure } from "../lib/acp-capabilities";
+import {
+  ACP_REQUIRED_DESKTOP_VERSION,
+  acpDesktopOutdatedSummary,
+  acpSupportsAdapterEnsure,
+} from "../lib/acp-capabilities";
+import {
+  isAcpDesktopOutdatedError,
+  isBareLocalAgentNotFound,
+} from "../lib/acp-user-errors";
 import { useAcpStore } from "../store/acpStore";
 import { useLocalAgentStore } from "../store/localAgentStore";
 import type { AcpProviderId } from "../lib/acp-types";
+import { AcpDesktopOutdatedBanner } from "./AcpDesktopOutdatedBanner";
 
 /**
  * Settings setup for Local Agent ACP providers.
@@ -76,26 +85,33 @@ export function CodingAgentsPanel() {
   }
 
   if (agentStatus === "offline" || statusError || !acpStatus) {
-    const hint =
-      statusError?.includes("404") || statusError?.includes("Not Found")
-        ? "Your Local Agent build does not include ACP yet. From the PR branch run: pnpm agent:start"
-        : null;
+    const outdated =
+      isAcpDesktopOutdatedError(statusError) ||
+      isBareLocalAgentNotFound(statusError);
 
     return (
       <Alert severity="warning">
-        Coding agents run on your machine via the Mako Local Agent (loopback ACP
-        bridge). Start <strong>Mako Desktop</strong> (PR build) or run{" "}
-        <code>pnpm agent:start</code> from the ACP branch, then retry.
-        {statusError ? (
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            {statusError}
-          </Typography>
-        ) : null}
-        {hint ? (
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            {hint}
-          </Typography>
-        ) : null}
+        {outdated ? (
+          <>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Local Agent needs Desktop {ACP_REQUIRED_DESKTOP_VERSION}+
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              {acpDesktopOutdatedSummary()}
+            </Typography>
+          </>
+        ) : (
+          <>
+            Coding agents run on your machine via the Mako Local Agent (loopback
+            ACP bridge). Start <strong>Mako Desktop</strong> or run{" "}
+            <code>pnpm agent:start</code> (developers), then retry.
+            {statusError && !isBareLocalAgentNotFound(statusError) ? (
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {statusError}
+              </Typography>
+            ) : null}
+          </>
+        )}
         <Box sx={{ mt: 2 }}>
           <Button size="small" variant="outlined" onClick={retry}>
             Retry
@@ -109,37 +125,12 @@ export function CodingAgentsPanel() {
   const provider = providers.find(p => p.id === selectedProviderId);
   const selectValue = provider ? selectedProviderId : "";
   const readyProviders = providers.filter(p => p.adapterFound);
-  const bridgeOk = Boolean(
-    acpStatus.acpBridge?.version && acpStatus.acpBridge.version >= 2,
-  );
+  const canEnsure = acpSupportsAdapterEnsure(acpStatus);
   const lastAdapterError = acpStatus.lastAdapterError;
 
   return (
     <Box>
-      {!bridgeOk ? (
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-            Local Agent is outdated for Coding Agents
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 1 }}>
-            You&apos;re still running an older Desktop-bundled agent (it reports
-            raw &quot;ACP connection closed&quot;). Install the latest{" "}
-            <strong>desktop-canary</strong>, fully quit Mako (Cmd+Q), and reopen
-            — or for developers: quit Desktop and run{" "}
-            <code>pnpm agent:start</code> from this PR branch.
-          </Typography>
-          <Typography variant="caption" component="div">
-            Canary:{" "}
-            <a
-              href="https://github.com/mako-ai/mako/releases/tag/desktop-canary"
-              target="_blank"
-              rel="noreferrer"
-            >
-              github.com/mako-ai/mako/releases/tag/desktop-canary
-            </a>
-          </Typography>
-        </Alert>
-      ) : null}
+      <AcpDesktopOutdatedBanner status={acpStatus} />
 
       <Alert severity="info" sx={{ mb: 2 }}>
         Chat with Claude Code or Codex from the <strong>main Chat</strong> model
@@ -237,12 +228,7 @@ export function CodingAgentsPanel() {
                   () => setUpdating(false),
                 );
               }}
-              disabled={
-                loadingStatus ||
-                updating ||
-                signingIn ||
-                !acpSupportsAdapterEnsure(acpStatus)
-              }
+              disabled={loadingStatus || updating || signingIn || !canEnsure}
             >
               {updating
                 ? "Updating…"
@@ -263,8 +249,8 @@ export function CodingAgentsPanel() {
                 : `Sign in with ${provider?.authProduct || "provider"}`}
             </Button>
             <Typography variant="body2" color="text.secondary">
-              {!acpSupportsAdapterEnsure(acpStatus)
-                ? "One-click Update needs Desktop 0.3.9+ (fully quit/reopen). Adapter already found — use Chat → Enable workspace tools."
+              {!canEnsure
+                ? `Update disabled until Desktop ${ACP_REQUIRED_DESKTOP_VERSION}+. ${acpDesktopOutdatedSummary()}`
                 : readyProviders.length > 0
                   ? `Update keeps ${provider?.label || "the adapter"} current. Sign in opens Terminal for CLI login.`
                   : "Install the adapter here — no Terminal npm required."}
@@ -300,13 +286,16 @@ export function CodingAgentsPanel() {
         </Alert>
       )}
 
-      {error && !/missing ACP route|outdated for this action/i.test(error) && (
+      {error &&
+      !isAcpDesktopOutdatedError(error) &&
+      !isBareLocalAgentNotFound(error) ? (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
           {/ACP connection closed/i.test(error) ? (
             <Typography variant="body2" sx={{ mt: 1 }}>
               Local Agent process may be stale on port 41720. Fully quit Desktop
-              (Cmd+Q / Quit), reopen Desktop 0.3.9+, then retry.
+              (Cmd+Q / Quit), reopen Desktop {ACP_REQUIRED_DESKTOP_VERSION}+,
+              then retry.
             </Typography>
           ) : null}
           {/ENOTEMPTY|_npx/i.test(`${error}\n${lastAdapterError || ""}`) ? (
@@ -334,7 +323,7 @@ export function CodingAgentsPanel() {
             </Typography>
           ) : null}
         </Alert>
-      )}
+      ) : null}
 
       <Paper variant="outlined" sx={{ p: 2 }}>
         <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>

--- a/app/src/lib/acp-capabilities.test.ts
+++ b/app/src/lib/acp-capabilities.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  ACP_REQUIRED_DESKTOP_VERSION,
+  acpDesktopOutdatedSummary,
+  acpIsDesktopOutdatedForEnsureWarm,
   acpSupportsAdapterEnsure,
   acpSupportsModelWarm,
   acpSupportsWorkspaceMcp,
@@ -22,15 +25,33 @@ describe("acp capabilities", () => {
     expect(acpSupportsWorkspaceMcp(status({ version: 2 }))).toBe(true);
   });
 
-  it("gates ensure/warm on bridge ≥ 6 or capability flags", () => {
+  it("gates ensure/warm on bridge ≥ 7 or capability flags", () => {
     expect(acpSupportsAdapterEnsure(status({ version: 5 }))).toBe(false);
     expect(acpSupportsModelWarm(status({ version: 5 }))).toBe(false);
-    expect(acpSupportsAdapterEnsure(status({ version: 6 }))).toBe(true);
+    expect(acpSupportsAdapterEnsure(status({ version: 6 }))).toBe(false);
+    expect(acpSupportsModelWarm(status({ version: 6 }))).toBe(false);
+    expect(acpSupportsAdapterEnsure(status({ version: 7 }))).toBe(true);
     expect(acpSupportsModelWarm(status({ version: 7, modelWarm: true }))).toBe(
       true,
     );
     expect(
       acpSupportsAdapterEnsure(status({ version: 3, adapterEnsure: true })),
     ).toBe(true);
+  });
+
+  it("treats missing ensure/warm as first-class Desktop outdated", () => {
+    expect(acpIsDesktopOutdatedForEnsureWarm(null)).toBe(false);
+    expect(acpIsDesktopOutdatedForEnsureWarm(status())).toBe(false);
+    expect(acpIsDesktopOutdatedForEnsureWarm(status({ version: 5 }))).toBe(
+      true,
+    );
+    expect(
+      acpIsDesktopOutdatedForEnsureWarm(
+        status({ version: 7, adapterEnsure: true, modelWarm: true }),
+      ),
+    ).toBe(false);
+    expect(acpDesktopOutdatedSummary()).toContain(ACP_REQUIRED_DESKTOP_VERSION);
+    expect(acpDesktopOutdatedSummary()).toMatch(/fully quit/i);
+    expect(acpDesktopOutdatedSummary()).toMatch(/Enable workspace tools/i);
   });
 });

--- a/app/src/lib/acp-capabilities.ts
+++ b/app/src/lib/acp-capabilities.ts
@@ -1,12 +1,33 @@
 import type { AcpStatus } from "./acp-types";
 
-/** One-click `npm i -g` adapter install/update (Desktop 0.3.9+ / bridge ≥ 6). */
+/** Desktop / Local Agent floor for ensure + warm-models ACP routes. */
+export const ACP_REQUIRED_DESKTOP_VERSION = "0.3.9";
+
+/** Bridge version that advertises adapterEnsure + modelWarm. */
+export const ACP_ENSURE_WARM_BRIDGE_VERSION = 7;
+
+/**
+ * True when Local Agent is online with an ACP bridge, but lacks one-click
+ * adapter ensure / model warm (Desktop older than {@link ACP_REQUIRED_DESKTOP_VERSION}).
+ * Distinct from "agent offline" and from bridge &lt; 2 (no MCP attach).
+ */
+export function acpIsDesktopOutdatedForEnsureWarm(
+  status: AcpStatus | null | undefined,
+): boolean {
+  const bridge = status?.acpBridge;
+  if (!bridge) return false;
+  return !acpSupportsAdapterEnsure(status) || !acpSupportsModelWarm(status);
+}
+
+/** One-click `npm i -g` adapter install/update (Desktop 0.3.9+ / bridge ≥ 7). */
 export function acpSupportsAdapterEnsure(
   status: AcpStatus | null | undefined,
 ): boolean {
   const bridge = status?.acpBridge;
   if (!bridge) return false;
-  return Boolean(bridge.adapterEnsure || bridge.version >= 6);
+  return Boolean(
+    bridge.adapterEnsure || bridge.version >= ACP_ENSURE_WARM_BRIDGE_VERSION,
+  );
 }
 
 /** Warm Claude/Codex model catalogs without a Chat turn. */
@@ -16,7 +37,9 @@ export function acpSupportsModelWarm(
   const bridge = status?.acpBridge;
   if (!bridge) return false;
   return Boolean(
-    bridge.modelWarm || bridge.adapterEnsure || bridge.version >= 6,
+    bridge.modelWarm ||
+      bridge.adapterEnsure ||
+      bridge.version >= ACP_ENSURE_WARM_BRIDGE_VERSION,
   );
 }
 
@@ -26,4 +49,13 @@ export function acpSupportsWorkspaceMcp(
 ): boolean {
   const version = status?.acpBridge?.version;
   return typeof version === "number" && version >= 2;
+}
+
+/** Shared sticky-banner copy for Chat + Settings. */
+export function acpDesktopOutdatedSummary(): string {
+  return (
+    `Update Mako Desktop to ${ACP_REQUIRED_DESKTOP_VERSION}+, fully quit ` +
+    `(Cmd+Q / Quit — not only close the window), reopen, then use Chat → ` +
+    `Enable workspace tools.`
+  );
 }

--- a/app/src/lib/acp-client-not-found.test.ts
+++ b/app/src/lib/acp-client-not-found.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { rewriteLocalAgentNotFound } from "./acp-client";
+
+describe("rewriteLocalAgentNotFound", () => {
+  it("rewrites bare Not Found and HTTP 404", () => {
+    expect(rewriteLocalAgentNotFound("Not Found")).toMatch(/Desktop 0\.3\.9/);
+    expect(rewriteLocalAgentNotFound("Agent error (HTTP 404)")).toMatch(
+      /outdated/,
+    );
+    expect(rewriteLocalAgentNotFound("Failed (Not Found)")).toMatch(
+      /fully quit/i,
+    );
+  });
+
+  it("leaves other errors unchanged", () => {
+    expect(rewriteLocalAgentNotFound("ACP connection closed")).toBe(
+      "ACP connection closed",
+    );
+  });
+});

--- a/app/src/lib/acp-client.ts
+++ b/app/src/lib/acp-client.ts
@@ -26,9 +26,17 @@ function unwrap<T>(body: Envelope<T>, fallback: string): T {
   return body.data;
 }
 
-/** Old Local Agents return bare "Not Found" for new ACP routes. */
-function rewriteLocalAgentNotFound(message: string): string {
-  if (!/^not found$/i.test(message.trim())) return message;
+/**
+ * Old Local Agents return bare "Not Found" (or HTTP 404) for ensure/warm
+ * routes. Always rewrite — never surface raw 404 copy in Chat/Settings.
+ */
+export function rewriteLocalAgentNotFound(message: string): string {
+  const trimmed = message.trim();
+  const bareNotFound =
+    /^not found$/i.test(trimmed) ||
+    /^agent error \(http 404\)$/i.test(trimmed) ||
+    /\(not found\)$/i.test(trimmed);
+  if (!bareNotFound) return message;
   return (
     "Local Agent is outdated for this action (missing ACP route). " +
     "Fully quit and reopen Mako Desktop 0.3.9+ so the bundled agent restarts, " +
@@ -36,31 +44,49 @@ function rewriteLocalAgentNotFound(message: string): string {
   );
 }
 
+async function withNotFoundRewrite<T>(
+  run: () => Promise<T>,
+  fallback: string,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : fallback;
+    throw new Error(rewriteLocalAgentNotFound(message));
+  }
+}
+
 export const acpClient = {
   async getStatus(signal?: AbortSignal): Promise<AcpStatus> {
-    const body = await localAgentClient.get<Envelope<AcpStatus>>(
-      "/acp/status",
-      undefined,
-      { signal, timeoutMs: 5000 },
-    );
-    return unwrap(body, "Failed to load ACP status");
+    return withNotFoundRewrite(async () => {
+      const body = await localAgentClient.get<Envelope<AcpStatus>>(
+        "/acp/status",
+        undefined,
+        { signal, timeoutMs: 5000 },
+      );
+      return unwrap(body, "Failed to load ACP status");
+    }, "Failed to load ACP status");
   },
 
   async listSessions(): Promise<AcpSessionInfo[]> {
-    const body =
-      await localAgentClient.get<Envelope<AcpSessionInfo[]>>("/acp/sessions");
-    return unwrap(body, "Failed to list ACP sessions");
+    return withNotFoundRewrite(async () => {
+      const body =
+        await localAgentClient.get<Envelope<AcpSessionInfo[]>>("/acp/sessions");
+      return unwrap(body, "Failed to list ACP sessions");
+    }, "Failed to list ACP sessions");
   },
 
   async authenticate(
     providerId: AcpProviderId,
     methodId?: string,
   ): Promise<AcpAuthenticateResult> {
-    const body = await localAgentClient.post<Envelope<AcpAuthenticateResult>>(
-      "/acp/authenticate",
-      { providerId, methodId },
-    );
-    return unwrap(body, "Authentication failed");
+    return withNotFoundRewrite(async () => {
+      const body = await localAgentClient.post<Envelope<AcpAuthenticateResult>>(
+        "/acp/authenticate",
+        { providerId, methodId },
+      );
+      return unwrap(body, "Authentication failed");
+    }, "Authentication failed");
   },
 
   /**
@@ -71,7 +97,7 @@ export const acpClient = {
     providerId: AcpProviderId,
     options?: { force?: boolean },
   ): Promise<AcpEnsureAdapterResult> {
-    try {
+    return withNotFoundRewrite(async () => {
       const body = await localAgentClient.post<
         Envelope<AcpEnsureAdapterResult>
       >(
@@ -80,27 +106,21 @@ export const acpClient = {
         { timeoutMs: 4 * 60 * 1000 },
       );
       return unwrap(body, "Failed to update local adapter");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(rewriteLocalAgentNotFound(message));
-    }
+    }, "Failed to update local adapter");
   },
 
   /** Populate real Claude/Codex model ids without starting a Chat turn. */
   async warmProviderModels(
     providerId: AcpProviderId,
   ): Promise<AcpWarmModelsResult> {
-    try {
+    return withNotFoundRewrite(async () => {
       const body = await localAgentClient.post<Envelope<AcpWarmModelsResult>>(
         `/acp/providers/${encodeURIComponent(providerId)}/warm-models`,
         {},
         { timeoutMs: 2 * 60 * 1000 },
       );
       return unwrap(body, "Failed to load local models");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(rewriteLocalAgentNotFound(message));
-    }
+    }, "Failed to load local models");
   },
 
   async createSession(input: {
@@ -117,45 +137,58 @@ export const acpClient = {
     model?: string;
   }): Promise<AcpSessionInfo> {
     // session/new may `npm i -g` Codex/Claude adapters before connecting.
-    const body = await localAgentClient.post<Envelope<AcpSessionInfo>>(
-      "/acp/sessions",
-      input,
-      { timeoutMs: 4 * 60 * 1000 },
-    );
-    return unwrap(body, "Failed to create ACP session");
+    return withNotFoundRewrite(async () => {
+      const body = await localAgentClient.post<Envelope<AcpSessionInfo>>(
+        "/acp/sessions",
+        input,
+        { timeoutMs: 4 * 60 * 1000 },
+      );
+      return unwrap(body, "Failed to create ACP session");
+    }, "Failed to create ACP session");
   },
 
   async setSessionConfig(
     sessionId: string,
     input: { configId?: string; value: string | boolean },
   ): Promise<AcpSessionInfo> {
-    const body = await localAgentClient.post<Envelope<AcpSessionInfo>>(
-      `/acp/sessions/${encodeURIComponent(sessionId)}/config`,
-      input,
-    );
-    return unwrap(body, "Failed to update session config");
+    return withNotFoundRewrite(async () => {
+      const body = await localAgentClient.post<Envelope<AcpSessionInfo>>(
+        `/acp/sessions/${encodeURIComponent(sessionId)}/config`,
+        input,
+      );
+      return unwrap(body, "Failed to update session config");
+    }, "Failed to update session config");
   },
 
   async prompt(
     sessionId: string,
     text: string,
   ): Promise<{ stopReason: string }> {
-    const body = await localAgentClient.post<Envelope<{ stopReason: string }>>(
-      `/acp/sessions/${encodeURIComponent(sessionId)}/prompt`,
-      { text },
-    );
-    return unwrap(body, "Prompt failed");
+    return withNotFoundRewrite(async () => {
+      const body = await localAgentClient.post<
+        Envelope<{ stopReason: string }>
+      >(`/acp/sessions/${encodeURIComponent(sessionId)}/prompt`, { text });
+      return unwrap(body, "Prompt failed");
+    }, "Prompt failed");
   },
 
   async cancel(sessionId: string): Promise<void> {
-    await localAgentClient.post(
-      `/acp/sessions/${encodeURIComponent(sessionId)}/cancel`,
+    await withNotFoundRewrite(
+      () =>
+        localAgentClient.post(
+          `/acp/sessions/${encodeURIComponent(sessionId)}/cancel`,
+        ),
+      "Cancel failed",
     );
   },
 
   async closeSession(sessionId: string): Promise<void> {
-    await localAgentClient.delete(
-      `/acp/sessions/${encodeURIComponent(sessionId)}`,
+    await withNotFoundRewrite(
+      () =>
+        localAgentClient.delete(
+          `/acp/sessions/${encodeURIComponent(sessionId)}`,
+        ),
+      "Close session failed",
     );
   },
 
@@ -164,11 +197,13 @@ export const acpClient = {
     requestId: string,
     outcome: { outcome: "cancelled" | "selected"; optionId?: string },
   ): Promise<void> {
-    const body = await localAgentClient.post<Envelope<{ ok: true }>>(
-      `/acp/sessions/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(requestId)}`,
-      outcome,
-    );
-    unwrap(body, "Failed to respond to permission");
+    await withNotFoundRewrite(async () => {
+      const body = await localAgentClient.post<Envelope<{ ok: true }>>(
+        `/acp/sessions/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(requestId)}`,
+        outcome,
+      );
+      unwrap(body, "Failed to respond to permission");
+    }, "Failed to respond to permission");
   },
 
   /**

--- a/app/src/lib/acp-provider-label.test.ts
+++ b/app/src/lib/acp-provider-label.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { acpProviderLabel } from "./acp-provider-label";
+import type { AcpStatus } from "./acp-types";
+
+const status: AcpStatus = {
+  available: true,
+  defaultCwd: "/tmp",
+  providers: [
+    {
+      id: "claude",
+      label: "Claude Code",
+      description: "",
+      authProduct: "Claude",
+      installHint: "",
+      adapterCommand: null,
+      adapterFound: true,
+      connected: false,
+      authRequired: false,
+      authMethods: [],
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      description: "",
+      authProduct: "ChatGPT",
+      installHint: "",
+      adapterCommand: null,
+      adapterFound: true,
+      connected: false,
+      authRequired: false,
+      authMethods: [],
+    },
+  ],
+};
+
+describe("acpProviderLabel", () => {
+  it("uses status label when present", () => {
+    expect(acpProviderLabel("codex", status)).toBe("Codex");
+    expect(acpProviderLabel("claude", status)).toBe("Claude Code");
+  });
+
+  it("falls back by provider id", () => {
+    expect(acpProviderLabel("codex")).toBe("Codex");
+    expect(acpProviderLabel("claude")).toBe("Claude Code");
+  });
+});

--- a/app/src/lib/acp-provider-label.ts
+++ b/app/src/lib/acp-provider-label.ts
@@ -1,0 +1,13 @@
+import type { AcpProviderId, AcpStatus } from "./acp-types";
+
+/** User-visible provider name for Chat ACP surfaces (HITL, banners). */
+export function acpProviderLabel(
+  providerId: AcpProviderId | string | null | undefined,
+  status?: AcpStatus | null,
+): string {
+  if (providerId && status?.providers?.length) {
+    const fromStatus = status.providers.find(p => p.id === providerId)?.label;
+    if (fromStatus) return fromStatus;
+  }
+  return providerId === "codex" ? "Codex" : "Claude Code";
+}

--- a/app/src/lib/acp-user-errors.ts
+++ b/app/src/lib/acp-user-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Errors that are already explained by the Desktop-outdated sticky banner.
+ * Hide them as raw Alert body text so Chat never shows "Not Found" / 404.
+ */
+export function isAcpDesktopOutdatedError(
+  message: string | null | undefined,
+): boolean {
+  if (!message) return false;
+  return /missing ACP route|outdated for this action|One-click Update needs|Local Agent needs Desktop|fully quit and reopen Mako Desktop/i.test(
+    message,
+  );
+}
+
+/** Bare Not Found / HTTP 404 that slipped past rewrite (should be rare). */
+export function isBareLocalAgentNotFound(
+  message: string | null | undefined,
+): boolean {
+  if (!message) return false;
+  const trimmed = message.trim();
+  return (
+    /^not found$/i.test(trimmed) ||
+    /^agent error \(http 404\)$/i.test(trimmed) ||
+    /\b404\b/.test(trimmed)
+  );
+}

--- a/app/src/store/acpStore.ts
+++ b/app/src/store/acpStore.ts
@@ -2,9 +2,12 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { acpClient } from "../lib/acp-client";
 import {
+  ACP_REQUIRED_DESKTOP_VERSION,
+  acpDesktopOutdatedSummary,
   acpSupportsAdapterEnsure,
   acpSupportsModelWarm,
 } from "../lib/acp-capabilities";
+import { acpProviderLabel } from "../lib/acp-provider-label";
 import type {
   AcpChatMessage,
   AcpEnsureAdapterResult,
@@ -348,9 +351,10 @@ export const useAcpStore = create<AcpState>()(
           options?.workspaceId?.trim() || getActiveWorkspaceId();
         if (!workspaceId) {
           throw new Error(
-            `Select a workspace before starting ${
-              selectedProviderId === "codex" ? "Codex" : "Claude Code"
-            } (local).`,
+            `Select a workspace before starting ${acpProviderLabel(
+              selectedProviderId,
+              get().status,
+            )} (local).`,
           );
         }
 
@@ -461,9 +465,10 @@ export const useAcpStore = create<AcpState>()(
       const id = providerId || get().selectedProviderId;
       if (!acpSupportsAdapterEnsure(get().status)) {
         const message =
-          "One-click Update needs Mako Desktop 0.3.9+ — fully quit and reopen so Local Agent restarts. " +
-          "If the adapter is already found, use Chat → Enable workspace tools (Update is optional).";
-        // Only surface when the user explicitly clicked Update/Install.
+          `One-click Update needs Mako Desktop ${ACP_REQUIRED_DESKTOP_VERSION}+. ` +
+          acpDesktopOutdatedSummary();
+        // Only surface when the user explicitly clicked Update/Install —
+        // the sticky Desktop-outdated banner already explains the path.
         if (options?.force) {
           set(s => {
             s.error = message;

--- a/docs/src/content/docs/coding-agents-acp.md
+++ b/docs/src/content/docs/coding-agents-acp.md
@@ -90,9 +90,13 @@ not need to restart Desktop for a single adapter crash.
 The Chat UI updates with every cloud deploy. The **Local Agent inside Desktop**
 only updates when a new Desktop release ships (or when you install a
 [desktop-canary](https://github.com/mako-ai/mako/releases/tag/desktop-canary)
-build from a PR). If Coding Agents features misbehave on an older Desktop,
-install the latest Desktop / canary — do not rely on `pnpm agent:start`
-unless you are developing the agent itself.
+build from a PR).
+
+**If Chat says Local Agent is outdated (or Update / model warm is disabled):**
+install Desktop **0.3.9+** (or the latest canary) → **fully quit** Mako
+(Cmd+Q / Quit — closing the window is not enough) → reopen → Chat →
+**Enable workspace tools**. Do not rely on `pnpm agent:start` unless you are
+developing the agent itself.
 
 ## Security notes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up on the ACP Coding Agents work (#1 + #2 from the remaining-improvements plan). Leaves native Chat parity (#3) for later.

### 1. Provider-correct HITL copy
- `AcpPermissionBanner` uses `acpProviderLabel()` from `acpStore` status (Codex → “Codex wants to run…”, Claude unchanged).
- Tool summary falls back to `title` / `name` / `kind` when `_meta.claudeCode` is missing (Codex).

### 2. Stale Local Agent / Desktop footgun
- First-class capability: missing `adapterEnsure` / `modelWarm` (or bridge &lt; 7) → `acpIsDesktopOutdatedForEnsureWarm`.
- Single sticky `AcpDesktopOutdatedBanner` in Chat + Settings with required Desktop **0.3.9+**, fully quit/reopen, then **Enable workspace tools**.
- Update / warm stay gated until capabilities present; bare `Not Found` / HTTP 404 rewritten everywhere in `acpClient` (never show raw 404 in Chat).
- Docs one-liner in `coding-agents-acp.md`.

### Out of scope
- #3 native Chat parity (guidance depth, memory tip UX, model picker warm polish, HITL polish, continuity).
- Auto-download Desktop / in-app Local Agent hot-reload.

## Test plan
- [x] `pnpm --filter app run typecheck`
- [x] `pnpm --filter app run lint`
- [x] Unit tests: capabilities, provider label, Not Found rewrite, CodingAgentsPanel
- [ ] Manual: select Codex → permission prompt says “Codex wants to run…”
- [ ] Manual: old Local Agent (no ensure/warm) → sticky upgrade banner; no “Not Found” in Chat; Update disabled

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef812b89-cb8e-4a7f-9f9f-fa391727dcb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef812b89-cb8e-4a7f-9f9f-fa391727dcb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

