### PR TITLE
fix(chat): stop clipping card shadows at the assistant row edges

### DIFF
--- a/app/src/components/chat/ChatMessageRow.tsx
+++ b/app/src/components/chat/ChatMessageRow.tsx
@@ -55,9 +55,18 @@ const userMessagePaperSx = {
 } as const;
 const assistantMessageSx = {
   flex: 1,
+  // The row must clip runaway-wide content (tables, code) — but a plain
+  // overflow:hidden box also clips the BUI card shadows (1px ring + 6px
+  // blur) of full-width children at its left/right edges. Same clip-box
+  // trick as Beautiful UI: pad the box 8px so shadows have room inside the
+  // clip, and pull it back with matching negative margins so alignment is
+  // unchanged (top: the 8px padding replaces the old mt: 1).
   overflow: "hidden",
+  p: "8px",
+  mx: "-8px",
+  mt: 0,
+  mb: "-8px",
   fontSize: "0.875rem",
-  mt: 1,
   "& pre": { margin: 0, overflow: "hidden" },
 } as const;
 const listItemSx = { p: 0 } as const;


### PR DESCRIPTION
## What

Follow-up to #797. The assistant message container uses `overflow: hidden` (required so runaway-wide content can't blow out the row), but that also sliced the BUI card shadows (1px hairline ring + 6px blur) of full-width children — visibly cut on the left/right edges of the plan card.

Fix is the standard clip-box trick (same one beautifului.dev uses in its own components): pad the container 8px so shadows have room inside the clip, and pull it back with matching negative margins so alignment is pixel-identical (the 8px top padding replaces the previous `mt: 1`).

## Verification

- Reproduced the clipped card, then confirmed the ring + blur render fully on both edges after the fix (light + dark, via the mocked-stream harness).
- `pnpm --filter app run typecheck`, full package lint, and all 55 chat component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)