### PR TITLE
feat(chat): show per-response cost on assistant messages

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -48,7 +48,11 @@ import {
 import { saveChat } from "../services/agent-thread.service";
 import { buildMcpToolsForChat } from "../services/mcp-client.service";
 import { trackUsage } from "../services/llm-usage.service";
-import { computeInvocationCost } from "../services/cost-calculator";
+import {
+  computeCostFromTokens,
+  computeInvocationCost,
+} from "../services/cost-calculator";
+import { lookupPricing } from "../services/gateway-pricing.service";
 import { generateChatTitle } from "../services/title-generator";
 import {
   isDescriptionGenAvailable,
@@ -1001,6 +1005,14 @@ agentRoutes.openapi(
           // segment.
           let turnStreamId: string | null = null;
 
+          // Pricing rows for the live per-response cost metadata below. The
+          // messageMetadata callback is synchronous, so resolve the (cached)
+          // gateway pricing up front. Empty rows → costUsd omitted, tokens
+          // still sent. Never let a pricing hiccup block the turn.
+          const metadataPricingRows = await lookupPricing(
+            resolvedModelId,
+          ).catch(() => []);
+
           const result = streamText({
             model,
             system: systemPrompt,
@@ -1083,6 +1095,40 @@ agentRoutes.openapi(
           const streamResponse = result.toUIMessageStreamResponse({
             originalMessages: segmentUiMessages,
             generateMessageId: () => new ObjectId().toString(),
+            // Per-response cost for the chat UI: on the finish part, price the
+            // segment's total usage with the prefetched gateway pricing. This
+            // lands in `message.metadata` client-side and survives resumable-
+            // stream replay. (Authoritative billing still happens in onFinish
+            // via computeInvocationCost, which prices per-step models; this
+            // display value prices totals at the resolved model — the two only
+            // diverge on multi-model turns.)
+            messageMetadata: ({ part }) => {
+              if (part.type !== "finish") return undefined;
+              const usage = part.totalUsage;
+              const tokens = {
+                inputTokens: toNum(usage?.inputTokens),
+                outputTokens: toNum(usage?.outputTokens),
+                cacheReadTokens: toNum(
+                  usage?.inputTokenDetails?.cacheReadTokens,
+                ),
+                cacheWriteTokens: toNum(
+                  usage?.inputTokenDetails?.cacheWriteTokens,
+                ),
+                reasoningTokens: toNum(
+                  usage?.outputTokenDetails?.reasoningTokens,
+                ),
+              };
+              const costUsd =
+                metadataPricingRows.length > 0
+                  ? computeCostFromTokens(tokens, metadataPricingRows)
+                  : undefined;
+              return {
+                costUsd,
+                modelId: resolvedModelId,
+                inputTokens: tokens.inputTokens,
+                outputTokens: tokens.outputTokens,
+              };
+            },
             // Replace the SDK's raw error text (for gateway auth failures a
             // misleading "configure AI_GATEWAY_API_KEY" message) with the
             // structured `{ code, message, ... }` JSON envelope. The client

--- a/app/src/components/chat-message-comparator.ts
+++ b/app/src/components/chat-message-comparator.ts
@@ -10,6 +10,10 @@ export interface ChatMessageRowProps {
     id: string;
     role: string;
     parts?: Array<Record<string, unknown>>;
+    /** Stream messageMetadata (live) or usage.history (reload) — see
+     * chat/response-cost.ts. Rides on the message object, so the comparator's
+     * reference check covers it. */
+    metadata?: unknown;
   };
   isLastMessage: boolean;
   isStreaming: boolean;

--- a/app/src/components/chat/ChatMessageRow.tsx
+++ b/app/src/components/chat/ChatMessageRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, List, ListItem, Paper } from "@mui/material";
+import { Box, List, ListItem, Paper, Tooltip } from "@mui/material";
 import { StreamingMarkdown } from "../StreamingMarkdown";
 import { StreamingToolCard, type ToolPartState } from "../StreamingToolCard";
 import { ClarifyingQuestionsCard } from "../ClarifyingQuestionsCard";
@@ -27,6 +27,13 @@ import {
 } from "./tool-presentation";
 import { ReasoningDisplay } from "./ReasoningDisplay";
 import { StreamingIndicator } from "./StreamingIndicator";
+import {
+  formatCostUsd,
+  formatTokenCount,
+  getResponseCostMetadata,
+  type ResponseCostMetadata,
+} from "./response-cost";
+import { BUI_MONO_FONT_FAMILY } from "./bui-styles";
 import { CollapsibleUserText } from "./CollapsibleUserText";
 import { ImagePreviewDialog } from "./ImagePreviewDialog";
 import { isRawMcpToolLabel } from "../../lib/local-acp-parts";
@@ -70,6 +77,45 @@ const assistantMessageSx = {
   "& pre": { margin: 0, overflow: "hidden" },
 } as const;
 const listItemSx = { p: 0 } as const;
+
+// Quiet per-response cost tag at the end of a finished assistant turn.
+// Memoized per the ChatMessageRow child rule (chat-performance).
+const ResponseCostTag = React.memo(function ResponseCostTag({
+  meta,
+}: {
+  meta: ResponseCostMetadata;
+}) {
+  const tooltip = [
+    meta.modelId,
+    meta.inputTokens != null && `${formatTokenCount(meta.inputTokens)} in`,
+    meta.outputTokens != null && `${formatTokenCount(meta.outputTokens)} out`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <Tooltip title={tooltip} placement="left">
+      <Box
+        component="span"
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          width: "fit-content",
+          mt: 0.75,
+          fontFamily: BUI_MONO_FONT_FAMILY,
+          fontSize: "11px",
+          color: "var(--bui-ink-3)",
+          fontVariantNumeric: "tabular-nums",
+          cursor: "default",
+          transition: "color 0.15s",
+          "&:hover": { color: "var(--bui-ink-2)" },
+          animation: "bui-fade-in 300ms ease-out both",
+        }}
+      >
+        {formatCostUsd(meta.costUsd ?? 0)}
+      </Box>
+    </Tooltip>
+  );
+});
 
 export const ChatMessageRow = React.memo(function ChatMessageRow({
   message,
@@ -411,6 +457,12 @@ export const ChatMessageRow = React.memo(function ChatMessageRow({
           return null;
         })}
         {isStreaming && isLastMessage && <StreamingIndicator />}
+        {(() => {
+          // Cost tag only once the turn is settled — never under the loader.
+          if (isStreaming && isLastMessage) return null;
+          const costMeta = getResponseCostMetadata(message);
+          return costMeta ? <ResponseCostTag meta={costMeta} /> : null;
+        })()}
       </Box>
     </ListItem>
   );

--- a/app/src/components/chat/convert-stored-messages.ts
+++ b/app/src/components/chat/convert-stored-messages.ts
@@ -8,12 +8,15 @@
  */
 
 import { isApprovalPendingState } from "./tool-presentation";
+import type { ResponseCostMetadata } from "./response-cost";
 
 /** Loose UIMessage shape accepted by useChat's setMessages. */
 export interface ConvertedUiMessage {
   id: string;
   role: string;
   parts: Array<Record<string, unknown>>;
+  /** Per-response cost from the chat's persisted usage.history. */
+  metadata?: ResponseCostMetadata;
 }
 
 /** Exported for the Local ACP resume path's incomplete-turn heuristic. */
@@ -42,6 +45,13 @@ export interface ConvertStoredMessagesOptions {
    * genuinely stuck once the turn goes quiet.
    */
   turnActive?: boolean;
+  /**
+   * Per-response cost from the persisted chat's `usage.history`, keyed by the
+   * assistant message's ordinal within the thread (saveChat's messageIndex).
+   * When present, matching assistant messages get it as `metadata` — the same
+   * shape live turns receive from the stream's messageMetadata.
+   */
+  costByAssistantOrdinal?: Map<number, ResponseCostMetadata>;
 }
 
 function convertStoredPart(
@@ -156,6 +166,14 @@ export function convertStoredMessages(
   rawMessages: unknown[] | null | undefined,
   opts?: ConvertStoredMessagesOptions,
 ): ConvertedUiMessage[] {
+  let assistantOrdinal = -1;
+  const costMetadata = (msg: any): Pick<ConvertedUiMessage, "metadata"> => {
+    if (msg.role !== "assistant") return {};
+    assistantOrdinal += 1;
+    const meta = opts?.costByAssistantOrdinal?.get(assistantOrdinal);
+    return meta ? { metadata: meta } : {};
+  };
+
   return (
     (rawMessages as any[] | null | undefined)?.map((msg: any) => {
       // NEW: If parts are stored, use them directly (preserves chronological order)
@@ -164,6 +182,7 @@ export function convertStoredMessages(
           id: msg.id || msg._id?.toString() || `${Date.now()}-${Math.random()}`,
           role: msg.role,
           parts: msg.parts.map((p: any) => convertStoredPart(p, opts)),
+          ...costMetadata(msg),
         };
       }
 
@@ -211,6 +230,7 @@ export function convertStoredMessages(
         id: msg._id?.toString() || msg.id || `${Date.now()}-${Math.random()}`,
         role: msg.role,
         parts,
+        ...costMetadata(msg),
       };
     }) || []
   );

--- a/app/src/components/chat/hooks/useChatSessionLoader.ts
+++ b/app/src/components/chat/hooks/useChatSessionLoader.ts
@@ -8,6 +8,7 @@ import { isLocalAcpModelId } from "../../../lib/local-acp-models";
 import { useConsoleStore } from "../../../store/consoleStore";
 import { useSettingsStore } from "../../../store/settingsStore";
 import { convertStoredMessages } from "../convert-stored-messages";
+import { buildCostByAssistantOrdinal } from "../response-cost";
 import type { ToolDispatchGate } from "../tool-dispatch-gate";
 
 type ChatHelpers = UseChatHelpers<UIMessage>;
@@ -211,6 +212,7 @@ export function useChatSessionLoader({
         consoles?: Array<{ id: string }>;
         activeStreamId?: string | null;
         localAcp?: LocalAcpChatBinding | null;
+        usage?: unknown;
       };
       if (chatIdRef.current !== targetChatId) return false;
 
@@ -260,6 +262,9 @@ export function useChatSessionLoader({
         {
           turnActive:
             Boolean(data.activeStreamId) || Boolean(localAcpBusyRef.current),
+          // Attach per-response cost from the persisted usage.history so
+          // historical assistant messages show their cost tag too.
+          costByAssistantOrdinal: buildCostByAssistantOrdinal(data.usage),
         },
       );
 

--- a/app/src/components/chat/response-cost.test.ts
+++ b/app/src/components/chat/response-cost.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCostByAssistantOrdinal,
+  formatCostUsd,
+  formatTokenCount,
+  getResponseCostMetadata,
+} from "./response-cost";
+import { convertStoredMessages } from "./convert-stored-messages";
+
+describe("formatCostUsd", () => {
+  it("uses 2 decimals from a cent up, 4 below", () => {
+    expect(formatCostUsd(0)).toBe("$0.00");
+    expect(formatCostUsd(0.0132)).toBe("$0.01");
+    expect(formatCostUsd(0.0032)).toBe("$0.0032");
+    expect(formatCostUsd(1.5)).toBe("$1.50");
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("abbreviates thousands and millions", () => {
+    expect(formatTokenCount(950)).toBe("950");
+    expect(formatTokenCount(12_400)).toBe("12.4k");
+    expect(formatTokenCount(2_100_000)).toBe("2.1M");
+  });
+});
+
+describe("getResponseCostMetadata", () => {
+  it("requires a finite numeric costUsd", () => {
+    expect(getResponseCostMetadata({})).toBeNull();
+    expect(getResponseCostMetadata({ metadata: { costUsd: "x" } })).toBeNull();
+    expect(getResponseCostMetadata({ metadata: { costUsd: NaN } })).toBeNull();
+    expect(
+      getResponseCostMetadata({ metadata: { costUsd: 0.01, modelId: "m" } }),
+    ).toEqual({ costUsd: 0.01, modelId: "m" });
+  });
+});
+
+describe("buildCostByAssistantOrdinal", () => {
+  it("maps usage.history entries by messageIndex", () => {
+    const map = buildCostByAssistantOrdinal({
+      history: [
+        {
+          messageIndex: 0,
+          costUsd: 0.002,
+          model: "openai/gpt-5.4-mini",
+          promptTokens: 1200,
+          completionTokens: 300,
+        },
+        { messageIndex: 2, costUsd: 0.01 },
+        { messageIndex: 3 }, // no cost — skipped
+      ],
+    });
+    expect(map.get(0)).toEqual({
+      costUsd: 0.002,
+      modelId: "openai/gpt-5.4-mini",
+      inputTokens: 1200,
+      outputTokens: 300,
+    });
+    expect(map.get(2)?.costUsd).toBe(0.01);
+    expect(map.has(3)).toBe(false);
+  });
+
+  it("tolerates missing/invalid usage", () => {
+    expect(buildCostByAssistantOrdinal(undefined).size).toBe(0);
+    expect(buildCostByAssistantOrdinal({}).size).toBe(0);
+    expect(buildCostByAssistantOrdinal({ history: "nope" }).size).toBe(0);
+  });
+});
+
+describe("convertStoredMessages cost attachment", () => {
+  it("attaches metadata to assistant messages by ordinal, skipping users", () => {
+    const messages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "yo" }] },
+      { id: "u2", role: "user", parts: [{ type: "text", text: "more" }] },
+      { id: "a2", role: "assistant", parts: [{ type: "text", text: "sure" }] },
+    ];
+    const converted = convertStoredMessages(messages, {
+      costByAssistantOrdinal: new Map([
+        [0, { costUsd: 0.001 }],
+        [1, { costUsd: 0.002 }],
+      ]),
+    });
+    expect(converted[0].metadata).toBeUndefined();
+    expect(converted[1].metadata).toEqual({ costUsd: 0.001 });
+    expect(converted[2].metadata).toBeUndefined();
+    expect(converted[3].metadata).toEqual({ costUsd: 0.002 });
+  });
+
+  it("leaves messages untouched without a cost map", () => {
+    const converted = convertStoredMessages([
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "yo" }] },
+    ]);
+    expect(converted[0].metadata).toBeUndefined();
+  });
+});

--- a/app/src/components/chat/response-cost.ts
+++ b/app/src/components/chat/response-cost.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-response cost metadata for assistant messages.
+ *
+ * Two producers, one shape:
+ *  - Live turns: the chat stream's `messageMetadata` (server-priced on the
+ *    finish part) lands on `message.metadata` via the AI SDK.
+ *  - History: `GET /chats/{id}` returns `usage.history[]` keyed by assistant
+ *    ordinal; the session loader attaches the same shape during conversion.
+ */
+
+export interface ResponseCostMetadata {
+  costUsd?: number;
+  modelId?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+/** Extract cost metadata from a UIMessage, tolerating unknown shapes. */
+export function getResponseCostMetadata(message: {
+  metadata?: unknown;
+}): ResponseCostMetadata | null {
+  const meta = message.metadata as ResponseCostMetadata | undefined;
+  if (!meta || typeof meta !== "object") return null;
+  if (typeof meta.costUsd !== "number" || !Number.isFinite(meta.costUsd)) {
+    return null;
+  }
+  return meta;
+}
+
+/** "$0.0132" under a cent, "$0.04" above — always parseable at a glance. */
+export function formatCostUsd(costUsd: number): string {
+  if (costUsd >= 0.01 || costUsd === 0) return `$${costUsd.toFixed(2)}`;
+  return `$${costUsd.toFixed(4)}`;
+}
+
+/** "12.4k" style token counts for the tooltip. */
+export function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`;
+  return String(tokens);
+}
+
+/**
+ * Build the assistant-ordinal → cost map from a persisted chat's
+ * `usage.history` (the shape saved by the API's saveChat).
+ */
+export function buildCostByAssistantOrdinal(
+  usage: unknown,
+): Map<number, ResponseCostMetadata> {
+  const map = new Map<number, ResponseCostMetadata>();
+  const history = (
+    usage as { history?: Array<Record<string, unknown>> } | undefined
+  )?.history;
+  if (!Array.isArray(history)) return map;
+  for (const entry of history) {
+    const index = entry.messageIndex;
+    const costUsd = entry.costUsd;
+    if (typeof index !== "number" || typeof costUsd !== "number") continue;
+    map.set(index, {
+      costUsd,
+      modelId: typeof entry.model === "string" ? entry.model : undefined,
+      inputTokens:
+        typeof entry.promptTokens === "number" ? entry.promptTokens : undefined,
+      outputTokens:
+        typeof entry.completionTokens === "number"
+          ? entry.completionTokens
+          : undefined,
+    });
+  }
+  return map;
+}


### PR DESCRIPTION
## What

Displays the cost of each assistant response in the chat UI: a quiet mono tag (`$0.0032` / `$0.01`) at the end of every settled assistant turn, with a tooltip showing the model id and in/out token counts.

The server already computes and persists per-turn cost (`LlmUsage` + `Chat.usage.history` → Stripe meter); this PR only adds transport to the client, via two paths sharing one metadata shape (`{ costUsd, modelId, inputTokens, outputTokens }`):

- **Live turns**: `agent.routes.ts` adds a `messageMetadata` callback to `toUIMessageStreamResponse` — on the `finish` part it prices the segment's `totalUsage` with prefetched (cached) gateway pricing, synchronously. Lands in `message.metadata` on the client and survives resumable-stream replay. Authoritative billing is untouched (`onFinish` → `computeInvocationCost`, which prices per-step models; the display value prices totals at the resolved model — divergence only on multi-model turns).
- **History**: the session loader keeps the chat payload's `usage.history` (previously discarded) and attaches costs to assistant messages by ordinal during conversion — so **every past cloud chat shows costs immediately**, no backfill needed. Local-ACP chats have no usage data and gracefully show nothing.

Perf: metadata rides on the message object, so `ChatMessageRow`'s reference-equality memo comparator covers the live update with no changes; the tag component is `React.memo`-wrapped per the chat-performance rules, and never renders under the streaming indicator.

## Verification

- Real end-to-end turn (no mocks): sent a message on `openai/gpt-5.4-mini`, tag appeared on finish (`$0.01`), then **reloaded** — tag re-rendered from persisted `usage.history` with tooltip `openai/gpt-5.4-mini · 16.3k in · 7 out`.
- New unit tests for formatting, the `usage.history` mapping, and ordinal attachment (7 tests); full chat suite passes (62 total), app typecheck + lint clean, api build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)