### PR TITLE
feat(apps): per-app warehouse cost block (BigQuery guilt meter)

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1159,6 +1159,11 @@ export interface IQueryExecution extends Document {
   // Optional console tracking
   consoleId?: Types.ObjectId; // If executed from a saved console
 
+  // Optional app attribution (app-editor previews, published-app viewers,
+  // binding materialization builds) — group-by keys for per-app cost.
+  appId?: Types.ObjectId;
+  bindingId?: string; // Stable IMakoAppDataBinding.id
+
   // Execution context
   source:
     | "console_ui"
@@ -1167,7 +1172,10 @@ export interface IQueryExecution extends Document {
     | "mcp"
     | "agent"
     | "flow"
-    | "scheduled_query";
+    | "scheduled_query"
+    | "app_runtime"
+    | "app_public"
+    | "materialization";
   databaseType: string; // postgresql, mongodb, bigquery, etc.
   queryLanguage: "sql" | "mongodb" | "javascript";
 
@@ -1179,6 +1187,7 @@ export interface IQueryExecution extends Document {
 
   // Optional resource tracking (some DBs provide this)
   bytesScanned?: number; // BigQuery, ClickHouse report this
+  cacheHit?: boolean; // Engine served from cache (no scan billed)
 }
 
 export interface IConnectionVerification extends Document {
@@ -2938,6 +2947,14 @@ const QueryExecutionSchema = new Schema<IQueryExecution>(
       required: false,
     },
 
+    // Optional app attribution (per-app cost)
+    appId: {
+      type: Schema.Types.ObjectId,
+      ref: "MakoApp",
+      required: false,
+    },
+    bindingId: { type: String, required: false },
+
     // Execution context
     source: {
       type: String,
@@ -2949,6 +2966,9 @@ const QueryExecutionSchema = new Schema<IQueryExecution>(
         "agent",
         "flow",
         "scheduled_query",
+        "app_runtime",
+        "app_public",
+        "materialization",
       ],
       required: true,
     },
@@ -2971,6 +2991,7 @@ const QueryExecutionSchema = new Schema<IQueryExecution>(
 
     // Optional resource tracking
     bytesScanned: { type: Number, required: false },
+    cacheHit: { type: Boolean, required: false },
   },
   {
     collection: "query_executions",
@@ -2987,6 +3008,10 @@ QueryExecutionSchema.index(
   { workspaceId: 1, consoleId: 1, executedAt: -1 },
   { sparse: true, name: "query_executions_workspace_console_executed" },
 ); // Per-console recent runs
+QueryExecutionSchema.index(
+  { workspaceId: 1, appId: 1, executedAt: -1 },
+  { sparse: true, name: "query_executions_workspace_app_executed" },
+); // Per-app cost aggregation
 QueryExecutionSchema.index({ executedAt: 1 }, { expireAfterSeconds: 7776000 }); // TTL: 90 days
 
 const ScheduledQueryRunSchema = new Schema<IScheduledQueryRun>(

--- a/api/src/migrations/2026-08-20-100000_query_executions_app_index.ts
+++ b/api/src/migrations/2026-08-20-100000_query_executions_app_index.ts
@@ -1,0 +1,47 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Index query_executions by workspaceId + appId + executedAt for per-app cost aggregation";
+
+function hasIndexOnKeys(
+  indexes: Array<{ key?: Record<string, unknown> }>,
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key ?? {}) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collection = db.collection("query_executions");
+  const keyPattern = { workspaceId: 1, appId: 1, executedAt: -1 };
+
+  try {
+    const existingIndexes = await collection.indexes();
+    if (hasIndexOnKeys(existingIndexes, keyPattern)) {
+      log.info(
+        "Index { workspaceId: 1, appId: 1, executedAt: -1 } already exists on query_executions",
+      );
+      return;
+    }
+
+    await collection.createIndex(keyPattern, {
+      name: "query_executions_workspace_app_executed",
+      background: true,
+      sparse: true,
+    });
+    log.info(
+      "Created sparse index { workspaceId: 1, appId: 1, executedAt: -1 } on query_executions",
+    );
+  } catch (err: unknown) {
+    const code = (err as { code?: number; codeName?: string })?.code;
+    const codeName = (err as { codeName?: string })?.codeName;
+    if (code === 85 || codeName === "IndexOptionsConflict") {
+      log.info("Index already exists under a different name, skipping");
+      return;
+    }
+    throw err;
+  }
+}

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -21,6 +21,8 @@ import {
   type IMakoApp,
 } from "../database/workspace-schema";
 import { loggers, enrichContextWithWorkspace } from "../logging";
+import { queryExecutionService } from "../services/query-execution.service";
+import { estimateWarehouseCostUsd } from "../services/warehouse-pricing";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
@@ -508,6 +510,70 @@ app.openapi(
     } catch (error) {
       logger.error("Error fetching app", { error });
       return c.json({ success: false, error: "Failed to fetch app" }, 500);
+    }
+  },
+);
+
+// GET /:id/cost — per-app warehouse usage/cost ("guilt meter").
+// Windows: 24h / 7d / 90d (the query_executions TTL bounds history at 90d).
+// Cost is estimated from bytes scanned; only per-query-metered engines get a
+// dollar figure (BigQuery on-demand); others report runs/duration only.
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/cost",
+    tags: ["Apps"],
+    summary: "Get an app's warehouse usage and estimated cost",
+    security: AUTH_SECURITY,
+    request: { params: AppIdParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const userId = c.get("user")?.id;
+
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      }).select("_id workspaceId createdBy sharedWith visibility");
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      const memberRole = c.get("memberRole");
+      if (!canRead(doc, userId, memberRole)) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const summary = await queryExecutionService.getAppUsageSummary(
+        workspaceId,
+        id,
+      );
+
+      const priceWindow = (w: (typeof summary)["last24h"]) => ({
+        byEngine: w.byEngine.map(e => ({
+          ...e,
+          estimatedCostUsd: estimateWarehouseCostUsd(
+            e.databaseType,
+            e.bytesScanned,
+          ),
+        })),
+      });
+
+      return c.json({
+        success: true,
+        cost: {
+          last24h: priceWindow(summary.last24h),
+          last7d: priceWindow(summary.last7d),
+          last90d: priceWindow(summary.last90d),
+        },
+      });
+    } catch (error) {
+      logger.error("Error fetching app cost", { error });
+      return c.json({ success: false, error: "Failed to fetch app cost" }, 500);
     }
   },
 );

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -1992,6 +1992,8 @@ workspaceExecuteRoutes.openapi(
         executionId,
         consoleId,
         source,
+        appId,
+        bindingId,
         mode,
         pageSize,
         cursor,
@@ -2172,13 +2174,32 @@ workspaceExecuteRoutes.openapi(
       // Track query execution (fire-and-forget)
       const userId = user?.id || apiKey?.createdBy;
       if (userId && database) {
-        // Determine source: API key auth = "api", otherwise check body or default to "console_ui"
+        // Determine source: API key auth = "api", otherwise check body or
+        // default to "console_ui". Client-sent values are validated against
+        // the known sources — an unknown string used to make the Mongoose
+        // save throw (and be swallowed), silently dropping the row.
+        const clientSources: ReadonlySet<QuerySource> = new Set([
+          "console_ui",
+          "app_runtime",
+        ]);
         let executionSource: QuerySource = apiKey
           ? "api"
-          : source || "console_ui";
+          : clientSources.has(source as QuerySource)
+            ? (source as QuerySource)
+            : "console_ui";
         if (usedAdminPreviewOverride && !apiKey) {
           executionSource = "console_ui_admin_override";
         }
+
+        // App attribution (app-editor binding runs send these)
+        const validAppId =
+          typeof appId === "string" && Types.ObjectId.isValid(appId)
+            ? new Types.ObjectId(appId)
+            : undefined;
+        const validBindingId =
+          typeof bindingId === "string" && bindingId.length > 0
+            ? bindingId.slice(0, 200)
+            : undefined;
 
         // Validate consoleId before converting to ObjectId
         let validConsoleId: Types.ObjectId | undefined;
@@ -2196,6 +2217,12 @@ workspaceExecuteRoutes.openapi(
           }
         }
 
+        // Bytes-scanned / cache stats when the engine reports them (BigQuery)
+        const resultStats = result as {
+          bytesProcessed?: number;
+          cacheHit?: boolean;
+        };
+
         queryExecutionService.track({
           userId,
           apiKeyId: apiKey?._id,
@@ -2203,6 +2230,8 @@ workspaceExecuteRoutes.openapi(
           connectionId: database._id,
           databaseName: databaseName || database.connection.database,
           consoleId: validConsoleId,
+          appId: validAppId,
+          bindingId: validBindingId,
           source: executionSource,
           databaseType: database.type,
           queryLanguage: getQueryLanguage(database.type),
@@ -2210,6 +2239,8 @@ workspaceExecuteRoutes.openapi(
           executionTimeMs: Date.now() - startTime,
           rowCount,
           errorType,
+          bytesScanned: resultStats.bytesProcessed,
+          cacheHit: resultStats.cacheHit,
         });
 
         // When a saved console id is provided, keep console execution stats

--- a/api/src/services/app-binding-materialization.service.ts
+++ b/api/src/services/app-binding-materialization.service.ts
@@ -575,6 +575,12 @@ export async function materializeAppBinding(input: {
         rowLimit: PARQUET_ROW_LIMIT,
         filenameBase: `app-${appId}-${bindingId}`,
         schemaProbe: schemaProbeMode(binding),
+        tracking: {
+          workspaceId: appDoc.workspaceId,
+          userId: appDoc.createdBy,
+          appId: appDoc._id,
+          bindingId,
+        },
       });
       await storeParquetArtifactFile({
         filePath: parquet.filePath,

--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -41,6 +41,12 @@ export interface QueryResult {
   error?: string;
   rowCount?: number;
   fields?: any[];
+  /** Bytes the engine reports scanning (BigQuery totalBytesProcessed).
+   * Basis for warehouse cost attribution; engines without per-query
+   * metering leave it undefined. */
+  bytesProcessed?: number;
+  /** True when the engine served the result from its own cache (no scan). */
+  cacheHit?: boolean;
 }
 
 export interface QueryPreviewResult {
@@ -51,6 +57,10 @@ export interface QueryPreviewResult {
   fields?: Array<{ name: string; type?: string }>;
   pageInfo?: PreviewPageInfo;
   warnings?: string[];
+  /** See QueryResult.bytesProcessed — BigQuery bills the full scan even for
+   * LIMITed previews, so preview runs carry cost too. */
+  bytesProcessed?: number;
+  cacheHit?: boolean;
 }
 
 // Types for different connection contexts
@@ -1550,6 +1560,19 @@ export class DatabaseConnectionService {
       let schema: any = data.schema;
       let pageToken: string | undefined = data.pageToken;
       const rowsAccum: any[] = [];
+      // Job statistics for cost attribution — present on the query/getQueryResults
+      // responses; capture whenever reported (pagination pages may omit them).
+      let bytesProcessed: number | undefined;
+      let cacheHit: boolean | undefined;
+      const captureJobStats = (d: any) => {
+        const raw = d?.totalBytesProcessed;
+        const parsed = typeof raw === "string" ? Number(raw) : raw;
+        if (typeof parsed === "number" && Number.isFinite(parsed)) {
+          bytesProcessed = parsed;
+        }
+        if (typeof d?.cacheHit === "boolean") cacheHit = d.cacheHit;
+      };
+      captureJobStats(data);
 
       // Track running job for cancellation
       if (executionId && jobId) {
@@ -1590,6 +1613,7 @@ export class DatabaseConnectionService {
           { params },
         );
         data = response.data || {};
+        captureJobStats(data);
         schema = data.schema || schema;
       }
 
@@ -1635,6 +1659,7 @@ export class DatabaseConnectionService {
           { params },
         );
         data = response.data || {};
+        captureJobStats(data);
         schema = data.schema || schema;
         if (Array.isArray(data.rows) && schema) {
           rowsAccum.push(...this.bqMapRowsToObjects(data.rows, schema));
@@ -1642,7 +1667,13 @@ export class DatabaseConnectionService {
         pageToken = data.pageToken;
       }
 
-      return { success: true, data: rowsAccum, rowCount: rowsAccum.length };
+      return {
+        success: true,
+        data: rowsAccum,
+        rowCount: rowsAccum.length,
+        bytesProcessed,
+        cacheHit,
+      };
     } catch (error: any) {
       if (error?.message === "Query cancelled") {
         return { success: false, error: "Query cancelled" };
@@ -1668,6 +1699,16 @@ export class DatabaseConnectionService {
     }
 
     const decodedCursor = decodePreviewCursor(options?.cursor);
+    let previewBytesProcessed: number | undefined;
+    let previewCacheHit: boolean | undefined;
+    const capturePreviewStats = (d: any) => {
+      const raw = d?.totalBytesProcessed;
+      const parsed = typeof raw === "string" ? Number(raw) : raw;
+      if (typeof parsed === "number" && Number.isFinite(parsed)) {
+        previewBytesProcessed = parsed;
+      }
+      if (typeof d?.cacheHit === "boolean") previewCacheHit = d.cacheHit;
+    };
     const queryHash = hashPreviewQuery(baseQuery);
     if (decodedCursor && decodedCursor.queryHash !== queryHash) {
       return {
@@ -1736,6 +1777,7 @@ export class DatabaseConnectionService {
           },
         );
         data = response.data || {};
+        capturePreviewStats(data);
       } else {
         const startBody: any = {
           query: baseQuery,
@@ -1751,6 +1793,7 @@ export class DatabaseConnectionService {
           startBody,
         );
         data = response.data || {};
+        capturePreviewStats(data);
         jobId = data.jobReference?.jobId;
         jobLocation = data.jobReference?.location || configuredLocation;
       }
@@ -1789,6 +1832,7 @@ export class DatabaseConnectionService {
           },
         );
         data = response.data || {};
+        capturePreviewStats(data);
       }
 
       checkAborted();
@@ -1818,6 +1862,8 @@ export class DatabaseConnectionService {
         rowCount: rows.length,
         fields,
         warnings: safety.warnings,
+        bytesProcessed: previewBytesProcessed,
+        cacheHit: previewCacheHit,
         pageInfo: {
           pageSize,
           hasMore: Boolean(nextPageToken),
@@ -1853,9 +1899,25 @@ export class DatabaseConnectionService {
     database: IDatabaseConnection,
     query: string,
     options: StreamingQueryOptions & QueryExecuteOptions,
-  ): Promise<{ success: boolean; totalRows: number; error?: string }> {
+  ): Promise<{
+    success: boolean;
+    totalRows: number;
+    error?: string;
+    bytesProcessed?: number;
+    cacheHit?: boolean;
+  }> {
     const executionId = options.executionId;
     const signal = options.signal;
+    let streamBytesProcessed: number | undefined;
+    let streamCacheHit: boolean | undefined;
+    const captureStreamStats = (d: any) => {
+      const raw = d?.totalBytesProcessed;
+      const parsed = typeof raw === "string" ? Number(raw) : raw;
+      if (typeof parsed === "number" && Number.isFinite(parsed)) {
+        streamBytesProcessed = parsed;
+      }
+      if (typeof d?.cacheHit === "boolean") streamCacheHit = d.cacheHit;
+    };
 
     const checkAborted = () => {
       if (signal?.aborted) throw new Error("Query cancelled");
@@ -1910,6 +1972,7 @@ export class DatabaseConnectionService {
         startBody,
       );
       let data = response.data || {};
+      captureStreamStats(data);
       const jobId: string | undefined = data.jobReference?.jobId;
       const jobLocation: string | undefined =
         data.jobReference?.location || configuredLocation;
@@ -1946,6 +2009,7 @@ export class DatabaseConnectionService {
           },
         );
         data = response.data || {};
+        captureStreamStats(data);
         schema = data.schema || schema;
       }
 
@@ -1983,6 +2047,7 @@ export class DatabaseConnectionService {
           },
         );
         data = response.data || {};
+        captureStreamStats(data);
         schema = data.schema || schema;
 
         const rows =
@@ -1999,7 +2064,12 @@ export class DatabaseConnectionService {
         pageToken = data.pageToken;
       }
 
-      return { success: true, totalRows };
+      return {
+        success: true,
+        totalRows,
+        bytesProcessed: streamBytesProcessed,
+        cacheHit: streamCacheHit,
+      };
     } catch (error: any) {
       if (error?.message === "Query cancelled") {
         return { success: false, totalRows, error: "Query cancelled" };

--- a/api/src/services/parquet-build.service.ts
+++ b/api/src/services/parquet-build.service.ts
@@ -14,7 +14,9 @@
  */
 
 import { promises as fsPromises } from "fs";
+import type { Types } from "mongoose";
 import type { IDatabaseConnection } from "../database/workspace-schema";
+import { queryExecutionService } from "./query-execution.service";
 import {
   buildParquetFromBatches,
   type FieldMeta,
@@ -82,6 +84,15 @@ export interface BuildQueryParquetFileInput {
   schemaProbe?: "strict" | "lenient";
   /** Progress callback per inserted batch (heartbeats, run events). */
   onBatchInserted?: (totalRows: number) => Promise<void>;
+  /** When set, the streaming execution is recorded in query_executions for
+   * warehouse cost attribution (materialization builds are the largest
+   * BigQuery consumers and were previously invisible). */
+  tracking?: {
+    workspaceId: Types.ObjectId | string;
+    userId: string;
+    appId?: Types.ObjectId | string;
+    bindingId?: string;
+  };
 }
 
 export interface BuiltParquetFile {
@@ -150,6 +161,7 @@ export async function buildQueryParquetFile(
     fields,
     onBatchInserted,
     streamBatches: async insertBatch => {
+      const startedAt = Date.now();
       const streamResult =
         await databaseConnectionService.executeStreamingQuery(
           connection,
@@ -162,6 +174,26 @@ export async function buildQueryParquetFile(
             readOnly: enforceReadOnly,
           },
         );
+      if (input.tracking) {
+        queryExecutionService.track({
+          userId: input.tracking.userId,
+          workspaceId: input.tracking.workspaceId,
+          connectionId: connection._id,
+          databaseName: databaseName ?? undefined,
+          appId: input.tracking.appId,
+          bindingId: input.tracking.bindingId,
+          source: "materialization",
+          databaseType: connection.type,
+          queryLanguage: "sql",
+          status: streamResult.success ? "success" : "error",
+          executionTimeMs: Date.now() - startedAt,
+          rowCount: streamResult.success ? streamResult.totalRows : undefined,
+          errorType: streamResult.success ? undefined : "unknown",
+          bytesScanned: (streamResult as { bytesProcessed?: number })
+            .bytesProcessed,
+          cacheHit: (streamResult as { cacheHit?: boolean }).cacheHit,
+        });
+      }
       // A mid-stream failure must fail the build — otherwise a silently
       // truncated (or empty) artifact would be reported as "ready".
       if (!streamResult.success) {

--- a/api/src/services/public-live-query.service.ts
+++ b/api/src/services/public-live-query.service.ts
@@ -28,6 +28,7 @@ import {
 import { buildAppSnapshot, type AppSnapshot } from "./app-version.service";
 import { resolveDbtBoundCode } from "../dbt/dbt-environments.service";
 import { databaseConnectionService } from "./database-connection.service";
+import { queryExecutionService } from "./query-execution.service";
 import {
   applySqlRowLimit,
   checkPreviewQuerySafety,
@@ -308,6 +309,7 @@ async function executeAppBindingCore(input: {
     controller.abort();
     void databaseConnectionService.cancelQuery(executionId).catch(() => {});
   }, timeoutMs);
+  const startedAt = Date.now();
   let result;
   try {
     result = await databaseConnectionService.executeQuery(
@@ -324,6 +326,27 @@ async function executeAppBindingCore(input: {
   } finally {
     clearTimeout(timer);
   }
+
+  // Per-app cost attribution. Public viewers are anonymous, so the row is
+  // attributed to the app owner. Cache hits above never reach this point —
+  // they cost nothing and are not recorded.
+  queryExecutionService.track({
+    userId: app.createdBy,
+    workspaceId: app.workspaceId,
+    connectionId: connection._id,
+    databaseName: binding.databaseName ?? undefined,
+    appId: app._id,
+    bindingId,
+    source: "app_public",
+    databaseType: connection.type,
+    queryLanguage: "sql",
+    status: result.success ? "success" : timedOut ? "timeout" : "error",
+    executionTimeMs: Date.now() - startedAt,
+    rowCount: result.success ? result.rowCount : undefined,
+    errorType: result.success ? undefined : timedOut ? "timeout" : "unknown",
+    bytesScanned: result.bytesProcessed,
+    cacheHit: result.cacheHit,
+  });
 
   if (!result.success) {
     logger.warn("Public live query failed", {

--- a/api/src/services/query-execution.service.ts
+++ b/api/src/services/query-execution.service.ts
@@ -14,7 +14,10 @@ export type QuerySource =
   | "mcp"
   | "agent"
   | "flow"
-  | "scheduled_query";
+  | "scheduled_query"
+  | "app_runtime"
+  | "app_public"
+  | "materialization";
 
 /**
  * Query execution status types
@@ -42,6 +45,10 @@ export interface TrackQueryExecutionInput {
   // Optional console tracking
   consoleId?: Types.ObjectId | string;
 
+  // Optional app attribution (per-app cost)
+  appId?: Types.ObjectId | string;
+  bindingId?: string;
+
   // Execution context
   source: QuerySource;
   databaseType: string;
@@ -55,6 +62,23 @@ export interface TrackQueryExecutionInput {
 
   // Optional resource tracking
   bytesScanned?: number;
+  cacheHit?: boolean;
+}
+
+export interface AppUsageWindow {
+  byEngine: Array<{
+    databaseType: string;
+    runs: number;
+    bytesScanned: number;
+    executionTimeMs: number;
+    errors: number;
+  }>;
+}
+
+export interface AppUsageSummary {
+  last24h: AppUsageWindow;
+  last7d: AppUsageWindow;
+  last90d: AppUsageWindow;
 }
 
 /**
@@ -93,6 +117,10 @@ export class QueryExecutionService {
         consoleId: input.consoleId
           ? new Types.ObjectId(input.consoleId.toString())
           : undefined,
+        appId: input.appId
+          ? new Types.ObjectId(input.appId.toString())
+          : undefined,
+        bindingId: input.bindingId,
         source: input.source,
         databaseType: input.databaseType,
         queryLanguage: input.queryLanguage,
@@ -101,6 +129,7 @@ export class QueryExecutionService {
         rowCount: input.rowCount,
         errorType: input.errorType,
         bytesScanned: input.bytesScanned,
+        cacheHit: input.cacheHit,
       });
 
       await execution.save();
@@ -200,6 +229,72 @@ export class QueryExecutionService {
       .lean();
 
     return executions as IQueryExecution[];
+  }
+
+  /**
+   * Per-app warehouse usage over the standard guilt-meter windows.
+   * "Total" is bounded by the collection's 90-day TTL — label it as such.
+   * Costs are computed by the caller (pricing is engine-specific).
+   */
+  async getAppUsageSummary(
+    workspaceId: Types.ObjectId | string,
+    appId: Types.ObjectId | string,
+  ): Promise<AppUsageSummary> {
+    const now = Date.now();
+    const match = {
+      workspaceId: new Types.ObjectId(workspaceId.toString()),
+      appId: new Types.ObjectId(appId.toString()),
+    };
+
+    const windowPipeline = (since: Date | null) => [
+      ...(since ? [{ $match: { executedAt: { $gte: since } } }] : []),
+      {
+        $group: {
+          _id: "$databaseType",
+          runs: { $sum: 1 },
+          bytesScanned: { $sum: { $ifNull: ["$bytesScanned", 0] } },
+          executionTimeMs: { $sum: { $ifNull: ["$executionTimeMs", 0] } },
+          errors: {
+            $sum: { $cond: [{ $eq: ["$status", "error"] }, 1, 0] },
+          },
+        },
+      },
+    ];
+
+    const [facets] = await QueryExecution.aggregate([
+      { $match: match },
+      {
+        $facet: {
+          last24h: windowPipeline(new Date(now - 24 * 3600 * 1000)),
+          last7d: windowPipeline(new Date(now - 7 * 24 * 3600 * 1000)),
+          last90d: windowPipeline(null),
+        },
+      },
+    ]);
+
+    const toWindow = (
+      rows: Array<{
+        _id: string;
+        runs: number;
+        bytesScanned: number;
+        executionTimeMs: number;
+        errors: number;
+      }>,
+    ): AppUsageWindow => ({
+      byEngine: rows.map(r => ({
+        databaseType: r._id,
+        runs: r.runs,
+        bytesScanned: r.bytesScanned,
+        executionTimeMs: r.executionTimeMs,
+        errors: r.errors,
+      })),
+    });
+
+    return {
+      last24h: toWindow(facets?.last24h ?? []),
+      last7d: toWindow(facets?.last7d ?? []),
+      last90d: toWindow(facets?.last90d ?? []),
+    };
   }
 
   async getWorkspaceUsageSummary(

--- a/api/src/services/warehouse-pricing.ts
+++ b/api/src/services/warehouse-pricing.ts
@@ -1,0 +1,28 @@
+/**
+ * Warehouse cost estimation from bytes scanned.
+ *
+ * Only per-query-metered engines get a dollar figure; provisioned engines
+ * (Postgres, MySQL, MongoDB, …) have no per-query price and return null.
+ * Rates are list-price constants — good enough for a guilt meter, clearly
+ * labeled "estimated" in the UI. Region/edition discounts are ignored.
+ */
+
+const BYTES_PER_TIB = 1024 ** 4;
+
+/** BigQuery on-demand analysis, USD per TiB scanned (US multi-region list). */
+const BIGQUERY_USD_PER_TIB = 6.25;
+
+export function estimateWarehouseCostUsd(
+  databaseType: string,
+  bytesScanned: number,
+): number | null {
+  if (!Number.isFinite(bytesScanned) || bytesScanned <= 0) {
+    return databaseType === "bigquery" ? 0 : null;
+  }
+  switch (databaseType) {
+    case "bigquery":
+      return (bytesScanned / BYTES_PER_TIB) * BIGQUERY_USD_PER_TIB;
+    default:
+      return null;
+  }
+}

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3215,6 +3215,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/cost": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an app's warehouse usage and estimated cost */
+        get: operations["get_api_workspaces_workspaceId_apps_id_cost"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/bindings/{bindingId}/materialize": {
         parameters: {
             query?: never;
@@ -15556,6 +15573,47 @@ export interface operations {
         };
     };
     delete_api_workspaces_workspaceId_apps_id: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_cost: {
         parameters: {
             query?: never;
             header?: never;

--- a/app/src/components/AppCostChip.tsx
+++ b/app/src/components/AppCostChip.tsx
@@ -1,0 +1,248 @@
+/**
+ * AppCostChip — the app's warehouse "guilt meter".
+ *
+ * A quiet toolbar chip showing the last-7-days estimated warehouse cost for
+ * this app's queries (editor previews, published viewers, materialization
+ * builds), with a popover breaking down 24h / 7d / 90d per engine. Only
+ * per-query-metered engines (BigQuery) carry a dollar figure; provisioned
+ * engines show run counts. Tracking is prospective — the meter starts at
+ * zero when cost capture shipped, and history is bounded by the 90-day
+ * retention of query executions.
+ */
+import React from "react";
+import { Box, ButtonBase, Popover, Tooltip } from "@mui/material";
+import { CircleDollarSign } from "lucide-react";
+import { api } from "../api/client";
+import { BUI_MONO_FONT_FAMILY } from "./chat/bui-styles";
+import { formatCostUsd } from "./chat/response-cost";
+
+interface EngineUsage {
+  databaseType: string;
+  runs: number;
+  bytesScanned: number;
+  executionTimeMs: number;
+  errors: number;
+  estimatedCostUsd: number | null;
+}
+
+interface CostWindow {
+  byEngine: EngineUsage[];
+}
+
+interface AppCost {
+  last24h: CostWindow;
+  last7d: CostWindow;
+  last90d: CostWindow;
+}
+
+function windowCostUsd(w: CostWindow): number | null {
+  let total: number | null = null;
+  for (const e of w.byEngine) {
+    if (typeof e.estimatedCostUsd === "number") {
+      total = (total ?? 0) + e.estimatedCostUsd;
+    }
+  }
+  return total;
+}
+
+function windowRuns(w: CostWindow): number {
+  return w.byEngine.reduce((n, e) => n + e.runs, 0);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(2)} TiB`;
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+  return `${bytes} B`;
+}
+
+const WINDOWS = [
+  { key: "last24h", label: "24h" },
+  { key: "last7d", label: "7d" },
+  { key: "last90d", label: "90d" },
+] as const;
+
+export const AppCostChip = React.memo(function AppCostChip({
+  workspaceId,
+  appId,
+}: {
+  workspaceId: string;
+  appId: string;
+}) {
+  const [cost, setCost] = React.useState<AppCost | null>(null);
+  const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await api.GET(
+          "/api/workspaces/{workspaceId}/apps/{id}/cost",
+          { params: { path: { workspaceId, id: appId } } },
+        );
+        const payload = result.data as
+          | { success?: boolean; cost?: AppCost }
+          | undefined;
+        if (!cancelled && payload?.success && payload.cost) {
+          setCost(payload.cost);
+        }
+      } catch {
+        // Guilt meter is best-effort chrome — never surface fetch errors.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, appId]);
+
+  if (!cost || windowRuns(cost.last90d) === 0) return null;
+
+  const cost7d = windowCostUsd(cost.last7d);
+  const chipLabel =
+    cost7d != null
+      ? `${formatCostUsd(cost7d)} · 7d`
+      : `${windowRuns(cost.last7d)} runs · 7d`;
+
+  return (
+    <>
+      <Tooltip title="Warehouse usage for this app — click for the breakdown">
+        <ButtonBase
+          onClick={e => setAnchor(e.currentTarget)}
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 0.5,
+            height: 24,
+            px: 1,
+            borderRadius: "999px",
+            flexShrink: 0,
+            backgroundColor: "var(--bui-field)",
+            boxShadow: "var(--bui-shadow-hairline)",
+            color: "var(--bui-ink-2)",
+            fontFamily: BUI_MONO_FONT_FAMILY,
+            fontSize: "11px",
+            fontVariantNumeric: "tabular-nums",
+            whiteSpace: "nowrap",
+            transition: "background-color 0.1s",
+            "&:hover": { backgroundColor: "var(--bui-hover-2)" },
+          }}
+        >
+          <CircleDollarSign size={12} />
+          {chipLabel}
+        </ButtonBase>
+      </Tooltip>
+      <Popover
+        open={anchor !== null}
+        anchorEl={anchor}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        <Box sx={{ p: 1.5, minWidth: 300 }}>
+          <Box
+            sx={{
+              fontSize: "11.5px",
+              fontWeight: 600,
+              color: "var(--bui-ink-3)",
+              letterSpacing: 0.2,
+              mb: 1,
+            }}
+          >
+            Warehouse usage
+          </Box>
+          {WINDOWS.map(({ key, label }) => {
+            const w = cost[key];
+            const usd = windowCostUsd(w);
+            return (
+              <Box key={key} sx={{ mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: 1,
+                  }}
+                >
+                  <Box
+                    component="span"
+                    sx={{
+                      width: 34,
+                      flexShrink: 0,
+                      fontFamily: BUI_MONO_FONT_FAMILY,
+                      fontSize: "11px",
+                      color: "var(--bui-ink-3)",
+                    }}
+                  >
+                    {label}
+                  </Box>
+                  <Box
+                    component="span"
+                    sx={{
+                      fontFamily: BUI_MONO_FONT_FAMILY,
+                      fontSize: "12.5px",
+                      fontWeight: 600,
+                      color: "var(--bui-ink)",
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {usd != null ? formatCostUsd(usd) : "—"}
+                  </Box>
+                  <Box
+                    component="span"
+                    sx={{
+                      fontSize: "11.5px",
+                      color: "var(--bui-ink-3)",
+                    }}
+                  >
+                    {windowRuns(w)} runs
+                  </Box>
+                </Box>
+                {w.byEngine.map(e => (
+                  <Box
+                    key={e.databaseType}
+                    sx={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 1,
+                      pl: "42px",
+                      fontSize: "11px",
+                      color: "var(--bui-ink-2)",
+                    }}
+                  >
+                    <Box component="span" sx={{ minWidth: 72 }}>
+                      {e.databaseType}
+                    </Box>
+                    <Box
+                      component="span"
+                      sx={{
+                        fontFamily: BUI_MONO_FONT_FAMILY,
+                        color: "var(--bui-ink-3)",
+                      }}
+                    >
+                      {e.estimatedCostUsd != null
+                        ? `${formatCostUsd(e.estimatedCostUsd)} · ${formatBytes(e.bytesScanned)}`
+                        : `${e.runs} runs`}
+                      {e.errors > 0 ? ` · ${e.errors} failed` : ""}
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
+            );
+          })}
+          <Box
+            sx={{
+              mt: 1,
+              pt: 1,
+              borderTop: "1px solid var(--bui-line)",
+              fontSize: "10.5px",
+              color: "var(--bui-ink-3)",
+            }}
+          >
+            Estimated at on-demand list price. Tracking since Aug 2026; history
+            kept 90 days.
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+});
+AppCostChip.displayName = "AppCostChip";

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -40,6 +40,7 @@ import { useAppStore } from "../store/appStore";
 import { useVersionStore } from "../store/versionStore";
 import { useConsoleStore } from "../store/consoleStore";
 import ShareDialog from "./ShareDialog";
+import { AppCostChip } from "./AppCostChip";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
@@ -815,6 +816,7 @@ export default function AppRenderer({
           </Tooltip>
         )}
         <Box sx={{ flex: 1 }} />
+        {workspaceId && <AppCostChip workspaceId={workspaceId} appId={appId} />}
         <Tooltip
           title={
             previewViewport == null

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -964,6 +964,9 @@ export const useAppStore = create<AppStore>()(
             databaseName: binding.databaseName,
             mode: "preview",
             source: "app_runtime",
+            // Per-app cost attribution (query_executions.appId/bindingId)
+            appId,
+            bindingId: binding.id,
           },
         });
         const status = result.response.status;

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -20758,6 +20758,83 @@
         "operationId": "delete_api_workspaces_workspaceId_apps_id"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/cost": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Get an app's warehouse usage and estimated cost",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_cost"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/bindings/{bindingId}/materialize": {
       "post": {
         "tags": [


### PR DESCRIPTION
## What

A standard cost block for every app: estimated warehouse spend over **24h / 7d / 90d**, as a toolbar chip (`$1.31 · 7d`) with a per-engine breakdown popover.

## Why this needed more than UI

Tracing the data path surfaced that app-attributable warehouse spend was invisible — and partly a live bug:

- App-editor binding runs send `source: "app_runtime"`, which the `query_executions` Mongoose enum rejected — **every save threw a ValidationError that was silently swallowed**. Fixed (client-sent sources are now validated, and the enum includes the new sources).
- Public-app viewer queries and parquet materialization builds (the biggest BigQuery consumers) were never tracked at all. Both now record executions.
- BigQuery's `totalBytesProcessed`/`cacheHit` were present in the very response object the driver held and dropped one line before the return. All three BQ paths (query / preview / streaming) now capture them — zero extra API calls.

## How

- **Schema**: `query_executions` gains `appId`, `bindingId`, `cacheHit`, sources `app_runtime`/`app_public`/`materialization`, and a sparse `{workspaceId, appId, executedAt}` index (migration included; applied to dev).
- **Aggregation**: `getAppUsageSummary()` — a single `$facet` over the three windows grouped by engine. `GET /apps/:id/cost` prices bytes at the BigQuery on-demand list rate (`warehouse-pricing.ts`); non-metered engines report runs/duration only. OpenAPI spec + app types regenerated.
- **UI**: `AppCostChip` in the app toolbar — renders nothing until the app has tracked runs; popover shows per-window totals, per-engine cost/bytes/failures, and the honesty footer: *estimated at on-demand list price, tracking since Aug 2026, history kept 90 days* (the collection TTL bounds "lifetime" at 90d, and nothing historical was ever recorded, so the meter starts at zero).

## Verification

- Real endpoint end-to-end on dev: seeded synthetic BQ executions against a scratch app → `GET /cost` returned correct math (≈1 TiB × $6.25 = $6.20 for 90d, window bucketing correct incl. an error run) → chip + popover verified in the browser. Scratch app + seeds deleted after.
- `api` build + lint clean; app typecheck + lint clean; chat suite (62 tests) passes.
- Local BQ credentials are broken on this machine (known ENCRYPTION_KEY mismatch), so live byte capture was verified by code-path review; the fields come straight off the documented `jobs.query`/`getQueryResults` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)