### PR TITLE
feat(acp): add Cursor Agent provider — Grok on your Cursor subscription

### DIFF
--- a/app/src/components/AcpPermissionBanner.tsx
+++ b/app/src/components/AcpPermissionBanner.tsx
@@ -49,7 +49,11 @@ export function AcpPermissionBanner() {
     sessions.find(x => x.id === sessionId)?.providerId || selectedProviderId;
   const providerLabel =
     providers?.find(p => p.id === providerId)?.label ||
-    (providerId === "codex" ? "Codex" : "Claude Code");
+    (providerId === "codex"
+      ? "Codex"
+      : providerId === "cursor"
+        ? "Cursor Agent"
+        : "Claude Code");
 
   return (
     <Alert

--- a/app/src/components/CodingAgentsPanel.tsx
+++ b/app/src/components/CodingAgentsPanel.tsx
@@ -158,11 +158,12 @@ export function CodingAgentsPanel() {
       ) : null}
 
       <Alert severity="info" sx={{ mb: 2 }}>
-        Chat with Claude Code or Codex from the <strong>main Chat</strong> model
-        dropdown under <strong>On this machine</strong>. Tokens bill to your
-        Claude Pro/Max or ChatGPT subscription. If workspace tools are not
-        active, Chat shows <strong>Enable workspace tools</strong> — one click,
-        no <code>claude mcp</code>. File and shell tools still run locally.
+        Chat with Claude Code, Codex, or Cursor Agent (Grok) from the{" "}
+        <strong>main Chat</strong> model dropdown under{" "}
+        <strong>On this machine</strong>. Tokens bill to your Claude Pro/Max,
+        ChatGPT, or Cursor subscription. If workspace tools are not active, Chat
+        shows <strong>Enable workspace tools</strong> — one click, no{" "}
+        <code>claude mcp</code>. File and shell tools still run locally.
       </Alert>
 
       <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
@@ -323,6 +324,13 @@ export function CodingAgentsPanel() {
                   npm i -g @openai/codex @agentclientprotocol/codex-acp
                 </code>
                 , then return here and use Chat → Enable workspace tools.
+              </>
+            ) : selectedProviderId === "cursor" ? (
+              <>
+                Prefer the CLI? Install Cursor CLI with{" "}
+                <code>curl https://cursor.com/install -fsS | bash</code>, run{" "}
+                <code>cursor-agent login</code> (Cursor subscription — includes
+                Grok), then return here and use Chat → Enable workspace tools.
               </>
             ) : (
               <>

--- a/app/src/lib/acp-types.ts
+++ b/app/src/lib/acp-types.ts
@@ -1,6 +1,6 @@
 /** Types for the Local Agent ACP bridge (`/acp/*`). */
 
-export type AcpProviderId = "claude" | "codex";
+export type AcpProviderId = "claude" | "codex" | "cursor";
 
 export interface AcpModelChoice {
   value: string;

--- a/app/src/lib/acp-user-errors.ts
+++ b/app/src/lib/acp-user-errors.ts
@@ -24,7 +24,7 @@ export function isAcpAdapterNoise(text: string): boolean {
 
 export function sanitizeAcpUserError(
   message: string | null | undefined,
-  options?: { providerId?: "claude" | "codex" | null },
+  options?: { providerId?: "claude" | "codex" | "cursor" | null },
 ): string | null {
   const raw = (message || "").trim();
   if (!raw) return null;
@@ -56,6 +56,13 @@ export function sanitizeAcpUserError(
     return (
       "Codex could not apply that model setting. Pick Codex · GPT-5.6 Terra " +
       "(or Luna), then Enable workspace tools again."
+    );
+  }
+  if (/Invalid params/i.test(kept) && options?.providerId === "cursor") {
+    return (
+      "Cursor Agent could not apply that model setting. Pick Cursor · Grok " +
+      "(local) again, or update Cursor CLI (`cursor-agent update`), then " +
+      "Enable workspace tools again."
     );
   }
   return kept.length > 600 ? `${kept.slice(0, 600)}…` : kept;

--- a/app/src/lib/desktop.ts
+++ b/app/src/lib/desktop.ts
@@ -20,11 +20,12 @@ export interface MakoDesktopBridge {
    */
   startBrowserAuth?: () => Promise<void>;
   /**
-   * Open system Terminal with Claude/Codex CLI login (`codex login`, etc.).
+   * Open system Terminal with Claude/Codex/Cursor CLI login (`codex login`,
+   * `cursor-agent login`, etc.).
    * Optional — older Desktop builds lack this; Local Agent may still open Terminal.
    */
   startAcpCliLogin?: (
-    providerId: "claude" | "codex",
+    providerId: "claude" | "codex" | "cursor",
   ) => Promise<{ opened: boolean; commandLine: string }>;
 }
 
@@ -70,7 +71,7 @@ export function supportsDesktopAcpCliLogin(): boolean {
  * Returns null when not running in a Desktop build that supports it.
  */
 export async function startDesktopAcpCliLogin(
-  providerId: "claude" | "codex",
+  providerId: "claude" | "codex" | "cursor",
 ): Promise<{ opened: boolean; commandLine: string } | null> {
   const start = window.makoDesktop?.startAcpCliLogin;
   if (!start) return null;

--- a/app/src/lib/local-acp-chat.ts
+++ b/app/src/lib/local-acp-chat.ts
@@ -110,8 +110,9 @@ async function ensureSessionModelOrNeedsFresh(
     return "ok";
   }
 
-  // Codex: never hot-swap model on a live chat session.
-  if (providerId === "codex") {
+  // Codex/Cursor: never hot-swap model on a live chat session (Codex dumps
+  // "Conversation interrupted"; Cursor set_config support varies by build).
+  if (providerId === "codex" || providerId === "cursor") {
     return "needs_fresh";
   }
 
@@ -626,8 +627,8 @@ export async function runLocalAcpChatTurn(
     }
     if (skippedAttachments > 0) {
       throw new Error(
-        "Only image attachments can be sent to local Claude/Codex. " +
-          "Remove other file types and try again.",
+        "Only image attachments can be sent to local coding agents " +
+          "(Claude/Codex/Cursor). Remove other file types and try again.",
       );
     }
 
@@ -652,7 +653,7 @@ export async function runLocalAcpChatTurn(
           parts,
           modelSwitch
             ? "_Switching local model — starting a fresh session…_"
-            : "_Reconnecting local Claude/Codex…_",
+            : "_Reconnecting local coding agent…_",
         ),
       );
       // Clear the reconnect notice before the retry streams real tokens.
@@ -689,8 +690,11 @@ export async function runLocalAcpChatTurn(
         providerId === "codex"
           ? "Codex could not apply that model (or Local Agent is outdated). " +
             "Fully quit/reopen Mako Desktop 0.3.9+, then pick GPT-5.6 Sol/Terra/Luna again."
-          : "Claude could not apply that model (or Local Agent is outdated). " +
-            "Fully quit/reopen Mako Desktop 0.3.9+, then pick Opus/Sonnet again.";
+          : providerId === "cursor"
+            ? "Cursor Agent could not apply that model (or Local Agent is outdated). " +
+              "Update Cursor CLI (`cursor-agent update`), then pick Grok 4.6/4.5 again."
+            : "Claude could not apply that model (or Local Agent is outdated). " +
+              "Fully quit/reopen Mako Desktop 0.3.9+, then pick Opus/Sonnet again.";
     }
     // Codex often returns opaque "Internal error" / missing model metadata
     // when the CLI or ACP adapter is outdated. Local Agent auto-updates;

--- a/app/src/lib/local-acp-models.test.ts
+++ b/app/src/lib/local-acp-models.test.ts
@@ -30,8 +30,9 @@ describe("local-acp-models", () => {
 
   it("expands Claude Code into Sonnet/Opus/Fable rows when adapter found", () => {
     const offline = localAcpModelsFromProviders(null);
-    expect(offline).toHaveLength(2);
+    expect(offline).toHaveLength(3);
     expect(offline.map(m => m.id)).toContain(LOCAL_ACP_CLAUDE_MODEL_ID);
+    expect(offline.map(m => m.id)).toContain("local-acp/cursor");
 
     const models = localAcpModelsFromProviders([
       {
@@ -109,6 +110,39 @@ describe("local-acp-models", () => {
     expect(ids).toContain("local-acp/codex/gpt-5.6-terra");
     expect(ids).toContain("local-acp/codex/gpt-5.6-luna"); // fallback
     expect(ids).toContain("local-acp/codex"); // Default
+  });
+
+  it("expands Cursor Agent into Grok rows (fallbacks + advertised)", () => {
+    expect(localAcpModelIdToProviderId("local-acp/cursor/grok-4.6")).toBe(
+      "cursor",
+    );
+    expect(localAcpModelPreference("local-acp/cursor/grok-4.6")).toBe(
+      "grok-4.6",
+    );
+
+    const models = localAcpModelsFromProviders([
+      {
+        id: "cursor",
+        label: "Cursor Agent",
+        description: "z",
+        authProduct: "Cursor subscription",
+        installHint: "curl https://cursor.com/install -fsS | bash",
+        adapterCommand: "cursor-agent acp",
+        adapterFound: true,
+        connected: true,
+        authRequired: false,
+        authMethods: [],
+        availableModels: [{ value: "grok-4.6", name: "Grok 4.6" }],
+      },
+    ]);
+    const ids = models.map(m => m.id);
+    expect(ids).toContain("local-acp/cursor"); // Default
+    expect(ids).toContain("local-acp/cursor/grok-4.6"); // advertised
+    expect(ids).toContain("local-acp/cursor/grok-4.5"); // fallback
+    expect(ids).toContain("local-acp/cursor/composer"); // fallback
+    expect(
+      models.find(m => m.id === "local-acp/cursor/grok-4.6")?.name,
+    ).toMatch(/Cursor · Grok 4\.6 \(local\)/);
   });
 
   it("resolves opus/sonnet aliases to canonical Claude ids", () => {

--- a/app/src/lib/local-acp-models.ts
+++ b/app/src/lib/local-acp-models.ts
@@ -6,6 +6,7 @@
  * - `local-acp/claude` — Claude Code with adapter default model
  * - `local-acp/claude/fable` — Claude Code forced to Fable (alias or full id)
  * - `local-acp/codex` / `local-acp/codex/<model>` — same for Codex
+ * - `local-acp/cursor` / `local-acp/cursor/<model>` — Cursor Agent (Grok, …)
  */
 import type { AIModel } from "./api-types";
 import type {
@@ -18,6 +19,7 @@ export const LOCAL_ACP_MODEL_PREFIX = "local-acp/";
 
 export const LOCAL_ACP_CLAUDE_MODEL_ID = `${LOCAL_ACP_MODEL_PREFIX}claude`;
 export const LOCAL_ACP_CODEX_MODEL_ID = `${LOCAL_ACP_MODEL_PREFIX}codex`;
+export const LOCAL_ACP_CURSOR_MODEL_ID = `${LOCAL_ACP_MODEL_PREFIX}cursor`;
 
 /**
  * Shown in Chat before a session reports adapter model lists.
@@ -70,9 +72,28 @@ export const CODEX_MODEL_FALLBACKS: AcpModelChoice[] = [
   { value: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark" },
 ];
 
+/**
+ * Cursor model slugs when the adapter has not advertised a list yet.
+ * Grok first — Cursor's flagship models are the Grok family.
+ * @see https://cursor.com/help/models-and-usage/available-models
+ */
+export const CURSOR_MODEL_FALLBACKS: AcpModelChoice[] = [
+  {
+    value: "default",
+    name: "Default",
+    description: "Cursor’s current default (Auto router)",
+  },
+  { value: "grok-4.6", name: "Grok 4.6" },
+  { value: "grok-4.5", name: "Grok 4.5" },
+  { value: "composer", name: "Composer" },
+  { value: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+  { value: "gemini-pro", name: "Gemini Pro" },
+];
+
 const PROVIDER_LABEL: Record<AcpProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  cursor: "Cursor",
 };
 
 const PROVIDER_BASE: Record<
@@ -95,6 +116,15 @@ const PROVIDER_BASE: Record<
     tier: "free",
     supportsTools: true,
   },
+  cursor: {
+    id: LOCAL_ACP_CURSOR_MODEL_ID,
+    name: "Cursor Agent (local)",
+    provider: "local",
+    description:
+      "Your Cursor subscription (Grok, Composer, …) via ACP on this machine",
+    tier: "free",
+    supportsTools: true,
+  },
 };
 
 export function isLocalAcpModelId(modelId: string | null | undefined): boolean {
@@ -107,7 +137,9 @@ export function localAcpModelIdToProviderId(
   if (!isLocalAcpModelId(modelId)) return null;
   const rest = modelId.slice(LOCAL_ACP_MODEL_PREFIX.length);
   const provider = rest.split("/")[0];
-  if (provider === "claude" || provider === "codex") return provider;
+  if (provider === "claude" || provider === "codex" || provider === "cursor") {
+    return provider;
+  }
   return null;
 }
 
@@ -244,6 +276,16 @@ export function localAcpModelsFromProviders(
       continue;
     }
 
+    // Local Agent build predates this provider (e.g. cursor). Don't expand
+    // model rows — session/new on old agents coerces unknown ids to claude.
+    if (!status) {
+      out.push({
+        ...def,
+        description: `${def.description} — update Mako Desktop / Local Agent to use`,
+      });
+      continue;
+    }
+
     if (status && !status.adapterFound) {
       out.push({
         ...def,
@@ -255,7 +297,9 @@ export function localAcpModelsFromProviders(
     const fallbacks =
       providerId === "claude"
         ? CLAUDE_CODE_MODEL_FALLBACKS
-        : CODEX_MODEL_FALLBACKS;
+        : providerId === "cursor"
+          ? CURSOR_MODEL_FALLBACKS
+          : CODEX_MODEL_FALLBACKS;
     // Show every model the adapter advertises, plus current Codex fallbacks
     // so Sol/Terra/Luna appear even before the first session caches a list.
     const choices = mergeModelChoices(status?.availableModels, fallbacks);

--- a/app/src/store/acpStore.ts
+++ b/app/src/store/acpStore.ts
@@ -26,6 +26,12 @@ import {
   shouldClearAcpAuthGuidance,
 } from "../lib/acp-user-errors";
 
+function providerLabel(id: AcpProviderId): string {
+  if (id === "codex") return "Codex";
+  if (id === "cursor") return "Cursor Agent";
+  return "Claude Code";
+}
+
 function messageId(): string {
   return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -457,9 +463,9 @@ export const useAcpStore = create<AcpState>()(
           options?.workspaceId?.trim() || getActiveWorkspaceId();
         if (!workspaceId) {
           throw new Error(
-            `Select a workspace before starting ${
-              selectedProviderId === "codex" ? "Codex" : "Claude Code"
-            } (local).`,
+            `Select a workspace before starting ${providerLabel(
+              selectedProviderId,
+            )} (local).`,
           );
         }
 
@@ -478,6 +484,16 @@ export const useAcpStore = create<AcpState>()(
           systemPromptAppend,
           model: options?.model?.trim() || undefined,
         });
+        if (session.providerId !== selectedProviderId) {
+          // Old Local Agents coerce unknown provider ids (cursor) to claude —
+          // fail loudly instead of silently chatting with the wrong agent.
+          void acpClient.closeSession(session.id).catch(() => undefined);
+          throw new Error(
+            `Local Agent does not support ${providerLabel(
+              selectedProviderId,
+            )} yet. Update Mako Desktop (or restart the Local Agent from this branch), then retry.`,
+          );
+        }
         if (requireMakoMcp && !session.makoMcpAttached) {
           throw new Error(
             "Local session started without Mako data tools. Restart Local Agent from this branch and try again.",
@@ -568,7 +584,9 @@ export const useAcpStore = create<AcpState>()(
           message =
             providerId === "codex"
               ? `Codex could not switch to "${value}". Fully quit/reopen Desktop 0.3.9+, Update adapter, then pick GPT-5.6 Terra/Luna again.`
-              : `Claude could not switch to "${value}". Fully quit/reopen Desktop 0.3.9+, Update adapter, then pick Opus/Sonnet again.`;
+              : providerId === "cursor"
+                ? `Cursor Agent could not switch to "${value}". Update Cursor CLI (\`cursor-agent update\`), then pick Grok 4.6/4.5 again.`
+                : `Claude could not switch to "${value}". Fully quit/reopen Desktop 0.3.9+, Update adapter, then pick Opus/Sonnet again.`;
         }
         set(s => {
           s.error = sanitizeAcpUserError(message, { providerId }) || message;
@@ -685,15 +703,17 @@ export const useAcpStore = create<AcpState>()(
     ensureAdapter: async (providerId, options) => {
       const id = providerId || get().selectedProviderId;
       if (!acpSupportsAdapterEnsure(get().status)) {
-        const npmCmd =
+        const installCmd =
           id === "codex"
             ? "npm i -g @openai/codex @agentclientprotocol/codex-acp"
-            : "npm i -g @agentclientprotocol/claude-agent-acp";
+            : id === "cursor"
+              ? "curl https://cursor.com/install -fsS | bash"
+              : "npm i -g @agentclientprotocol/claude-agent-acp";
         const message =
           "One-click Update needs PR Desktop 0.3.9 Local Agent " +
           "(mako.ai/download is still 0.3.1). Until then, run this in Terminal, " +
           "then click Retry / refresh status:\n\n" +
-          npmCmd;
+          installCmd;
         // Explicit Update/Install: show Terminal fallback instead of a dead button.
         if (options?.force) {
           set(s => {
@@ -709,7 +729,9 @@ export const useAcpStore = create<AcpState>()(
           packages:
             id === "codex"
               ? ["@openai/codex", "@agentclientprotocol/codex-acp"]
-              : ["@agentclientprotocol/claude-agent-acp"],
+              : id === "cursor"
+                ? []
+                : ["@agentclientprotocol/claude-agent-acp"],
           message,
           adapterCommand: null,
           adapterVia: null,

--- a/docs/src/content/docs/coding-agents-acp.md
+++ b/docs/src/content/docs/coding-agents-acp.md
@@ -1,9 +1,10 @@
 ---
 title: Coding Agents (ACP)
-description: Run Claude Code or Codex inside Mako via the Agent Client Protocol — on your machine, on your subscription.
+description: Run Claude Code, Codex, or Cursor Agent (Grok) inside Mako via the Agent Client Protocol — on your machine, on your subscription.
 ---
 
-Mako can host **Claude Code** and **Codex (ChatGPT)** inside the app using the
+Mako can host **Claude Code**, **Codex (ChatGPT)**, and **Cursor Agent**
+(Grok, Composer, …) inside the app using the
 [Agent Client Protocol](https://agentclientprotocol.com/) (ACP).
 
 This is the reverse of [MCP Server](/mcp-server/):
@@ -11,7 +12,7 @@ This is the reverse of [MCP Server](/mcp-server/):
 | Surface | Direction | Who pays for model tokens |
 | --- | --- | --- |
 | **Connect Agents** (MCP) | External agent → Mako tools/data | Your Claude / Cursor / Codex sub |
-| **Coding Agents** (ACP) | Mako UI → Claude Code / Codex | Your Claude Pro/Max or ChatGPT sub |
+| **Coding Agents** (ACP) | Mako UI → Claude Code / Codex / Cursor Agent | Your Claude Pro/Max, ChatGPT, or Cursor sub |
 | **In-product chat** | Mako → AI Gateway | Mako / workspace billing |
 
 ## Requirements
@@ -22,9 +23,13 @@ This is the reverse of [MCP Server](/mcp-server/):
 2. An ACP adapter on `PATH`:
    - Claude: `npm i -g @agentclientprotocol/claude-agent-acp`
    - Codex: `npm i -g @zed-industries/codex-acp`
+   - Cursor: no adapter needed — Cursor CLI speaks ACP natively
+     (`cursor-agent acp`). Install it with
+     `curl https://cursor.com/install -fsS | bash`.
 3. Sign in with the provider when prompted. **Claude Code** uses a **Terminal**
    login (`claude auth login` / Claude subscription) — Mako’s **Sign in** button
-   opens Terminal; it is not a browser popup inside the app.
+   opens Terminal; it is not a browser popup inside the app. **Cursor Agent**
+   uses `cursor-agent login` (Cursor subscription).
 
 ## How to use
 
@@ -32,9 +37,11 @@ This is the reverse of [MCP Server](/mcp-server/):
 2. Optional: **Settings → Coding Agents** to sign in and set the default
    working directory.
 3. Open **Chat**, open the model dropdown, and under **On this machine** pick
-   **Claude Code · Fable (local)** (or Sonnet / Opus / Haiku / Default), or
-   **Codex (local)**. Mako applies the choice via ACP
-   `session/set_config_option` — no Terminal `/model` required.
+   **Claude Code · Fable (local)** (or Sonnet / Opus / Haiku / Default),
+   **Codex (local)**, or **Cursor · Grok 4.6 (local)** (or Grok 4.5 /
+   Composer / Default) to run Grok on your Cursor subscription. Mako applies
+   the choice via ACP `session/set_config_option` — no Terminal `/model`
+   required.
 4. Send messages in the normal Chat composer. Mako starts the local ACP session
    automatically and attaches workspace data tools.
 5. Optional: attach images in the composer (screenshots, diagrams). They are
@@ -75,6 +82,9 @@ To feel like the in-app agent, Mako:
   into the system prompt. Workspace **custom prompt** is appended when set.
 - **Codex ACP:** skills/tools come from MCP server instructions (Codex adapters
   often ignore Claude-style `systemPrompt` `_meta` today)
+- **Cursor ACP:** same as Codex — Mako guidance rides the first prompt; skills
+  stay on demand via MCP. Model switches (e.g. Grok 4.6 → Composer) start a
+  fresh local session with Chat continuity instead of a mid-chat hot-swap.
 
 If attach fails (offline API, missing workspace), Chat shows an **Enable
 workspace tools** banner — one click remints the token and starts a fresh ACP

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -543,11 +543,18 @@ if (!hasSingleInstanceLock) {
   ipcMain.handle(
     "mako:start-acp-cli-login",
     async (_event, providerId: unknown) => {
-      const id = providerId === "codex" ? "codex" : "claude";
+      const id =
+        providerId === "codex"
+          ? "codex"
+          : providerId === "cursor"
+            ? "cursor"
+            : "claude";
       const commandLine =
         id === "codex"
           ? "codex login"
-          : "npx --yes @agentclientprotocol/claude-agent-acp --cli auth login --claudeai";
+          : id === "cursor"
+            ? "cursor-agent login"
+            : "npx --yes @agentclientprotocol/claude-agent-acp --cli auth login --claudeai";
       return launchCliLoginInTerminal(commandLine);
     },
   );

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -20,11 +20,11 @@ contextBridge.exposeInMainWorld("makoDesktop", {
   startBrowserAuth: (): Promise<void> =>
     ipcRenderer.invoke("mako:start-browser-auth"),
   /**
-   * Open system Terminal with a fixed Claude/Codex CLI login command.
+   * Open system Terminal with a fixed Claude/Codex/Cursor CLI login command.
    * Allowlisted in main — not an arbitrary shell.
    */
   startAcpCliLogin: (
-    providerId: "claude" | "codex",
+    providerId: "claude" | "codex" | "cursor",
   ): Promise<{ opened: boolean; commandLine: string }> =>
     ipcRenderer.invoke("mako:start-acp-cli-login", providerId),
 });

--- a/packages/local-agent/package.json
+++ b/packages/local-agent/package.json
@@ -12,7 +12,7 @@
     "start": "tsx src/index.ts",
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/connection.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/acp/prompt-images.test.ts src/desktop-bridge/mcp.test.ts",
+    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/connection.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/resolve-command.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/acp/prompt-images.test.ts src/desktop-bridge/mcp.test.ts",
     "acp:mock-agent": "tsx src/acp/mock-agent.ts"
   },
   "dependencies": {

--- a/packages/local-agent/src/acp/codex-login-status.ts
+++ b/packages/local-agent/src/acp/codex-login-status.ts
@@ -117,7 +117,8 @@ export function shouldAutoAuthenticateOnSessionNew(args: {
   if (!args.authRequired || args.authenticated) return false;
   // Codex advertises api-key / chat-gpt (non-terminal) methods, but Sign in
   // must own the CLI login — never auto-run `codex login` on session/new.
-  if (args.providerId === "codex") return false;
+  // Cursor is the same shape (`cursor-agent login` CLI flow).
+  if (args.providerId === "codex" || args.providerId === "cursor") return false;
   const terminalOnly =
     args.authMethods.length > 0 &&
     args.authMethods.every(m => m.type === "terminal" || Boolean(m.terminalAuth));

--- a/packages/local-agent/src/acp/connection-errors.ts
+++ b/packages/local-agent/src/acp/connection-errors.ts
@@ -57,7 +57,7 @@ export function sanitizeAdapterStderrForUi(
  */
 export function userFacingAcpError(
   message: string,
-  options?: { providerId?: "claude" | "codex" },
+  options?: { providerId?: "claude" | "codex" | "cursor" },
 ): string {
   const raw = (message || "").trim();
   if (!raw) return "Something went wrong with the local agent.";
@@ -72,6 +72,13 @@ export function userFacingAcpError(
     return (
       "Codex could not apply that model setting. Pick Codex · GPT-5.6 Terra " +
       "(or Luna) in the Chat model dropdown, then Enable workspace tools again."
+    );
+  }
+  if (/Invalid params/i.test(text) && options?.providerId === "cursor") {
+    return (
+      "Cursor Agent could not apply that setting. Pick Cursor · Grok (local) " +
+      "again in the Chat model dropdown, or update Cursor CLI " +
+      "(`cursor-agent update`), then Enable workspace tools again."
     );
   }
   if (/Invalid params/i.test(text) && options?.providerId === "claude") {

--- a/packages/local-agent/src/acp/ensure-adapter.test.ts
+++ b/packages/local-agent/src/acp/ensure-adapter.test.ts
@@ -17,6 +17,10 @@ describe("ensure-adapter", () => {
     ]);
   });
 
+  it("never runs npm for Cursor (CLI installs via curl, not npm)", () => {
+    assert.deepEqual(packagesForProvider("cursor"), []);
+  });
+
   it("classifies npm ensure failures", () => {
     assert.equal(
       classifyEnsureFailure({

--- a/packages/local-agent/src/acp/ensure-adapter.ts
+++ b/packages/local-agent/src/acp/ensure-adapter.ts
@@ -104,6 +104,8 @@ function writeState(state: EnsureStateFile): void {
 /** npm packages to keep current for each ACP provider. */
 export function packagesForProvider(providerId: AcpProviderId): string[] {
   const def = ACP_PROVIDERS[providerId];
+  // Not npm-distributed (Cursor CLI installs via curl) — nothing to ensure.
+  if (!def.npxPackage) return [];
   if (providerId === "codex") {
     return ["@openai/codex", def.npxPackage];
   }
@@ -219,6 +221,26 @@ export async function ensureAdapterPackages(
   const before = resolveAdapterCommand(def);
   const state = readState();
   const prior = state.providers[providerId];
+
+  // Nothing npm can install (Cursor CLI): report presence, never run npm.
+  if (packages.length === 0) {
+    const found = Boolean(before);
+    return {
+      ok: found,
+      providerId,
+      skipped: true,
+      updated: false,
+      packages,
+      message: found
+        ? `${def.label} CLI found — Mako keeps it as installed (${def.label} updates itself).`
+        : `${def.label} CLI is not installed. ${def.installHint}`,
+      adapterCommand: before
+        ? [before.command, ...before.args].join(" ")
+        : null,
+      adapterVia: before?.via ?? null,
+      errorCode: found ? undefined : "adapter_missing",
+    };
+  }
 
   if (
     shouldSkipEnsure({

--- a/packages/local-agent/src/acp/providers.ts
+++ b/packages/local-agent/src/acp/providers.ts
@@ -5,7 +5,7 @@
  * adapter binary to spawn" plus setup/auth hints for the UI.
  */
 
-export type AcpProviderId = "claude" | "codex";
+export type AcpProviderId = "claude" | "codex" | "cursor";
 
 export interface AcpProviderDefinition {
   id: AcpProviderId;
@@ -13,8 +13,18 @@ export interface AcpProviderDefinition {
   description: string;
   /** Prefer these commands in order when resolving the adapter binary. */
   commands: string[];
-  /** npm package useful for `npx <package>` fallback. */
-  npxPackage: string;
+  /**
+   * Args appended when a PATH command resolves (e.g. Cursor CLI speaks ACP
+   * via the `acp` subcommand: `cursor-agent acp`). Adapter-only binaries
+   * (claude-agent-acp, codex-acp) omit this.
+   */
+  commandArgs?: string[];
+  /**
+   * npm package useful for `npx <package>` fallback and `npm i -g` ensure.
+   * `null` for CLIs not distributed via npm (Cursor) — no npx fallback and
+   * ensure-adapter never runs npm for them.
+   */
+  npxPackage: string | null;
   /** Human-facing install hint shown when the adapter is missing. */
   installHint: string;
   /** Auth product the adapter typically uses. */
@@ -51,6 +61,21 @@ export const ACP_PROVIDERS: Record<AcpProviderId, AcpProviderDefinition> = {
     installHint:
       "Mako can install Codex CLI + ACP adapter automatically — use Install in Chat, or: npm i -g @openai/codex @agentclientprotocol/codex-acp",
     authProduct: "ChatGPT / OpenAI API",
+  },
+  cursor: {
+    id: "cursor",
+    label: "Cursor Agent",
+    description:
+      "Cursor CLI via native ACP (`cursor-agent acp`) — Grok, Composer and " +
+      "more on your Cursor subscription.",
+    // Cursor CLI ships ACP built in; newer builds install the binary as
+    // `agent`, older ones as `cursor-agent`. Not distributed via npm.
+    commands: ["cursor-agent", "agent"],
+    commandArgs: ["acp"],
+    npxPackage: null,
+    installHint:
+      "Install Cursor CLI in Terminal: curl https://cursor.com/install -fsS | bash — then run `cursor-agent login` (Cursor subscription).",
+    authProduct: "Cursor subscription",
   },
 };
 

--- a/packages/local-agent/src/acp/resolve-command.test.ts
+++ b/packages/local-agent/src/acp/resolve-command.test.ts
@@ -1,0 +1,65 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ACP_PROVIDERS } from "./providers";
+import { resolveAdapterCommand } from "./resolve-command";
+
+describe("resolveAdapterCommand (cursor)", () => {
+  let binDir: string;
+  const savedPath = process.env.PATH;
+  const savedEnvCommand = process.env.MAKO_ACP_AGENT_COMMAND;
+  const savedEnvProvider = process.env.MAKO_ACP_PROVIDER;
+
+  before(() => {
+    binDir = mkdtempSync(join(tmpdir(), "mako-acp-resolve-"));
+    delete process.env.MAKO_ACP_AGENT_COMMAND;
+    delete process.env.MAKO_ACP_PROVIDER;
+  });
+
+  after(() => {
+    process.env.PATH = savedPath;
+    if (savedEnvCommand !== undefined) {
+      process.env.MAKO_ACP_AGENT_COMMAND = savedEnvCommand;
+    }
+    if (savedEnvProvider !== undefined) {
+      process.env.MAKO_ACP_PROVIDER = savedEnvProvider;
+    }
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
+  it("launches `cursor-agent acp` when the CLI is on PATH", () => {
+    const bin = join(binDir, "cursor-agent");
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    process.env.PATH = binDir;
+
+    const launch = resolveAdapterCommand(ACP_PROVIDERS.cursor);
+    assert.ok(launch, "cursor-agent on PATH should resolve");
+    assert.equal(launch.via, "path");
+    assert.equal(launch.command, bin);
+    // Cursor CLI speaks ACP via the `acp` subcommand — args must carry it.
+    assert.deepEqual(launch.args, ["acp"]);
+  });
+
+  it("has no npx fallback (Cursor CLI is not npm-distributed)", () => {
+    rmSync(join(binDir, "cursor-agent"), { force: true });
+    process.env.PATH = binDir;
+
+    const launch = resolveAdapterCommand(ACP_PROVIDERS.cursor);
+    assert.equal(launch, null);
+  });
+
+  it("keeps adapter-only binaries argless on PATH resolve", () => {
+    const bin = join(binDir, "claude-agent-acp");
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    process.env.PATH = binDir;
+
+    const launch = resolveAdapterCommand(ACP_PROVIDERS.claude);
+    assert.ok(launch);
+    assert.equal(launch.via, "path");
+    assert.deepEqual(launch.args, []);
+  });
+});

--- a/packages/local-agent/src/acp/resolve-command.ts
+++ b/packages/local-agent/src/acp/resolve-command.ts
@@ -76,10 +76,17 @@ export function resolveAdapterCommand(
     if (!name.startsWith("@")) {
       const resolved = resolveOnPath(name);
       if (resolved) {
-        return { command: resolved, args: [], via: "path" };
+        return {
+          command: resolved,
+          args: provider.commandArgs ? [...provider.commandArgs] : [],
+          via: "path",
+        };
       }
     }
   }
+
+  // No npx fallback for CLIs that aren't npm-distributed (Cursor).
+  if (!provider.npxPackage) return null;
 
   const npx = resolveOnPath(process.platform === "win32" ? "npx.cmd" : "npx");
   if (npx) {

--- a/packages/local-agent/src/acp/terminal-auth.test.ts
+++ b/packages/local-agent/src/acp/terminal-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  defaultTerminalLoginLaunch,
   extractTerminalAuthLaunch,
   formatTerminalAuthCommand,
 } from "./terminal-auth";
@@ -30,5 +31,22 @@ describe("extractTerminalAuthLaunch", () => {
     });
     assert.ok(launch);
     assert.match(formatTerminalAuthCommand(launch), /claudeai/);
+  });
+});
+
+describe("defaultTerminalLoginLaunch", () => {
+  it("uses provider CLI logins", () => {
+    assert.equal(
+      formatTerminalAuthCommand(defaultTerminalLoginLaunch("codex")),
+      "codex login",
+    );
+    assert.equal(
+      formatTerminalAuthCommand(defaultTerminalLoginLaunch("cursor")),
+      "cursor-agent login",
+    );
+    assert.match(
+      formatTerminalAuthCommand(defaultTerminalLoginLaunch("claude")),
+      /claude-agent-acp/,
+    );
   });
 });

--- a/packages/local-agent/src/acp/terminal-auth.ts
+++ b/packages/local-agent/src/acp/terminal-auth.ts
@@ -89,6 +89,13 @@ export function defaultTerminalLoginLaunch(
       label: "Codex / ChatGPT Login",
     };
   }
+  if (providerId === "cursor") {
+    return {
+      command: "cursor-agent",
+      args: ["login"],
+      label: "Cursor Login",
+    };
+  }
   return {
     command: "npx",
     args: [


### PR DESCRIPTION
Adds **Cursor Agent** as a third Coding Agents (ACP) provider alongside Claude Code and Codex. Cursor CLI speaks ACP natively (`cursor-agent acp` — no third-party adapter), so picking **Cursor · Grok 4.6 (local)** (or Grok 4.5 / Composer / Default) in Chat runs Grok on the user's Cursor subscription, with Mako workspace tools attached over MCP as usual.

## Local Agent

- **providers**: new `cursor` entry. The registry now supports per-command args (Cursor needs the `acp` subcommand) and `npxPackage: null` for CLIs not distributed via npm (Cursor installs via `curl https://cursor.com/install -fsS | bash`).
- **resolve-command**: PATH-resolved binaries carry the provider's `commandArgs`; the npx fallback is skipped when there is no npm package. Tries `cursor-agent` first, then `agent` (newer Cursor builds).
- **ensure-adapter**: package-less providers never run `npm i -g` — the ensure reports adapter presence or the curl install hint (`adapter_missing`) instead.
- **terminal auth**: default login launch is `cursor-agent login`; like Codex, session/new never auto-runs the CLI login (Sign in owns it).
- **connection-errors**: cursor-specific `Invalid params` tip.

## App

- **local-acp-models**: `local-acp/cursor/<model>` picker rows under *On this machine* — Grok-first fallbacks (`grok-4.6`, `grok-4.5`, `composer`, …) merged with adapter-advertised models.
- **Old-agent guard**: Local Agent builds that predate this provider coerce unknown ids to `claude`, which would silently run Claude when the user picked Grok. The picker now shows an "update Mako Desktop" placeholder instead of expanding model rows when the agent doesn't report the provider, and `createSession` fails loudly (and closes the session) on a provider mismatch.
- **Chat**: model switches on Cursor start a fresh session with continuity seed (no mid-chat `set_config` hot-swap, same posture as Codex); cursor-aware error copy in store/banners/panel.
- **Desktop bridge**: `cursor-agent login` added to the allowlisted Terminal login commands (renderer can never pass arbitrary shell).

## Docs

- `coding-agents-acp.md`: Cursor provider requirements, sign-in, and Grok model rows.

## Testing

- `@mako/local-agent`: typecheck + full suite (80 tests) green, including new coverage: `resolve-command.test.ts` (`cursor-agent acp` args, no npx fallback, adapter binaries stay argless), `terminal-auth` default launches, `packagesForProvider("cursor") === []`.
- `app`: typecheck + full vitest suite green (62 files, 446 tests), including new Cursor/Grok row expansion and old-agent placeholder assertions.
- `@mako/desktop`: typecheck green.
- eslint on changed app files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhrAWbw6zaLjKdj2nnMNa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhrAWbw6zaLjKdj2nnMNa8)_