### PR TITLE
docs: mention Cursor Agent alongside Claude Code/Codex

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -182,7 +182,7 @@ Mako routes all AI requests through the **Vercel AI Gateway**, which provides ac
 
 Models are discovered dynamically at runtime by merging the Gateway model catalog with [arena.ai](https://arena.ai) code leaderboard ELO scores. The catalog refreshes hourly.
 
-On **Mako Desktop**, the model dropdown also shows an **On this machine** group — Claude Code and Codex running locally via ACP on your own subscription. See [Coding Agents (ACP)](/coding-agents-acp/).
+On **Mako Desktop**, the model dropdown also shows an **On this machine** group — Claude Code, Codex, and Cursor Agent (Grok) running locally via ACP on your own subscription. See [Coding Agents (ACP)](/coding-agents-acp/).
 
 ### Free vs Pro Models
 

--- a/docs/src/content/docs/desktop.md
+++ b/docs/src/content/docs/desktop.md
@@ -31,7 +31,7 @@ How it behaves:
 - **Identical behavior** — the agent reuses the exact same database drivers as the cloud API, so query execution, preview safety checks, schema trees, and autocomplete work identically. All connection types are supported locally, including PostgreSQL, MySQL, MongoDB, ClickHouse, Redshift, BigQuery, Cloud SQL, and Cloudflare D1/KV.
 - **Loopback only** — the agent listens on `127.0.0.1` exclusively and allows requests only from Mako origins. It is never reachable from the network.
 
-Beyond local databases, the bundled agent also hosts the **ACP bridge** for [Coding Agents](/coding-agents-acp/) — running Claude Code or Codex inside Mako Chat on your own subscription.
+Beyond local databases, the bundled agent also hosts the **ACP bridge** for [Coding Agents](/coding-agents-acp/) — running Claude Code, Codex, or Cursor Agent inside Mako Chat on your own subscription.
 
 Using the **web app** instead of the desktop app? You can still query local databases by running the agent standalone — see [`packages/local-agent`](https://github.com/mako-ai/mako/tree/master/packages/local-agent) for details. Your browser will ask once for permission to reach the local agent (Chromium's Local Network Access prompt).
 


### PR DESCRIPTION
PR #804 added Cursor Agent as a third ACP local coding-agent provider and thoroughly updated `coding-agents-acp.md`, but two other pages enumerating the local ACP set (`ai-agent.md` AI Models section, `desktop.md` Local Agent section) still said only "Claude Code and Codex" — stale as of that merge.

Small P2 fix, two-line diff, no behavior change.