### PR TITLE
fix(apps-v2): publishing a folder-only (repo-imported) app persists

### DIFF
--- a/api/src/apps-v2/adversarial.test.ts
+++ b/api/src/apps-v2/adversarial.test.ts
@@ -808,3 +808,45 @@ describe("failure mid-flight", () => {
     expect(inBox.stdout.trim()).toBe(settled.doc.branch);
   }, 180_000);
 });
+
+describe("publishing a folder-only app (repo-imported, no row)", () => {
+  it("materializes the row so publishedSha actually persists", async () => {
+    const { initRepo, repoDirFor } = await import("./repository.service");
+    const { synthesizeProjectFromFolder, ensureProjectRow } = await import(
+      "./worktree.service"
+    );
+    const { setPublishedSha } = await import("./deployment.service");
+    const { AppProjectV2 } = await import("../database/workspace-schema");
+
+    // A workspace whose repo arrived by IMPORT (connected-repo adoption):
+    // the app exists as a folder, no AppProjectV2 row anywhere.
+    const ws2 = new Types.ObjectId().toString();
+    await initRepo(repoDirFor(ws2), {
+      "apps/pubfix/mako.json": JSON.stringify({ title: "Pub Fix" }),
+    });
+
+    const synth = await synthesizeProjectFromFolder(ws2, "pubfix");
+    expect(synth).not.toBeNull();
+    const sha = "a".repeat(40);
+
+    // The old failure mode: setPublishedSha on the synthesized shape is an
+    // updateOne against an _id no document has — a silent no-op.
+    await setPublishedSha(synth!, sha);
+    expect(await AppProjectV2.findOne({ _id: synth!._id })).toBeNull();
+
+    // Publish now materializes the row first (same DERIVED id), and the sha
+    // sticks.
+    const row = await ensureProjectRow(synth!, "publisher");
+    expect(row._id.toString()).toBe(synth!._id.toString());
+    expect(row.slug).toBe("pubfix");
+    expect(row.access).toBe("workspace");
+    await setPublishedSha(row, sha);
+    const reread = await AppProjectV2.findOne({ _id: synth!._id });
+    expect(reread?.publishedSha).toBe(sha);
+
+    // Idempotent: a second materialize returns the winner, sha intact.
+    const again = await ensureProjectRow(synth!, "someone-else");
+    expect(again._id.toString()).toBe(row._id.toString());
+    expect(again.publishedSha).toBe(sha);
+  }, 60_000);
+});

--- a/api/src/apps-v2/worktree.service.ts
+++ b/api/src/apps-v2/worktree.service.ts
@@ -2028,6 +2028,43 @@ export function derivedAppId(
 }
 
 /**
+ * Persist the row for a folder-only app, keeping the DERIVED id so every
+ * artifact key and worktree doc stays stable. The three row-creating acts
+ * (§13.6: restrict, publish, share) all converge here; everything else keeps
+ * reading the synthesized shape. Idempotent and race-safe: a concurrent
+ * create loses the unique-index race and re-reads the winner.
+ *
+ * Publishing NEEDS this: `setPublishedSha` is an updateOne by _id, which
+ * silently matches nothing for a synthesized project — the publish then
+ * "succeeds" without persisting anything, and a reload shows the app
+ * unpublished (found on prod with repo-imported apps, §13.22).
+ */
+export async function ensureProjectRow(
+  project: IAppProjectV2,
+  actorId: string,
+): Promise<IAppProjectV2> {
+  const existing = await AppProjectV2.findOne({ _id: project._id });
+  if (existing) return existing;
+  try {
+    return await AppProjectV2.create({
+      _id: project._id,
+      workspaceId: project.workspaceId,
+      title: project.title,
+      slug: project.slug,
+      description: project.description,
+      access: project.access ?? "workspace",
+      createdBy: project.createdBy || actorId,
+      owner_id: actorId,
+      defaultBranch: project.defaultBranch || DEFAULT_BRANCH,
+    });
+  } catch {
+    const winner = await AppProjectV2.findOne({ _id: project._id });
+    if (winner) return winner;
+    throw new Error("Could not persist the app's project row");
+  }
+}
+
+/**
  * An app that exists only as a folder, shaped like a project document so every
  * read path works unchanged. Never persisted — writing a row is what happens
  * when someone restricts, publishes, or shares the app, not when they open it.

--- a/api/src/routes/apps-v2.ts
+++ b/api/src/routes/apps-v2.ts
@@ -44,6 +44,7 @@ import {
   listWorkspaceRepos,
 } from "../services/workspace-repos.service";
 import {
+  ensureProjectRow,
   PUBLISH_ACTOR,
   WorktreeConflictError,
   autoCommitFileEdit,
@@ -54,7 +55,6 @@ import {
   createProject,
   defaultBranchSha,
   deleteProject,
-  derivedAppId,
   discardWorktree,
   ensureWorktree,
   execInWorktree,
@@ -1948,6 +1948,14 @@ appsV2Routes.openapi(
     try {
       const loaded = await loadProject(c, { write: true });
       if ("errorResponse" in loaded) return loaded.errorResponse;
+      // Publishing is one of the three acts that give a folder-only app a
+      // database row (§13.6) — without this, `setPublishedSha` below is an
+      // updateOne against an _id that does not exist: the response says
+      // published, nothing persists, and a reload shows "not published".
+      loaded.project = await ensureProjectRow(
+        loaded.project,
+        loaded.userId ?? "api-key",
+      );
       const body = c.req.valid("json") ?? {};
       const user = c.get("user");
       // Publishing means "ship MY work" — the branch the caller is actually
@@ -2229,17 +2237,7 @@ registerPublicShareRoutes(appsV2Routes, {
     // artifact key stays stable.
     const folder = await synthesizeProjectFromFolder(workspaceId, ref);
     if (!folder) return null;
-    return AppProjectV2.create({
-      _id: derivedAppId(workspaceId, ref),
-      workspaceId: new Types.ObjectId(workspaceId),
-      title: folder.title,
-      slug: ref,
-      description: folder.description,
-      access: "workspace",
-      createdBy: actingUserId(c) ?? "",
-      owner_id: actingUserId(c),
-      defaultBranch: "main",
-    });
+    return ensureProjectRow(folder, actingUserId(c) ?? "");
   },
   getTitle: doc => (doc as unknown as IAppProjectV2).title,
 });


### PR DESCRIPTION
Publish on a row-less app (connected-repo import) silently no-op'd: setPublishedSha updateOne matched nothing while the route returned success. Publish now materializes the project row first (derived stable id, §13.6/§13.22); share-load reuses the same helper. Regression spec in the adversarial suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x