### PR TITLE
feat(apps-v2): rows-only migration backfill for repo-imported workspaces

### DIFF
--- a/api/src/apps-v2/migrate-v1-apps.cli.ts
+++ b/api/src/apps-v2/migrate-v1-apps.cli.ts
@@ -31,6 +31,7 @@ async function main(): Promise<void> {
   const appId = arg("app");
   const execute = process.argv.includes("--execute");
   const reset = process.argv.includes("--reset");
+  const rowsOnly = process.argv.includes("--rows-only");
   if (!workspaceId) {
     throw new Error(
       "Usage: migrate-v1-apps --workspace <id> [--app <id>] [--execute]",
@@ -49,12 +50,15 @@ async function main(): Promise<void> {
     appId,
     execute,
     reset,
+    rowsOnly,
   });
   for (const r of results) {
     // Execute mode never skips — a stamped app is overwritten in place — so
     // the marker reports what HAPPENED, with the stamp as an annotation.
     const marker = execute
-      ? `MIGRATED -> apps/${r.slug}` +
+      ? (rowsOnly
+          ? `ROW-BACKFILLED -> apps/${r.slug}`
+          : `MIGRATED -> apps/${r.slug}`) +
         (r.alreadyMigrated ? " (re-migrated, replaced in place)" : "")
       : r.alreadyMigrated
         ? "SKIP (already migrated — execute would replace it)"

--- a/api/src/apps-v2/migrate-v1-apps.test.ts
+++ b/api/src/apps-v2/migrate-v1-apps.test.ts
@@ -170,13 +170,11 @@ describe("v1 → v2 migration", () => {
     const app = await makeV1App();
 
     // A real user for author resolution (raw insert: user ids are strings).
-    await mongoose.connection.db
-      ?.collection("users")
-      .insertOne({
-        _id: "user-1" as never,
-        email: "dev@example.com",
-        name: "Dev One",
-      });
+    await mongoose.connection.db?.collection("users").insertOne({
+      _id: "user-1" as never,
+      email: "dev@example.com",
+      name: "Dev One",
+    });
 
     const base = {
       workspaceId: app.workspaceId,
@@ -328,6 +326,70 @@ describe("v1 → v2 migration", () => {
     const stamped = await MakoApp.findById(app._id);
     expect(stamped?.migratedToV2ProjectId?.toString()).toBe(mine.projectId);
   }, 180_000);
+
+  it("rows-only backfill carries the ACL and stamps, writes no git", async () => {
+    const { migrateWorkspaceV1Apps } = await import("./migrate-v1-apps");
+    const { derivedAppId } = await import("./worktree.service");
+    const { MakoApp, AppProjectV2 } = await import(
+      "../database/workspace-schema"
+    );
+    const { initRepo, repoDirFor } = await import("./repository.service");
+    const ws3 = new Types.ObjectId().toString();
+    // The imported repo already holds the folder — that is the premise of a
+    // rows-only backfill (and the folder guard skips apps without one).
+    await initRepo(repoDirFor(ws3), {
+      "apps/imported-private/mako.json": JSON.stringify({
+        title: "Imported Private",
+      }),
+    });
+    await MakoApp.create({
+      workspaceId: new Types.ObjectId(ws3),
+      title: "Imported Private",
+      template: "react",
+      runtime: "cdn",
+      entrypoint: "App.tsx",
+      files: [{ path: "a.ts", contents: "1\n" }],
+      dependencies: {},
+      dataBindings: [],
+      version: 1,
+      access: "private",
+      createdBy: "owner-1",
+    });
+
+    const results = await migrateWorkspaceV1Apps({
+      workspaceId: ws3,
+      execute: true,
+      rowsOnly: true,
+    });
+    expect(results).toHaveLength(1);
+    const slug = results[0].slug!;
+    const row = await AppProjectV2.findOne({
+      _id: derivedAppId(ws3, slug),
+    });
+    // The row exists under the DERIVED id with the v1 ACL carried over…
+    expect(row).not.toBeNull();
+    expect(row?.access).toBe("private");
+    expect(row?.createdBy).toBe("owner-1");
+    // …the v1 doc is stamped (v1 scheduler dedup + future guards key off it)…
+    const stamped = await MakoApp.findOne({
+      workspaceId: new Types.ObjectId(ws3),
+    });
+    expect(stamped?.migratedToV2ProjectId?.toString()).toBe(
+      row?._id.toString(),
+    );
+    // …and re-running is idempotent.
+    const again = await migrateWorkspaceV1Apps({
+      workspaceId: ws3,
+      execute: true,
+      rowsOnly: true,
+    });
+    expect(again[0].projectId).toBe(results[0].projectId);
+    expect(
+      await AppProjectV2.countDocuments({
+        workspaceId: new Types.ObjectId(ws3),
+      }),
+    ).toBe(1);
+  }, 60_000);
 
   it("dry run writes nothing", async () => {
     const { migrateWorkspaceV1Apps } = await import("./migrate-v1-apps");

--- a/api/src/apps-v2/migrate-v1-apps.ts
+++ b/api/src/apps-v2/migrate-v1-apps.ts
@@ -50,6 +50,8 @@ import { loggers } from "../logging";
 import { APP_SDK_DEPENDENCY } from "./app-sdk-package";
 import { createAppsV2Scaffold } from "./scaffold";
 import {
+  listAppFolders,
+  derivedAppId,
   appRootFor,
   commitFilesOnBranch,
   createProject,
@@ -673,6 +675,77 @@ export async function clearWorkspaceV2Apps(workspaceId: string): Promise<{
   };
 }
 
+/**
+ * ROWS-ONLY backfill (§13.22) for workspaces whose repo arrived by
+ * connected-repo IMPORT: the git side is already correct, but the import
+ * writes no database rows — so formerly-private apps are workspace-visible,
+ * the v1 docs carry no migration stamp (the v1 scheduler keeps refreshing
+ * them), and publish/share had nothing to persist against until they
+ * materialize a row. This writes exactly what the full migration would have:
+ * the AppProjectV2 row under the DERIVED id (same id every folder-only code
+ * path synthesizes, so nothing moves) with the v1 ACL carried over, and the
+ * stamp on the v1 doc. No git writes, no artifact copies — fresh
+ * materializations rebuild data (the v2 scheduler handles scheduled
+ * bindings on its own).
+ */
+export async function backfillV1AppRow(
+  app: IMakoApp,
+  slug: string,
+): Promise<V1AppMigrationResult> {
+  const plan = planV1AppMigration(app);
+  const workspaceId = app.workspaceId.toString();
+  // Only back-fill apps whose folder actually exists in the (imported) repo:
+  // stamping a v1 app with no v2 counterpart would stop its v1 refreshes
+  // while nothing replaces them — a v1 app created AFTER the repo snapshot
+  // must stay fully v1 until a real migration run brings it over.
+  const folders = await listAppFolders(workspaceId);
+  if (!folders.some(f => f.slug === slug)) {
+    logger.warn("Rows-only backfill skipped: no folder for this app", {
+      v1AppId: app._id.toString(),
+      slug,
+    });
+    return { ...plan, slug, versions: 0, versionCommits: 0 };
+  }
+  const id = derivedAppId(workspaceId, slug);
+  const existing = await AppProjectV2.findOne({ _id: id });
+  if (!existing) {
+    try {
+      await AppProjectV2.create({
+        _id: id,
+        workspaceId: app.workspaceId,
+        title: app.title,
+        slug,
+        description: app.description,
+        access: plan.access,
+        workspaceRole: plan.workspaceRole,
+        sharedWith: plan.sharedWith ?? [],
+        createdBy: app.owner_id || app.createdBy || "system",
+        owner_id: app.owner_id || app.createdBy,
+        defaultBranch: "main",
+      });
+    } catch (error) {
+      // Unique-index race or slug collision with a hand-made app: adopt the
+      // occupant rather than fighting it; the stamp below still applies.
+      logger.warn("Rows-only backfill could not create the row", {
+        v1AppId: app._id.toString(),
+        slug,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  await MakoApp.updateOne(
+    { _id: app._id },
+    { $set: { migratedToV2ProjectId: id } },
+  );
+  return {
+    ...plan,
+    projectId: id.toString(),
+    slug,
+    versions: 0,
+    versionCommits: 0,
+  };
+}
+
 /** Migrate every v1 app in a workspace (or one app). */
 export async function migrateWorkspaceV1Apps(input: {
   workspaceId: string;
@@ -680,6 +753,8 @@ export async function migrateWorkspaceV1Apps(input: {
   execute: boolean;
   /** Wipe all existing v2 apps first (see clearWorkspaceV2Apps). */
   reset?: boolean;
+  /** §13.22: DB rows + stamps only — for repo-imported workspaces. */
+  rowsOnly?: boolean;
 }): Promise<V1AppMigrationResult[]> {
   if (input.execute && input.reset && !input.appId) {
     const cleared = await clearWorkspaceV2Apps(input.workspaceId);
@@ -715,7 +790,9 @@ export async function migrateWorkspaceV1Apps(input: {
     const slug = slugs.get(app._id.toString()) ?? slugify(app.title);
     results.push(
       input.execute
-        ? await migrateV1App(app, slug)
+        ? input.rowsOnly
+          ? await backfillV1AppRow(app, slug)
+          : await migrateV1App(app, slug)
         : {
             ...planV1AppMigration(app),
             versions: versionCounts.get(app._id.toString()) ?? 0,


### PR DESCRIPTION
Writes the database half of the v1→v2 migration (ACL rows under derived ids + stamps) for workspaces migrated via connected-repo import. Folder-existence guard skips post-snapshot v1 apps. Spec in the migrate suite (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x