### PR TITLE
feat(apps-v2): My Apps / Workspace sections with drag-to-share parity

### DIFF
--- a/api/src/routes/apps-v2.ts
+++ b/api/src/routes/apps-v2.ts
@@ -21,7 +21,11 @@ import { loggers, enrichContextWithWorkspace } from "../logging";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
-import { canReadResource, canWriteResource } from "../utils/resource-acl";
+import {
+  canManageSharing,
+  canReadResource,
+  canWriteResource,
+} from "../utils/resource-acl";
 import {
   getGitHubAppClientId,
   getGitHubAppSlug,
@@ -2200,6 +2204,62 @@ appsV2Routes.openapi(
         },
         200,
       );
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+appsV2Routes.openapi(
+  createRoute({
+    method: "patch",
+    path: "/{id}/access",
+    tags: ["Apps v2"],
+    summary: "Set an app's sharing scope (My Apps <-> Workspace)",
+    description:
+      "The v1 rail's drag-between-sections, for v2: private = the owner's own list, workspace = everyone's. Folder-only apps get their row here (restricting is one of the three row-creating acts, §13.6).",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam,
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: z.object({ access: z.enum(["private", "workspace"]) }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: true });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const { access } = c.req.valid("json");
+      const userId = loaded.userId;
+      const role = await memberRoleFor(
+        loaded.project.workspaceId.toString(),
+        userId,
+      );
+      // Same gate as v1: the owner always; a workspace admin only for
+      // non-private apps (admins must not discover-or-toggle private ones).
+      if (!canManageSharing(loaded.project, userId, role)) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Only the owner (or an admin, for workspace apps) can change sharing",
+          },
+          403,
+        );
+      }
+      const project = await ensureProjectRow(
+        loaded.project,
+        userId ?? "api-key",
+      );
+      await AppProjectV2.updateOne({ _id: project._id }, { $set: { access } });
+      return c.json({ success: true as const, access }, 200);
     } catch (error) {
       return handleError(c, error);
     }

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -4428,6 +4428,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps-v2/{id}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set an app's sharing scope (My Apps <-> Workspace)
+         * @description The v1 rail's drag-between-sections, for v2: private = the owner's own list, workspace = everyone's. Folder-only apps get their row here (restricting is one of the three row-creating acts, §13.6).
+         */
+        patch: operations["patch_api_workspaces_workspaceId_apps_v2_id_access"];
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps-v2/{id}/public-share": {
         parameters: {
             query?: never;
@@ -19868,6 +19888,54 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    patch_api_workspaces_workspaceId_apps_v2_id_access: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    access: "private" | "workspace";
+                };
+            };
+        };
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/components/AppsV2Explorer.tsx
+++ b/app/src/components/AppsV2Explorer.tsx
@@ -20,6 +20,8 @@ import {
   Typography,
 } from "@mui/material";
 import {
+  Globe as GlobeIcon,
+  User as UserIcon,
   Braces as JsonFileIcon,
   Database as BindingIcon,
   File as PlainFileIcon,
@@ -160,6 +162,7 @@ export default function AppsV2Explorer() {
   const fetchRunningDevApps = useAppsV2Store(s => s.fetchRunningDevApps);
   const filesTruncatedByApp = useAppsV2Store(s => s.filesTruncatedByApp);
   const fetchApps = useAppsV2Store(s => s.fetchApps);
+  const setAppAccess = useAppsV2Store(s => s.setAppAccess);
   const fetchFiles = useAppsV2Store(s => s.fetchFiles);
   const createApp = useAppsV2Store(s => s.createApp);
   const deleteApp = useAppsV2Store(s => s.deleteApp);
@@ -258,16 +261,61 @@ export default function AppsV2Explorer() {
         : undefined,
     }));
     // §10 monorepo: ONE repo per workspace — the repo is not a tree level.
-    // The rail lists apps directly (org/repo grouping died with N-repos).
+    // Two sections, IDENTICAL to the v1 rail ("My Apps" / "Workspace", split
+    // by access), so the v1->v2 cutover is invisible in the tree. Access is
+    // organization, not security (§11.5): builders with repo access see all
+    // folders either way.
+    const byId = new Map(apps.map(a => [a.id, a]));
+    const mine = appNodes.filter(
+      n => (byId.get(n.id)?.access ?? "workspace") !== "workspace",
+    );
+    const shared = appNodes.filter(
+      n => (byId.get(n.id)?.access ?? "workspace") === "workspace",
+    );
     return [
       {
-        key: "apps",
-        label: "Apps",
-        nodes: appNodes,
-        hideSectionHeader: true,
+        key: "my",
+        label: "My Apps",
+        icon: <UserIcon size={16} strokeWidth={1.5} />,
+        nodes: mine,
+        droppableId: "__section_my",
+        defaultAccess: "private" as const,
+      },
+      {
+        key: "workspace",
+        label: "Workspace",
+        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
+        nodes: shared,
+        droppableId: "__section_workspace",
+        defaultAccess: "workspace" as const,
       },
     ];
   }, [apps, filesByApp]);
+
+  // Drag an app onto the other section (or any node inside it) to flip its
+  // sharing — the exact v1 gesture. Drops within the same section no-op.
+  const handleMoveNode = useCallback(
+    (nodeId: string, targetId: string | null, access?: string) => {
+      if (!workspaceId) return;
+      const parsed = parseNodeId(nodeId);
+      if (parsed.kind !== "app") return;
+      const accessOf = (appId: string) =>
+        (apps.find(a => a.id === appId)?.access ?? "workspace") === "workspace"
+          ? "workspace"
+          : "private";
+      let next: "private" | "workspace" | null =
+        access === "private" || access === "workspace" ? access : null;
+      if (!next && targetId) {
+        const target = parseNodeId(targetId);
+        if (target.kind === "app" || target.kind === "file") {
+          next = accessOf(target.appId);
+        }
+      }
+      if (!next || accessOf(parsed.appId) === next) return;
+      void setAppAccess(workspaceId, parsed.appId, next);
+    },
+    [workspaceId, apps, setAppAccess],
+  );
 
   const handleLoadChildren = useCallback(
     async (node: ResourceTreeNode) => {
@@ -437,6 +485,9 @@ export default function AppsV2Explorer() {
                   </Typography>
                 )}
                 <ResourceTree
+                  enableDragDrop
+                  onMoveItem={handleMoveNode}
+                  onMoveFolder={handleMoveNode}
                   sections={sections}
                   mode="sidebar"
                   searchQuery={searchQuery}

--- a/app/src/store/appsV2Store.ts
+++ b/app/src/store/appsV2Store.ts
@@ -28,6 +28,8 @@ export interface AppV2Meta {
   /** Commit sha currently deployed, if the app has ever been published. */
   publishedSha?: string;
   publishedAt?: string;
+  /** Sharing scope: private = owner's "My Apps", workspace = everyone's. */
+  access?: "private" | "workspace";
 }
 
 export interface AppV2FileEntry {
@@ -258,6 +260,12 @@ interface AppsV2Store {
     installationId: number,
   ) => Promise<{ ok: boolean; error?: string }>;
   fetchApps: (workspaceId: string) => Promise<void>;
+  /** Drag between rail sections: flip private <-> workspace. */
+  setAppAccess: (
+    workspaceId: string,
+    appId: string,
+    access: "private" | "workspace",
+  ) => Promise<void>;
   createApp: (
     workspaceId: string,
     title: string,
@@ -670,6 +678,24 @@ export const useAppsV2Store = create<AppsV2Store>()(
             s.error = message(e, "Failed to load apps");
           }
         });
+      }
+    },
+
+    setAppAccess: async (workspaceId, appId, access) => {
+      // Optimistic: the row moves sections immediately; server truth on error.
+      set(s => {
+        const app = s.apps.find(a => a.id === appId);
+        if (app) app.access = access;
+      });
+      try {
+        unwrapBody(
+          await api.PATCH("/api/workspaces/{workspaceId}/apps-v2/{id}/access", {
+            params: { path: { workspaceId, id: appId } },
+            body: { access },
+          }),
+        );
+      } catch {
+        void get().fetchApps(workspaceId);
       }
     },
 

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -27581,6 +27581,106 @@
         "operationId": "post_api_workspaces_workspaceId_apps_v2_id_view_token"
       }
     },
+    "/api/workspaces/{workspaceId}/apps-v2/{id}/access": {
+      "patch": {
+        "tags": [
+          "Apps v2"
+        ],
+        "summary": "Set an app's sharing scope (My Apps <-> Workspace)",
+        "description": "The v1 rail's drag-between-sections, for v2: private = the owner's own list, workspace = everyone's. Folder-only apps get their row here (restricting is one of the three row-creating acts, §13.6).",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "workspace"
+                    ]
+                  }
+                },
+                "required": [
+                  "access"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patch_api_workspaces_workspaceId_apps_v2_id_access"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps-v2/{id}/public-share": {
       "post": {
         "tags": [


### PR DESCRIPTION
Two-section rail identical to v1 (split by access), drag between sections flips sharing via new PATCH /{id}/access (canManageSharing gate, row materialized on restrict). Contract regenerated. Live-verified on both accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x