### PR TITLE
fix(agent): chat saves survive browse-heavy turns; browse serves text-only models

### DIFF
--- a/api/src/agent-lib/tools/apps-v2-tools.ts
+++ b/api/src/agent-lib/tools/apps-v2-tools.ts
@@ -562,7 +562,9 @@ export function createAppsV2Tools({
         "screenshot (you SEE it) plus console errors and failed requests. " +
         "Use it after edits to verify what actually renders, and to debug " +
         "blank screens. Needs a running dev session (app2_open_app). First " +
-        "use in a fresh sandbox installs the browser (~30-60s).",
+        "use in a fresh sandbox installs the browser (~30-60s). If your " +
+        "model cannot read images, pass screenshot:false — pageText, " +
+        "console and failed requests still tell you what rendered.",
       inputSchema: z.object({
         appId: z.string(),
         steps: z

--- a/api/src/apps-v2/eyes.service.ts
+++ b/api/src/apps-v2/eyes.service.ts
@@ -43,6 +43,8 @@ export interface EyesResult {
   droppedBeyondCaps?: Record<string, number>;
   /** JPEG, base64 (no data: prefix). */
   screenshotBase64?: string;
+  /** Rendered body text (capped) — real signal for models without vision. */
+  pageText?: string;
 }
 
 /**
@@ -152,12 +154,16 @@ try {
       await page.evaluate(() => (window.__makoEyesFlush ? window.__makoEyesFlush() : null));
     } catch {}
     await settle(400);
+    let pageText = "";
+    try {
+      pageText = String(await page.evaluate(() => (document.body && document.body.innerText) || "")).slice(0, 6000);
+    } catch {}
     let screenshotBase64;
     if (wantShot) {
       screenshotBase64 = await page.screenshot({ type: "jpeg", quality: 55, encoding: "base64" });
     }
     const truncated = Object.fromEntries(Object.entries(droppedCounts).filter(e => e[1] > 0));
-    out({ ok: true, url: page.url(), stepResults, consoleLogs, pageErrors, failedRequests, ...(Object.keys(truncated).length ? { droppedBeyondCaps: truncated } : {}), screenshotBase64 });
+    out({ ok: true, url: page.url(), pageText, stepResults, consoleLogs, pageErrors, failedRequests, ...(Object.keys(truncated).length ? { droppedBeyondCaps: truncated } : {}), screenshotBase64 });
   } finally {
     await browser.close().catch(() => {});
   }

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -4,7 +4,11 @@ import type { UIMessage } from "ai";
 import { Chat, SavedConsole } from "../database/workspace-schema";
 import type { AgentKind } from "../agent-lib";
 import { loggers } from "../logging";
-import { isModelReadyFilePart } from "../utils/message-sanitizer";
+import {
+  sanitizeMessagesForPersistence,
+  stripToolOutputsForRetry,
+  isModelReadyFilePart,
+} from "../utils/message-sanitizer";
 import {
   dedupeAssistantReasoning,
   dedupeAssistantStreamArtifacts,
@@ -697,9 +701,11 @@ export const saveChat = async (
   // inline-base64 approach could blow past MongoDB's 16 MB BSON limit, silently
   // failing the save so images "disappeared" on reload) and lets images be
   // fetched lazily. Best-effort: on failure the original part is kept inline.
-  let messagesToPersist = messages;
+  // Tool outputs first: drop screenshots and truncate pathological payloads
+  // BEFORE the size-sensitive steps below — see sanitizeMessagesForPersistence.
+  let messagesToPersist = sanitizeMessagesForPersistence(messages);
   try {
-    messagesToPersist = await externalizeChatAttachments(messages, {
+    messagesToPersist = await externalizeChatAttachments(messagesToPersist, {
       workspaceId,
       chatId,
       userId,
@@ -814,11 +820,36 @@ export const saveChat = async (
     };
   }
 
-  const result = await Chat.findOneAndUpdate(
-    { _id: new ObjectId(chatId) },
-    updateOp,
-    { upsert: true, new: true },
-  );
+  let result;
+  try {
+    result = await Chat.findOneAndUpdate(
+      { _id: new ObjectId(chatId) },
+      updateOp,
+      { upsert: true, new: true },
+    );
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (!/BSON|too large|larger than/i.test(msg)) throw error;
+    // The messages array outgrew Mongo's document limit despite the
+    // sanitizer. Retry once with every tool output reduced to a preview —
+    // losing payloads beats silently losing the whole conversation (§13.25).
+    logger.error(
+      "Chat save exceeded BSON limit; retrying with stripped tool outputs",
+      {
+        chatId,
+        error: msg,
+      },
+    );
+    (updateOp.$set as Record<string, unknown>).messages =
+      stripToolOutputsForRetry(artifactDedupe.messages).map(
+        convertUIMessageToStoredFormat,
+      );
+    result = await Chat.findOneAndUpdate(
+      { _id: new ObjectId(chatId) },
+      updateOp,
+      { upsert: true, new: true },
+    );
+  }
 
   return result;
 };

--- a/api/src/utils/message-sanitizer.test.ts
+++ b/api/src/utils/message-sanitizer.test.ts
@@ -12,7 +12,11 @@
  */
 import assert from "node:assert/strict";
 import { convertToModelMessages, type UIMessage } from "ai";
-import { sanitizeMessagesForModel } from "./message-sanitizer";
+import {
+  sanitizeMessagesForPersistence,
+  stripToolOutputsForRetry,
+  sanitizeMessagesForModel,
+} from "./message-sanitizer";
 
 type LoosePart = Record<string, unknown>;
 
@@ -192,3 +196,69 @@ async function main() {
 }
 
 void main();
+
+// ---- persistence sanitizers (§13.25) ----
+{
+  const big = "x".repeat(300 * 1024);
+  const messages = [
+    { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    {
+      id: "a1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "looking" },
+        {
+          type: "tool-app2_browse",
+          toolCallId: "t1",
+          state: "output-available",
+          input: {},
+          output: { ok: true, screenshotBase64: big, consoleLogs: ["a"] },
+        },
+        {
+          type: "tool-app2_dev_log",
+          toolCallId: "t2",
+          state: "output-available",
+          input: {},
+          output: { ok: true, log: big },
+        },
+      ],
+    },
+  ] as unknown as UIMessage[];
+  const out = sanitizeMessagesForPersistence(messages);
+  const parts = (
+    out[1] as { parts: Array<{ output?: Record<string, unknown> }> }
+  ).parts;
+  assert.ok(
+    !("screenshotBase64" in (parts[1].output ?? {})),
+    "screenshot dropped",
+  );
+  assert.equal(parts[1].output?.screenshotOmitted, true);
+  assert.deepEqual(parts[1].output?.consoleLogs, ["a"], "rest of output kept");
+  assert.equal(
+    parts[2].output?.truncatedForStorage,
+    true,
+    "oversized output truncated",
+  );
+  assert.ok(
+    Buffer.byteLength(JSON.stringify(out), "utf8") < 64 * 1024,
+    "sanitized payload is small",
+  );
+  // user message untouched, original array unmutated
+  assert.equal((messages[1] as { parts: unknown[] }).parts.length, 3);
+  assert.equal(
+    (
+      (messages[1] as { parts: Array<{ output?: Record<string, unknown> }> })
+        .parts[1].output ?? {}
+    ).screenshotBase64,
+    big,
+    "input not mutated",
+  );
+
+  const stripped = stripToolOutputsForRetry(messages);
+  const sparts = (
+    stripped[1] as { parts: Array<{ output?: Record<string, unknown> }> }
+  ).parts;
+  assert.equal(sparts[1].output?.truncatedForStorage, true);
+  assert.ok(String(sparts[1].output?.preview).length <= 1024);
+  console.log("persistence sanitizer tests passed");
+}

--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -231,3 +231,78 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
     return { ...msg, parts: sanitizedParts as UIMessage["parts"] };
   });
 }
+
+/**
+ * Shrink assistant TOOL outputs before persistence (§13.25). Found on prod:
+ * an app2_browse-heavy turn carries screenshots as base64 inside tool
+ * outputs; externalizeChatAttachments only covers user image `file` parts,
+ * so the stored messages array blew past MongoDB's 16 MB BSON limit and the
+ * WHOLE save threw — caught by a log-only catch, the entire turn vanished
+ * on reload while the agent's work (commits, publishes) survived. The
+ * screenshot's post-turn value is nil (the model already saw it), so it is
+ * dropped here; any other pathologically large output is truncated with a
+ * marker rather than sinking the save.
+ */
+const MAX_STORED_TOOL_OUTPUT_BYTES = 256 * 1024;
+
+export function sanitizeMessagesForPersistence(
+  messages: UIMessage[],
+): UIMessage[] {
+  return messages.map(message => {
+    if (message.role !== "assistant" || !Array.isArray(message.parts)) {
+      return message;
+    }
+    let changed = false;
+    const parts = message.parts.map(part => {
+      if (!isRecord(part) || typeof part.type !== "string") return part;
+      if (!part.type.startsWith("tool-")) return part;
+      const output = (part as { output?: unknown }).output;
+      if (!isRecord(output)) return part;
+      let next = output;
+      if (typeof next.screenshotBase64 === "string") {
+        const { screenshotBase64: _dropped, ...rest } = next;
+        next = { ...rest, screenshotOmitted: true };
+      }
+      const size = Buffer.byteLength(JSON.stringify(next), "utf8");
+      if (size > MAX_STORED_TOOL_OUTPUT_BYTES) {
+        next = {
+          truncatedForStorage: true,
+          originalBytes: size,
+          preview: JSON.stringify(next).slice(0, 4096),
+        };
+      }
+      if (next === output) return part;
+      changed = true;
+      return { ...part, output: next };
+    });
+    return changed
+      ? { ...message, parts: parts as typeof message.parts }
+      : message;
+  });
+}
+
+/**
+ * Last-resort shrink for a BSON-overflow retry: every tool output becomes a
+ * small preview. Losing tool payloads beats losing the conversation.
+ */
+export function stripToolOutputsForRetry(messages: UIMessage[]): UIMessage[] {
+  return messages.map(message => {
+    if (message.role !== "assistant" || !Array.isArray(message.parts)) {
+      return message;
+    }
+    const parts = message.parts.map(part => {
+      if (!isRecord(part) || typeof part.type !== "string") return part;
+      if (!part.type.startsWith("tool-")) return part;
+      const output = (part as { output?: unknown }).output;
+      if (output === undefined) return part;
+      return {
+        ...part,
+        output: {
+          truncatedForStorage: true,
+          preview: JSON.stringify(output ?? null).slice(0, 1024),
+        },
+      };
+    });
+    return { ...message, parts: parts as typeof message.parts };
+  });
+}


### PR DESCRIPTION
Tool-output screenshots blew the 16MB BSON limit and the whole turn's save was silently swallowed (prod incident). Persistence now drops stored screenshots + truncates pathological outputs, with a stripped-retry on BSON overflow. Browse gains pageText for non-vision models. Unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x