### PR TITLE
feat(catalog): gateway modalities + release dates (vision from real data, sortable models list)

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -775,11 +775,8 @@ agentRoutes.openapi(
     // Vision capability for tool outputs (browse screenshots): resolved from
     // the catalog BEFORE tool construction so toModelOutput can gate image
     // parts for text-only models (§13.26). getModelById is memory-cached.
-    agentContext.modelSupportsVision = modelSupportsImageInput(
-      resolvedModelId,
-      ((await getModelById(resolvedModelId)) as { tags?: string[] } | undefined)
-        ?.tags,
-    );
+    agentContext.modelSupportsVision =
+      await modelSupportsImageInput(resolvedModelId);
 
     if (resolvedAgentId === "unified") {
       const runtime = buildUnifiedModeRuntime({

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -39,6 +39,10 @@ export interface CatalogModel {
   description: string;
   contextWindow: number | null;
   tags: string[];
+  /** Unix seconds the model was released (gateway `released`); null pre-upgrade. */
+  releasedAt: number | null;
+  /** Accepts image input (gateway modalities); null = unknown (old snapshot). */
+  imageInput: boolean | null;
   supportsThinking: boolean;
   thinkingMode: AnthropicThinkingMode;
   thinkingBudgetTokens: number;
@@ -74,6 +78,8 @@ export interface AdminCatalogModel {
   description: string;
   contextWindow: number | null;
   tags: string[];
+  releasedAt: number | null;
+  imageInput: boolean | null;
   blendedCostPerM: number | null;
   visible: boolean;
   tier: "free" | "pro";
@@ -107,6 +113,16 @@ const GatewayPricingSchema = z
 
 const GatewayModelRawSchema = z.object({
   id: z.string(),
+  /** Model release date, unix seconds (the gateway sends it for all models). */
+  released: z.number().optional(),
+  /** Input/output modalities — the real vision signal ("image" in input). */
+  modalities: z
+    .object({
+      input: z.array(z.string()).optional(),
+      output: z.array(z.string()).optional(),
+    })
+    .passthrough()
+    .optional(),
   name: z.string().optional(),
   description: z.string().optional(),
   owned_by: z.string().optional(),
@@ -161,6 +177,10 @@ interface GatewayModelNormalized {
   provider: string;
   contextWindow: number | null;
   tags: string[];
+  /** Unix seconds; null on pre-upgrade snapshots. */
+  releasedAt?: number | null;
+  /** modalities.input includes "image"; null = unknown (old snapshot). */
+  imageInput?: boolean | null;
 }
 
 interface PricingEntry {
@@ -317,6 +337,10 @@ async function persistLanguageSnapshot(
     provider: raw.owned_by || raw.id.split("/")[0] || "unknown",
     contextWindow: raw.context_window ?? null,
     tags: raw.tags ?? [],
+    releasedAt: raw.released ?? null,
+    imageInput: raw.modalities?.input
+      ? raw.modalities.input.includes("image")
+      : null,
   }));
 
   const pricingDocs: PricingEntry[] = [];
@@ -664,6 +688,8 @@ function mergeCatalog(
     if (tier === "free") freeTierIds.add(gm.id);
 
     models.push({
+      releasedAt: gm.releasedAt ?? null,
+      imageInput: gm.imageInput ?? null,
       id: gm.id,
       provider: gm.provider,
       name: gm.name,
@@ -1035,6 +1061,8 @@ export async function getAdminCatalogView(): Promise<AdminCatalogView> {
       description: gm.description,
       contextWindow: gm.contextWindow,
       tags: gm.tags,
+      releasedAt: gm.releasedAt ?? null,
+      imageInput: gm.imageInput ?? null,
       blendedCostPerM,
       // Fail-closed: missing curation entry = hidden pro
       visible: cur?.visible ?? false,
@@ -1085,10 +1113,29 @@ const VISION_ID_PATTERNS: RegExp[] = [
   /grok-(2-vision|4)/i,
 ];
 
-export function modelSupportsImageInput(
+function visionByPattern(
   modelId: string,
   tags?: readonly string[] | null,
 ): boolean {
   if (tags?.some(t => VISION_TAGS.has(t.toLowerCase()))) return true;
   return VISION_ID_PATTERNS.some(re => re.test(modelId));
+}
+
+/**
+ * Catalog-first: the gateway reports modalities.input explicitly for every
+ * model, so a refreshed snapshot answers authoritatively. The pattern
+ * fallback only covers pre-upgrade snapshots and models missing from the
+ * catalog entirely.
+ */
+export async function modelSupportsImageInput(
+  modelId: string,
+): Promise<boolean> {
+  try {
+    const catalog = await getCatalogModels();
+    const entry = catalog.find(mm => mm.id === modelId);
+    if (entry?.imageInput != null) return entry.imageInput;
+    return visionByPattern(modelId, entry?.tags);
+  } catch {
+    return visionByPattern(modelId);
+  }
 }

--- a/app/src/pages/settings/SettingsAdmin.tsx
+++ b/app/src/pages/settings/SettingsAdmin.tsx
@@ -31,6 +31,10 @@ interface AdminCuratedModel {
   description: string;
   contextWindow: number | null;
   blendedCostPerM: number | null;
+  /** Unix seconds the model was released (gateway `released`). */
+  releasedAt: number | null;
+  /** Accepts image input (gateway modalities). */
+  imageInput: boolean | null;
   visible: boolean;
   tier: "free" | "pro";
 }
@@ -225,6 +229,7 @@ export default function SettingsAdmin() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [releasedSort, setReleasedSort] = useState<"desc" | "asc" | null>(null);
   const [hardRefreshing, setHardRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [refreshNotice, setRefreshNotice] = useState<string | null>(null);
@@ -550,6 +555,20 @@ export default function SettingsAdmin() {
                   <TableRow>
                     <TableCell>Model</TableCell>
                     <TableCell sx={{ width: 120 }}>Provider</TableCell>
+                    <TableCell
+                      sx={{ width: 100, cursor: "pointer", userSelect: "none" }}
+                      onClick={() =>
+                        setReleasedSort(s => (s === "desc" ? "asc" : "desc"))
+                      }
+                      title="Sort by release date"
+                    >
+                      Released{" "}
+                      {releasedSort === "desc"
+                        ? "\u2193"
+                        : releasedSort === "asc"
+                          ? "\u2191"
+                          : ""}
+                    </TableCell>
                     <TableCell align="right" sx={{ width: 90 }}>
                       $/M
                     </TableCell>
@@ -569,7 +588,14 @@ export default function SettingsAdmin() {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {filteredModels.map(m => (
+                  {(releasedSort
+                    ? [...filteredModels].sort((a, b) =>
+                        releasedSort === "desc"
+                          ? (b.releasedAt ?? 0) - (a.releasedAt ?? 0)
+                          : (a.releasedAt ?? 0) - (b.releasedAt ?? 0),
+                      )
+                    : filteredModels
+                  ).map(m => (
                     <TableRow key={m.id} hover>
                       <TableCell>
                         <Typography variant="body2" noWrap>
@@ -587,6 +613,21 @@ export default function SettingsAdmin() {
                       <TableCell>
                         <Typography variant="body2" noWrap>
                           {m.provider}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          noWrap
+                          color={
+                            m.releasedAt ? "text.primary" : "text.disabled"
+                          }
+                        >
+                          {m.releasedAt
+                            ? new Date(m.releasedAt * 1000)
+                                .toISOString()
+                                .slice(0, 10)
+                            : "\u2014"}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">


### PR DESCRIPTION
Gateway returns modalities.input + released for all 360 models; schema now keeps them, vision detection is catalog-first (patterns only as fallback), and the admin models table shows a sortable Released column. Verified live after a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x