### PR TITLE
feat(catalog): raw gateway snapshot + knowledge-cutoff column

### DIFF
--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -39,6 +39,7 @@ export interface CatalogModel {
   description: string;
   contextWindow: number | null;
   tags: string[];
+  knowledgeCutoff: string | null;
   /** Unix seconds the model was released (gateway `released`); null pre-upgrade. */
   releasedAt: number | null;
   /** Accepts image input (gateway modalities); null = unknown (old snapshot). */
@@ -78,6 +79,7 @@ export interface AdminCatalogModel {
   description: string;
   contextWindow: number | null;
   tags: string[];
+  knowledgeCutoff: string | null;
   releasedAt: number | null;
   imageInput: boolean | null;
   blendedCostPerM: number | null;
@@ -113,6 +115,8 @@ const GatewayPricingSchema = z
 
 const GatewayModelRawSchema = z.object({
   id: z.string(),
+  /** Knowledge cutoff (e.g. "2025-03-31"); present on ~160 models. */
+  knowledge: z.string().optional(),
   /** Model release date, unix seconds (the gateway sends it for all models). */
   released: z.number().optional(),
   /** Input/output modalities — the real vision signal ("image" in input). */
@@ -177,6 +181,8 @@ interface GatewayModelNormalized {
   provider: string;
   contextWindow: number | null;
   tags: string[];
+  /** Knowledge cutoff date string; null = gateway does not report it. */
+  knowledgeCutoff?: string | null;
   /** Unix seconds; null on pre-upgrade snapshots. */
   releasedAt?: number | null;
   /** modalities.input includes "image"; null = unknown (old snapshot). */
@@ -320,6 +326,10 @@ type GatewayModelRaw = z.infer<typeof GatewayModelRawSchema>;
  */
 async function persistLanguageSnapshot(
   entries: GatewayModelRaw[],
+  /** The UNVALIDATED gateway rows — persisted verbatim (§: raw snapshot) so
+   *  future field questions are queries against stored truth, not
+   *  re-implementation + refetch. ~1.5MB for 360 models; well under BSON. */
+  rawEntries?: unknown[],
 ): Promise<
   { models: number; pricedModels: number } | { skipped: true; reason: string }
 > {
@@ -338,6 +348,7 @@ async function persistLanguageSnapshot(
     contextWindow: raw.context_window ?? null,
     tags: raw.tags ?? [],
     releasedAt: raw.released ?? null,
+    knowledgeCutoff: raw.knowledge ?? null,
     imageInput: raw.modalities?.input
       ? raw.modalities.input.includes("image")
       : null,
@@ -367,6 +378,19 @@ async function persistLanguageSnapshot(
       { data: pricingDocs, fetchedAt: now, itemCount: pricingDocs.length },
       { upsert: true },
     ),
+    ...(rawEntries
+      ? [
+          ModelCatalogSnapshot.findOneAndUpdate(
+            { _id: "gateway-raw" },
+            {
+              data: rawEntries,
+              fetchedAt: now,
+              itemCount: rawEntries.length,
+            },
+            { upsert: true },
+          ),
+        ]
+      : []),
   ]);
 
   logger.info("Persisted gateway + pricing snapshots", {
@@ -413,7 +437,11 @@ export async function refreshGatewaySnapshot(): Promise<
     return { skipped: true, reason };
   }
 
-  return persistLanguageSnapshot(parsed.data.data);
+  const rawRows =
+    body && typeof body === "object"
+      ? ((body as { data?: unknown }).data as unknown[] | undefined)
+      : undefined;
+  return persistLanguageSnapshot(parsed.data.data, rawRows);
 }
 
 /**
@@ -463,7 +491,7 @@ export async function hardRefreshGatewaySnapshot(): Promise<
     });
   }
 
-  const result = await persistLanguageSnapshot(validEntries);
+  const result = await persistLanguageSnapshot(validEntries, rawData);
   if ("skipped" in result) return result;
   return { ...result, droppedEntries };
 }
@@ -689,6 +717,7 @@ function mergeCatalog(
 
     models.push({
       releasedAt: gm.releasedAt ?? null,
+      knowledgeCutoff: gm.knowledgeCutoff ?? null,
       imageInput: gm.imageInput ?? null,
       id: gm.id,
       provider: gm.provider,
@@ -1062,6 +1091,7 @@ export async function getAdminCatalogView(): Promise<AdminCatalogView> {
       contextWindow: gm.contextWindow,
       tags: gm.tags,
       releasedAt: gm.releasedAt ?? null,
+      knowledgeCutoff: gm.knowledgeCutoff ?? null,
       imageInput: gm.imageInput ?? null,
       blendedCostPerM,
       // Fail-closed: missing curation entry = hidden pro

--- a/app/src/pages/settings/SettingsAdmin.tsx
+++ b/app/src/pages/settings/SettingsAdmin.tsx
@@ -33,6 +33,8 @@ interface AdminCuratedModel {
   blendedCostPerM: number | null;
   /** Unix seconds the model was released (gateway `released`). */
   releasedAt: number | null;
+  /** Knowledge cutoff date string (gateway `knowledge`). */
+  knowledgeCutoff: string | null;
   /** Accepts image input (gateway modalities). */
   imageInput: boolean | null;
   visible: boolean;
@@ -554,9 +556,9 @@ export default function SettingsAdmin() {
                 <TableHead>
                   <TableRow>
                     <TableCell>Model</TableCell>
-                    <TableCell sx={{ width: 120 }}>Provider</TableCell>
+                    <TableCell sx={{ width: 88 }}>Provider</TableCell>
                     <TableCell
-                      sx={{ width: 100, cursor: "pointer", userSelect: "none" }}
+                      sx={{ width: 92, cursor: "pointer", userSelect: "none" }}
                       onClick={() =>
                         setReleasedSort(s => (s === "desc" ? "asc" : "desc"))
                       }
@@ -569,20 +571,21 @@ export default function SettingsAdmin() {
                           ? "\u2191"
                           : ""}
                     </TableCell>
-                    <TableCell align="right" sx={{ width: 90 }}>
+                    <TableCell sx={{ width: 84 }}>Knowledge</TableCell>
+                    <TableCell align="right" sx={{ width: 68 }}>
                       $/M
                     </TableCell>
-                    <TableCell align="center" sx={{ width: 70 }}>
+                    <TableCell align="center" sx={{ width: 58 }}>
                       Visible
                     </TableCell>
-                    <TableCell sx={{ width: 90 }}>Tier</TableCell>
-                    <TableCell align="center" sx={{ width: 80 }}>
+                    <TableCell sx={{ width: 80 }}>Tier</TableCell>
+                    <TableCell align="center" sx={{ width: 66 }}>
                       Default&nbsp;paid
                     </TableCell>
-                    <TableCell align="center" sx={{ width: 80 }}>
+                    <TableCell align="center" sx={{ width: 66 }}>
                       Default&nbsp;free
                     </TableCell>
-                    <TableCell align="center" sx={{ width: 70 }}>
+                    <TableCell align="center" sx={{ width: 50 }}>
                       Fast
                     </TableCell>
                   </TableRow>
@@ -628,6 +631,19 @@ export default function SettingsAdmin() {
                                 .toISOString()
                                 .slice(0, 10)
                             : "\u2014"}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          noWrap
+                          color={
+                            m.knowledgeCutoff
+                              ? "text.secondary"
+                              : "text.disabled"
+                          }
+                        >
+                          {m.knowledgeCutoff ?? "\u2014"}
                         </Typography>
                       </TableCell>
                       <TableCell align="right">


### PR DESCRIPTION
Follow-ups to #813 from the gateway-catalog audit:

1. **Raw snapshot** — the refresh path now stores the gateway response verbatim (`model_catalog_snapshots/_id: gateway-raw`, 360 rows × 19 fields) alongside the validated projection, so fields the Zod allowlist doesn't yet map (`zdr`, `max_tokens`, `supported_parameters`, `reasoning_options`, cache pricing) are never silently dropped again.
2. **Knowledge cutoff** — `knowledge` mapped through the pipeline and shown as a Knowledge column in Super Admin, next to the sortable Released column.
3. Column-width rebalance (the two new columns had collapsed the Model column under `tableLayout: fixed`).

Verified locally: refresh → `gateway-raw` itemCount 360; sonnet-4 `knowledgeCutoff: "2025-03-31"`; UI screenshot with both columns rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x