### PR TITLE
feat(apps): v1 cutover guards — stamped apps read-only, v2 workspaces redirect

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -68,6 +68,7 @@ import {
   DbtProject,
   SavedConsole,
   type IMakoApp,
+  Workspace,
 } from "../../database/workspace-schema";
 import {
   queueAppBindingMaterialization,
@@ -247,6 +248,17 @@ export function createServerAppTools({
     error: `You do not have write access to app ${appId}.`,
   });
 
+  /** V1 apps stamped by the Apps v2 migration are read-only in v1. */
+  const migratedBlock = (doc: IMakoApp) =>
+    doc.migratedToV2ProjectId
+      ? {
+          success: false,
+          error:
+            "This app was migrated to Apps v2 and is read-only in v1. " +
+            `Use the apps-v2 tools instead (v2 project ${doc.migratedToV2ProjectId.toString()}).`,
+        }
+      : null;
+
   const wrap = async <T>(
     label: string,
     fn: () => Promise<T>,
@@ -349,6 +361,10 @@ export function createServerAppTools({
     if (isLoadError(loaded)) return { success: false, ...loaded };
     const { doc } = loaded;
     if (!(await canWrite(doc))) return denied(input.appId);
+    {
+      const blocked = migratedBlock(doc);
+      if (blocked) return blocked;
+    }
     const binding = (doc.dataBindings ?? []).find(b => b.name === input.name);
     if (!binding) {
       return {
@@ -702,6 +718,18 @@ export function createServerAppTools({
       inputSchema: createAppSchema,
       execute: async ({ title, description }) =>
         wrap("create_app", async () => {
+          const wsFlag = (await Workspace.findById(workspaceId)
+            .select("settings.appsV2Enabled")
+            .lean()) as { settings?: { appsV2Enabled?: boolean } } | null;
+          if (wsFlag?.settings?.appsV2Enabled === true) {
+            return {
+              success: false,
+              error:
+                "This workspace uses Apps v2 — v1 create_app is disabled. " +
+                "Use the apps-v2 tools to create apps.",
+            };
+          }
+
           const scaffold = createAppScaffold(title || "Untitled App");
           const created = await MakoApp.create({
             workspaceId: new Types.ObjectId(workspaceId),
@@ -999,6 +1027,10 @@ export function createServerAppTools({
           const loaded = await loadApp(appId);
           if (isLoadError(loaded)) return { success: false, ...loaded };
           if (!(await canWrite(loaded.doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(loaded.doc);
+            if (blocked) return blocked;
+          }
           const binding = (loaded.doc.dataBindings ?? []).find(
             b => b.name === name,
           );
@@ -1103,6 +1135,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           doc.files = normalizeAppFiles([
             ...(doc.files ?? []).filter(f => f.path !== path),
             { path, contents: contents ?? "" },
@@ -1134,6 +1170,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const file = (doc.files ?? []).find(f => f.path === path);
           if (!file) {
             return {
@@ -1221,6 +1261,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           doc.files = (doc.files ?? []).filter(
             f => f.path !== path,
           ) as IMakoApp["files"];
@@ -1238,6 +1282,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const file = (doc.files ?? []).find(f => f.path === from);
           if (!file) {
             return { success: false, error: `File not found: ${from}` };
@@ -1263,6 +1311,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           doc.dependencies = {
             ...(doc.dependencies ?? {}),
             [name]: depVersion || "latest",
@@ -1281,6 +1333,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const next = { ...(doc.dependencies ?? {}) };
           delete next[name];
           doc.dependencies = next;
@@ -1306,6 +1362,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(input.appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
 
           // Resolve query fields from a saved console when provided;
           // explicit input fields always win.
@@ -1516,6 +1576,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const exists = (doc.dataBindings ?? []).some(b => b.name === name);
           if (!exists) {
             return { success: false, error: `No data binding named "${name}"` };
@@ -1544,6 +1608,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const snapshot = buildAppSnapshot(doc);
           const created = await createVersion({
             entityType: "app",
@@ -1582,6 +1650,10 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          {
+            const blocked = migratedBlock(doc);
+            if (blocked) return blocked;
+          }
           const old = await getVersion(
             appId,
             "app",

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -19,6 +19,7 @@ import {
   DbtProject,
   EntityVersion,
   type IMakoApp,
+  Workspace,
 } from "../database/workspace-schema";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
@@ -97,6 +98,7 @@ interface AppListItem {
   updatedAt: Date;
   createdAt: Date;
   readOnly?: boolean;
+  migratedToV2ProjectId?: string;
 }
 
 function toListItem(
@@ -113,7 +115,12 @@ function toListItem(
     fileCount: Array.isArray(doc.files) ? doc.files.length : 0,
     updatedAt: doc.updatedAt,
     createdAt: doc.createdAt,
-    readOnly: userId ? !canManage(doc, userId, memberRole) : undefined,
+    migratedToV2ProjectId: doc.migratedToV2ProjectId?.toString(),
+    readOnly: doc.migratedToV2ProjectId
+      ? true
+      : userId
+        ? !canManage(doc, userId, memberRole)
+        : undefined,
   };
 }
 
@@ -125,6 +132,20 @@ function serializePublicShare(doc: IMakoApp) {
     token: doc.publicShare.token,
     hasPassword: !!doc.publicShare.passwordHash,
     createdAt: doc.publicShare.createdAt,
+  };
+}
+
+/**
+ * 423 body for v1 apps stamped by the Apps v2 migration (§13 cutover):
+ * the stamped copy is read-only; edits belong in the v2 project.
+ */
+function migratedToV2Body(doc: IMakoApp) {
+  return {
+    success: false,
+    code: "migrated_to_v2",
+    error:
+      "This app was migrated to Apps v2 and is read-only here. Open it under Apps.",
+    v2ProjectId: doc.migratedToV2ProjectId?.toString(),
   };
 }
 
@@ -186,6 +207,7 @@ function serializeApp(doc: IMakoApp) {
     })),
     publicShare: serializePublicShare(doc),
     owner_id: doc.owner_id,
+    migratedToV2ProjectId: doc.migratedToV2ProjectId?.toString(),
     createdBy: doc.createdBy,
     createdAt: doc.createdAt,
     updatedAt: doc.updatedAt,
@@ -380,6 +402,24 @@ app.openapi(
       const userId = c.get("user")?.id ?? "system";
       const body = await c.req.json();
 
+      // Cutover guard: v2 workspaces create apps in Apps v2, not here.
+      // (Fetched directly — the auth middleware does not reliably set
+      // c.get("workspace") on this path.)
+      const wsForCreate = (await Workspace.findById(workspaceId)
+        .select("settings.appsV2Enabled")
+        .lean()) as { settings?: { appsV2Enabled?: boolean } } | null;
+      if (wsForCreate?.settings?.appsV2Enabled === true) {
+        return c.json(
+          {
+            success: false,
+            code: "apps_v2_workspace",
+            error:
+              "This workspace uses Apps v2 — create new apps there instead.",
+          },
+          409,
+        );
+      }
+
       const parsed = AppDefinitionSchema.safeParse(body);
       if (!parsed.success) {
         return c.json(
@@ -503,7 +543,8 @@ app.openapi(
       return c.json({
         success: true,
         app: serializeApp(doc),
-        readOnly: !canManage(doc, userId, memberRole),
+        readOnly:
+          !!doc.migratedToV2ProjectId || !canManage(doc, userId, memberRole),
       });
     } catch (error) {
       logger.error("Error fetching app", { error });
@@ -541,6 +582,9 @@ app.openapi(
       const memberRole = c.get("memberRole");
       if (!canManage(doc, userId, memberRole)) {
         return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      if (doc.migratedToV2ProjectId) {
+        return c.json(migratedToV2Body(doc), 423);
       }
 
       const body = (await c.req.json()) as Record<string, unknown>;
@@ -754,6 +798,9 @@ app.openapi(
       if (!doc) return c.json({ success: false, error: "App not found" }, 404);
       if (!canManage(doc, userId, c.get("memberRole"))) {
         return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      if (doc.migratedToV2ProjectId) {
+        return c.json(migratedToV2Body(doc), 423);
       }
 
       await doc.deleteOne();
@@ -1053,6 +1100,9 @@ app.openapi(
       if (!canManage(doc, userId, c.get("memberRole"))) {
         return c.json({ success: false, error: "Access denied" }, 403);
       }
+      if (doc.migratedToV2ProjectId) {
+        return c.json(migratedToV2Body(doc), 423);
+      }
 
       const body = (await c.req.json().catch(() => ({}))) as {
         comment?: string;
@@ -1120,6 +1170,9 @@ app.openapi(
       if (!doc) return c.json({ success: false, error: "App not found" }, 404);
       if (!canManage(doc, userId, c.get("memberRole"))) {
         return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      if (doc.migratedToV2ProjectId) {
+        return c.json(migratedToV2Body(doc), 423);
       }
 
       const newSnapshot = buildAppSnapshot(doc) as unknown as Record<
@@ -1249,6 +1302,9 @@ app.openapi(
       if (!doc) return c.json({ success: false, error: "App not found" }, 404);
       if (!canManage(doc, userId, c.get("memberRole"))) {
         return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      if (doc.migratedToV2ProjectId) {
+        return c.json(migratedToV2Body(doc), 423);
       }
       const old = await getVersion(
         id,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -197,6 +197,17 @@ function MobileDrawerIdentity() {
   );
 }
 
+/**
+ * Cutover shim: v2 workspaces see the Apps v2 explorer wherever "apps"
+ * points. A component (not a hook in MainApp) because MainApp renders ABOVE
+ * WorkspaceProvider — the hook is only legal inside the provider subtree.
+ */
+function AppsExplorerCutover() {
+  const { currentWorkspace } = useWorkspace();
+  const appsV2On = currentWorkspace?.settings?.appsV2Enabled === true;
+  return appsV2On ? <AppsV2Explorer /> : <AppsExplorer />;
+}
+
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
@@ -569,7 +580,7 @@ function MainApp() {
       case "dashboards":
         return <DashboardsExplorer />;
       case "apps":
-        return <AppsExplorer />;
+        return <AppsExplorerCutover />;
       case "notebooks":
         return <NotebooksExplorer />;
       case "apps-v2":

--- a/app/src/components/AppFileEditor.tsx
+++ b/app/src/components/AppFileEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Box, useTheme } from "@mui/material";
+import { Alert, Box, Button, useTheme } from "@mui/material";
 import MonacoEditor from "@monaco-editor/react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppStore } from "../store/appStore";
@@ -7,6 +7,7 @@ import {
   configureMonacoForJsx,
   languageForPath,
 } from "../app-runtime/monaco-jsx";
+import { focusAppsV2Tab } from "../apps-v2-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 import EntityLoadErrorState, {
   EntityLoadingState,
@@ -42,8 +43,11 @@ export default function AppFileEditor({
     if (!appEntity && workspaceId) void fetchApp(workspaceId, appId);
   }, [appEntity, workspaceId, appId, fetchApp]);
 
+  const migrated = !!appEntity?.migratedToV2ProjectId;
+
   const handleChange = useCallback(
     (value: string | undefined) => {
+      if (migrated) return; // stamped by the v2 migration — read-only
       writeFile(appId, path, value ?? "");
       if (saveTimer.current) clearTimeout(saveTimer.current);
       if (workspaceId) {
@@ -52,7 +56,7 @@ export default function AppFileEditor({
         }, 1200);
       }
     },
-    [appId, path, workspaceId, writeFile, persistApp],
+    [appId, path, workspaceId, writeFile, persistApp, migrated],
   );
 
   if (!appEntity) {
@@ -84,6 +88,28 @@ export default function AppFileEditor({
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       <EntityBreadcrumbs tabId={tabId} />
+      {migrated && (
+        <Alert
+          severity="info"
+          sx={{ borderRadius: 0 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() =>
+                focusAppsV2Tab(
+                  appEntity.migratedToV2ProjectId ?? "",
+                  appEntity.title,
+                )
+              }
+            >
+              Open in Apps
+            </Button>
+          }
+        >
+          This app moved to Apps v2 — this copy is read-only.
+        </Alert>
+      )}
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <MonacoEditor
           height="100%"
@@ -98,6 +124,7 @@ export default function AppFileEditor({
             fontSize: 13,
             automaticLayout: true,
             scrollBeyondLastLine: false,
+            readOnly: migrated,
           }}
         />
       </Box>

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -267,8 +267,9 @@ export function SidebarMobileExplorerNav() {
 
   const items = [...topNavigationItems, ...bottomNavigationItems].filter(
     item =>
-      (item.view !== "apps-v2" && item.view !== "source-control") ||
-      appsV2Visible,
+      ((item.view !== "apps-v2" && item.view !== "source-control") ||
+        appsV2Visible) &&
+      (item.view !== "apps" || !appsV2Visible),
   );
 
   return (
@@ -401,8 +402,9 @@ function Sidebar() {
           {topNavigationItems
             .filter(
               item =>
-                (item.view !== "apps-v2" && item.view !== "source-control") ||
-                appsV2Visible,
+                ((item.view !== "apps-v2" && item.view !== "source-control") ||
+                  appsV2Visible) &&
+                (item.view !== "apps" || !appsV2Visible),
             )
             .map(item => {
               const Icon = item.icon;

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -39,6 +39,10 @@ export interface AppEntity {
   /** EntityVersion number last published (draft/published split). */
   publishedVersion?: number;
   publishedAt?: string;
+  /** Set when the Apps v2 migration stamped this app — read-only in v1. */
+  migratedToV2ProjectId?: string;
+  /** Server-computed: viewer cannot modify this app. */
+  readOnly?: boolean;
   /** True when the working draft differs from the published version. */
   hasUnpublishedChanges?: boolean;
   access: "private" | "workspace";


### PR DESCRIPTION
The dangerous state during the v1→v2 migration is two writable systems: a
v1 edit to a stamped app silently diverges from its migrated v2 copy
(the Campaign Health Monitor incident class). Guards:

API
- PUT/DELETE/versions/version-comment/restore on a stamped app → 423
  {code: migrated_to_v2, v2ProjectId} (materialize stays allowed — it
  powers viewing).
- POST create in an appsV2Enabled workspace → 409 apps_v2_workspace
  (flag fetched directly; auth middleware doesn't reliably set
  c.get("workspace") here).
- All 12 mutating agent tools gated via migratedBlock(); create_app
  refuses in v2 workspaces and points at the apps-v2 tools.
- Serializers expose migratedToV2ProjectId and force readOnly.

App
- Rail hides the v1 Apps entry for v2 workspaces (desktop + mobile).
- AppsExplorerCutover shim: the "apps" view renders AppsV2Explorer for
  v2 workspaces (component, not a MainApp hook — MainApp renders above
  WorkspaceProvider).
- AppFileEditor: info banner with Open-in-Apps button + Monaco readOnly
  + autosave suppressed for stamped apps.

Verified against the dev API as the workspace owner: PUT 423, create
409, GET readOnly:true, rail shows only Apps v2.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
