### PR TITLE
fix(apps-v2): publish build reinstalls deps when package.json changed

### DIFF
--- a/api/src/apps-v2/deployment.service.ts
+++ b/api/src/apps-v2/deployment.service.ts
@@ -244,7 +244,14 @@ export async function buildApp(
     // `--loglevel=http` so the install streams progress into the log (npm is
     // near-silent when its stdout is a pipe), and `--foreground-scripts` so
     // lifecycle-script output shows too — the client is watching this live.
-    `set -o pipefail; ( [ -d node_modules ] || npm install --no-audit --no-fund --loglevel=http --foreground-scripts ) 2>&1 | tee -a ${log}`,
+    //
+    // Freshness, not existence: npm stamps node_modules/.package-lock.json on
+    // every install, so "stamp newer than package.json" means deps are
+    // current. A bare [ -d node_modules ] check kept serving a stale tree
+    // after a push changed package.json (the re-migrated apps failed to
+    // publish on missing new deps), and a half-written tree from a killed
+    // install passed the -d check with no vite binary at all.
+    `set -o pipefail; ( [ node_modules/.package-lock.json -nt package.json ] || npm install --no-audit --no-fund --loglevel=http --foreground-scripts ) 2>&1 | tee -a ${log}`,
     { timeoutMs: 300_000 },
   );
   if (install.exitCode !== 0) {


### PR DESCRIPTION
[ -d node_modules ] kept a stale tree alive: after re-migration pushed new
package.json deps (recharts), publish built with the old node_modules and
failed on unresolved imports; a half-written tree from an interrupted
install also passed the check with no vite binary. Gate the install on
npm's own stamp instead: node_modules/.package-lock.json newer than
package.json, else npm install.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
