### PR TITLE
test(modes): drop the v1 input-conditional grant scenario

### DIFF
--- a/api/src/agents/modes/tool-working-set.test.ts
+++ b/api/src/agents/modes/tool-working-set.test.ts
@@ -300,61 +300,6 @@ async function grantEnforcement() {
   assert.deepEqual(calls, ["dbt_git_status", "edit_dbt_file", "dbt_run_model"]);
 }
 
-// --- input-conditional grants: schedule leg of app_update_data_binding -------
-// app_set_binding_schedule's schedule-write gate survives the fold into
-// app_update_data_binding: the merged tool needs schedule-write only when the
-// input actually carries materializationSchedule.
-async function conditionalGrantEnforcement() {
-  const calls: unknown[] = [];
-  const grants = new Set<CapabilityGrant>(["artifact-write"]);
-  const tools = enforceCapabilityGrantsAtExecution(
-    {
-      app_update_data_binding: tool({
-        description: "app_update_data_binding",
-        inputSchema: z.object({}).passthrough(),
-        execute: async (input: unknown) => {
-          calls.push(input);
-          return { success: true };
-        },
-      }),
-    } as unknown as ToolSet,
-    () => grants,
-  );
-  const run = async (input: unknown) => {
-    const execute = tools.app_update_data_binding?.execute as (
-      input: unknown,
-      options: unknown,
-    ) => Promise<unknown>;
-    return execute(input, { toolCallId: "t1", messages: [] });
-  };
-
-  // Query-definition updates need only artifact-write.
-  const plain = (await run({ appId: "a", name: "b", code: "SELECT 1" })) as {
-    success: boolean;
-  };
-  assert.equal(plain.success, true, "definition update runs on artifact-write");
-
-  // Touching the schedule without schedule-write is denied with recovery.
-  const denied = (await run({
-    appId: "a",
-    name: "b",
-    materializationSchedule: { enabled: true, cron: "0 * * * *" },
-  })) as { success: boolean; error?: string };
-  assert.equal(denied.success, false, "schedule change denied without grant");
-  assert.ok(denied.error?.includes("schedule-write"), "error names the grant");
-  assert.ok(denied.error?.includes("submit_plan"), "error names the recovery");
-
-  // Acquiring schedule-write unlocks the schedule leg.
-  grants.add("schedule-write");
-  const allowed = (await run({
-    appId: "a",
-    name: "b",
-    materializationSchedule: { enabled: false, cron: null },
-  })) as { success: boolean };
-  assert.equal(allowed.success, true, "held schedule-write executes");
-  assert.equal(calls.length, 2, "denied call never reached the tool");
-}
-
 // --- policy: plan-grant gating is DISABLED in native Chat pending review ------
 // Until the #755 gating gets a proper product review, Chat implicitly holds
 // every grant, so no plan approval is required to execute warehouse/git/
@@ -591,7 +536,6 @@ async function endToEnd() {
 // schemas), which keeps the event loop alive — exit explicitly like
 // derive-mode-state.test.ts does.
 void grantEnforcement()
-  .then(conditionalGrantEnforcement)
   .then(endToEnd)
   .then(() => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
conditionalGrantEnforcement exercised the schedule-write gate on
app_update_data_binding — a capability deleted with Apps v1 (#816). The
capability trim landed after the test's last local run, so CI caught it
(the API Contract job on 38cef321). dbt/console schedule-write grants are
plain requiredGrant and stay covered by grantEnforcement.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
