### PR TITLE
fix(apps): version-store rip-out fallout + sturdier publish install gate

### DIFF
--- a/api/src/apps-v2/deployment.service.ts
+++ b/api/src/apps-v2/deployment.service.ts
@@ -245,13 +245,12 @@ export async function buildApp(
     // near-silent when its stdout is a pipe), and `--foreground-scripts` so
     // lifecycle-script output shows too — the client is watching this live.
     //
-    // Freshness, not existence: npm stamps node_modules/.package-lock.json on
-    // every install, so "stamp newer than package.json" means deps are
-    // current. A bare [ -d node_modules ] check kept serving a stale tree
-    // after a push changed package.json (the re-migrated apps failed to
-    // publish on missing new deps), and a half-written tree from a killed
-    // install passed the -d check with no vite binary at all.
-    `set -o pipefail; ( [ node_modules/.package-lock.json -nt package.json ] || npm install --no-audit --no-fund --loglevel=http --foreground-scripts ) 2>&1 | tee -a ${log}`,
+    // Freshness via OUR stamp, written only after a SUCCESSFUL install: npm
+    // writes .package-lock.json early during reify, so a killed install left
+    // a "fresh" stamp over a half-written tree (no vite binary) and every
+    // later publish skipped the install forever. Stamp-after-success plus
+    // rm -rf on miss makes the tree either complete or absent.
+    `set -o pipefail; ( [ node_modules/.mako-installed -nt package.json ] || (rm -rf node_modules && npm install --no-audit --no-fund --loglevel=http --foreground-scripts && touch node_modules/.mako-installed) ) 2>&1 | tee -a ${log}`,
     { timeoutMs: 300_000 },
   );
   if (install.exitCode !== 0) {

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -276,42 +276,19 @@ export async function executeDashboardAgentTool(
   // server's realtime app.updated poke.
   if (toolName === "save_version" || toolName === "restore_version") {
     const entityType =
-      input.entityType === "app" || input.entityType === "dashboard"
-        ? input.entityType
-        : null;
+      input.entityType === "dashboard" ? input.entityType : null;
     const entityId = typeof input.entityId === "string" ? input.entityId : null;
     if (!entityType || !entityId) {
       return {
         success: false,
-        error: "entityType ('app' | 'dashboard') and entityId are required.",
+        error: "entityType ('dashboard') and entityId are required.",
       };
     }
     const comment =
       typeof input.comment === "string" ? input.comment : undefined;
 
     if (toolName === "save_version") {
-      if (entityType === "dashboard") {
-        return saveDashboardVersionLeg(entityId, comment ?? "");
-      }
-      const workspaceId = getCurrentWorkspaceId();
-      if (!workspaceId) {
-        return { success: false, error: "No active workspace" };
-      }
-      const res = await useVersionStore
-        .getState()
-        .saveVersion(workspaceId, "app", entityId, comment);
-      if (!res.success) {
-        return {
-          success: false,
-          error: res.error || "Failed to save version",
-        };
-      }
-      return {
-        success: true,
-        version: res.version,
-        publishedVersion: res.version,
-        message: `Saved and published app version ${res.version}.`,
-      };
+      return saveDashboardVersionLeg(entityId, comment ?? "");
     }
 
     const version =
@@ -319,26 +296,7 @@ export async function executeDashboardAgentTool(
     if (!Number.isFinite(version)) {
       return { success: false, error: "version (number) is required" };
     }
-    if (entityType === "dashboard") {
-      return restoreDashboardVersionLeg(entityId, version, comment, signal);
-    }
-    const workspaceId = getCurrentWorkspaceId();
-    if (!workspaceId) {
-      return { success: false, error: "No active workspace" };
-    }
-    const res = await useVersionStore
-      .getState()
-      .restoreVersion(workspaceId, "app", entityId, version, comment);
-    if (!res.success) {
-      return { success: false, error: res.error || "Restore failed" };
-    }
-    return {
-      success: true,
-      restoredFrom: version,
-      message:
-        `Restored the app draft to version ${version}. This is not yet ` +
-        "published — save a version to push it live to viewers.",
-    };
+    return restoreDashboardVersionLeg(entityId, version, comment, signal);
   }
 
   // Deprecated aliases of restore_version / save_version (entityType:

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -5,7 +5,6 @@ import { api, unwrap } from "../api";
 const VERSION_BASE = {
   console: "/api/workspaces/{workspaceId}/consoles/{id}/versions",
   dashboard: "/api/workspaces/{workspaceId}/dashboards/{id}/versions",
-  app: "/api/workspaces/{workspaceId}/apps/{id}/versions",
 } as const;
 
 export type VersionEntityType = keyof typeof VERSION_BASE;
@@ -55,12 +54,6 @@ interface VersionStoreState {
    * this today (consoles/dashboards version implicitly on save); the base path
    * map gates which entity types support it.
    */
-  saveVersion: (
-    workspaceId: string,
-    entityType: VersionEntityType,
-    entityId: string,
-    comment?: string,
-  ) => Promise<{ success: boolean; version?: number; error?: string }>;
 
   clearHistory: (entityId: string) => void;
 }
@@ -141,32 +134,6 @@ export const useVersionStore = create<VersionStoreState>((set, get) => ({
       return {
         success: false,
         error: err instanceof Error ? err.message : "Restore failed",
-      };
-    }
-  },
-
-  saveVersion: async (workspaceId, entityType, entityId, comment) => {
-    // Only apps support explicit checkpoint creation today; consoles and
-    // dashboards version implicitly on save (no POST /versions endpoint).
-    if (entityType !== "app") {
-      return {
-        success: false,
-        error: `Explicit versions are not supported for ${entityType}`,
-      };
-    }
-    try {
-      const data = unwrap(
-        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/versions", {
-          params: { path: { workspaceId, id: entityId } },
-          body: { comment: comment ?? "" },
-        }),
-      ) as { version?: number };
-      await get().fetchVersionHistory(workspaceId, entityType, entityId);
-      return { success: true, version: data.version };
-    } catch (err) {
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Failed to save version",
       };
     }
   },


### PR DESCRIPTION
- versionStore/dashboard-runtime: drop the app leg of save/restore_version
  (the regenerated OpenAPI types no longer carry the deleted v1 version
  routes, which broke the frontend build on deploy).
- Publish install gate v2: stamp AFTER a successful install
  (node_modules/.mako-installed) and rm -rf on miss — npm writes
  .package-lock.json early during reify, so a killed install left a fresh
  stamp over a half-written tree and every later publish skipped install
  forever (the 'vite: not found' trio).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
