### PR TITLE
fix(apps): durable live URL for published apps + /apps/:slug paths

### DIFF
--- a/app/src/components/AppV2Workspace.tsx
+++ b/app/src/components/AppV2Workspace.tsx
@@ -45,6 +45,7 @@ import "@xterm/xterm/css/xterm.css";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useRealtimeStore } from "../store/realtimeStore";
 import { useAppsV2Store } from "../store/appsV2Store";
+import { useConsoleStore } from "../store/consoleStore";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { setIframeDragGuard } from "../lib/iframe-drag-guard";
 import { TerminalTypeAhead } from "../lib/terminal-type-ahead";
@@ -922,6 +923,14 @@ export default function AppV2Workspace({
   const runningDevApps = useAppsV2Store(s => s.runningDevApps);
   const devRunning = slug ? runningDevApps.includes(slug) : false;
   const viewUrl = useAppsV2Store(s => s.viewUrlByApp[appId]);
+  // Durable, session-authorized URL for the published app — for normal tabs.
+  // The token URL (viewUrl) exists ONLY for the sandboxed iframe, whose
+  // opaque origin cannot send cookies; tokens are short-lived and in-memory,
+  // so handing them to window.open produced "Preview expired" minutes later.
+  const liveUrl =
+    app?.publishedSha && workspaceId
+      ? `/api/workspaces/${workspaceId}/apps-v2/${appId}/live/`
+      : undefined;
   const fetchViewUrl = useAppsV2Store(s => s.fetchViewUrl);
 
   // Derive the workbench view from BOX TRUTH, never localStorage. Auto-open
@@ -955,6 +964,17 @@ export default function AppV2Workspace({
       void fetchViewUrl(workspaceId, appId);
     }
   }, [editing, app?.publishedSha, workspaceId, appId, fetchViewUrl]);
+  // Older tabs were opened before slugs rode in tab metadata; heal them so
+  // the URL upgrades from /apps/<id> to /apps/<slug>.
+  useEffect(() => {
+    const slug = app?.slug;
+    if (!slug) return;
+    useConsoleStore.setState(state => {
+      const t = state.tabs[_tabId];
+      if (t?.metadata && !t.metadata.appV2Slug) t.metadata.appV2Slug = slug;
+    });
+  }, [app?.slug, _tabId]);
+
   const [terminalDragging, setTerminalDragging] = useState(false);
   useEffect(() => {
     if (!terminalDragging) return;
@@ -1064,8 +1084,8 @@ export default function AppV2Workspace({
             // not published → this IS the call to action, publish.
             onClick={
               publishedSha
-                ? viewUrl
-                  ? () => window.open(viewUrl, "_blank", "noopener")
+                ? liveUrl
+                  ? () => window.open(liveUrl, "_blank", "noopener")
                   : undefined
                 : preview?.building
                   ? undefined
@@ -1151,9 +1171,9 @@ export default function AppV2Workspace({
             <IconButton
               size="small"
               aria-label="Open the preview in a new tab"
-              disabled={!(editing ? preview?.url : viewUrl)}
+              disabled={!(editing ? preview?.url : liveUrl)}
               onClick={() => {
-                const url = editing ? preview?.url : viewUrl;
+                const url = editing ? preview?.url : liveUrl;
                 if (url) window.open(url, "_blank", "noopener");
               }}
             >

--- a/app/src/components/AppsV2Explorer.tsx
+++ b/app/src/components/AppsV2Explorer.tsx
@@ -335,17 +335,18 @@ export default function AppsV2Explorer() {
   const handleItemClick = useCallback(
     (node: ResourceTreeNode) => {
       const parsed = parseNodeId(node.id);
+      const slug = apps.find(a => a.id === parsed.appId)?.slug;
       if (parsed.kind === "app") {
-        focusAppsV2Tab(parsed.appId, node.name);
+        focusAppsV2Tab(parsed.appId, node.name, slug);
         // Warm the file tree so expanding is instant.
         if (workspaceId && !filesByApp[parsed.appId]) {
           void fetchFiles(workspaceId, parsed.appId);
         }
       } else if (parsed.kind === "file") {
-        focusAppsV2FileTab(parsed.appId, parsed.path);
+        focusAppsV2FileTab(parsed.appId, parsed.path, slug);
       }
     },
-    [workspaceId, filesByApp, fetchFiles, editingByApp],
+    [workspaceId, filesByApp, fetchFiles, editingByApp, apps],
   );
 
   const handleCreate = useCallback(async () => {
@@ -356,7 +357,7 @@ export default function AppsV2Explorer() {
     if (app) {
       setCreateOpen(false);
       setNewTitle("");
-      focusAppsV2Tab(app.id, app.title);
+      focusAppsV2Tab(app.id, app.title, app.slug);
     }
   }, [workspaceId, newTitle, createApp]);
 

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -40,9 +40,9 @@ export const TAB_DEEP_LINK_PATTERNS = {
   dashboard: /^\/d\/([a-zA-Z0-9-]+)\/?$/,
   "dashboard-data-source": /^\/d\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9_-]+)/,
   "table-data": /^\/t\/([a-zA-Z0-9-]+)\/([^/]+)\/([^/]+)\/?$/,
-  // Apps v2 (git-backed, experimental) — /a2 so it can't collide with /a.
-  "app-v2": /^\/a2\/([a-zA-Z0-9-]+)\/?$/,
-  "app-v2-file": /^\/a2\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
+  // Apps live at /apps/:slug (folder name). /a2 stays accepted for old links.
+  "app-v2": /^\/(?:apps|a2)\/([a-zA-Z0-9-]+)\/?$/,
+  "app-v2-file": /^\/(?:apps|a2)\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
   "app-v2-diff": null,
   plan: /^\/p\/([a-zA-Z0-9-]+)/,
   settings: /^\/settings\/([a-z-]+)$/,
@@ -103,14 +103,16 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
       const appId = tab.metadata?.appV2Id as string | undefined;
       const slug = tab.metadata?.appV2Slug as string | undefined;
       const ref = slug || appId;
-      return ref ? `/a2/${ref}` : null;
+      return ref ? `/apps/${ref}` : null;
     }
     case "app-v2-file": {
       const appId = tab.metadata?.appV2Id as string | undefined;
       const slug = tab.metadata?.appV2Slug as string | undefined;
       const ref = slug || appId;
       const path = tab.metadata?.path as string | undefined;
-      return ref && path ? `/a2/${ref}/file/${encodePathSegments(path)}` : null;
+      return ref && path
+        ? `/apps/${ref}/file/${encodePathSegments(path)}`
+        : null;
     }
     case "app-v2-diff":
       // Diffs are transient views of the working copy: no deep link.


### PR DESCRIPTION
- 'published · sha' chip and open-in-new-tab now open the session-authed
  /live route (serves the deployment from the artifact store). The
  short-lived in-memory preview token stays iframe-only — handing it to
  window.open produced 'Preview expired — rebuild to get a new link' after
  30 minutes or any API restart.
- App URLs are /apps/:slug now that v1 is gone (/a2 still accepted for old
  links). The explorer passes slugs when opening tabs, and AppV2Workspace
  heals pre-slug tabs so their URL upgrades from the id.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
