### PR TITLE
fix(apps-v2): cull dead HMR sockets + pause hidden tabs so idle boxes sleep

### DIFF
--- a/api/src/apps-v2/dev-server.service.ts
+++ b/api/src/apps-v2/dev-server.service.ts
@@ -462,6 +462,32 @@ const reportViewers = () => {
 reportViewers();
 const viewersTimer = setInterval(reportViewers, 10000);
 if (viewersTimer.unref) viewersTimer.unref();
+// Cull half-open HMR sockets: a laptop sleeping mid-session leaves its
+// websocket ESTABLISHED here for hours (observed: a dev server surviving
+// 3h with zero real viewers), and vite's client set never shrinks on its
+// own — so the viewer count above stays >=1 and the idle reaper never
+// fires. Ping every 20s; no pong for 60s = dead, terminate it.
+const lastPong = new WeakMap();
+const cullTimer = setInterval(() => {
+  try {
+    const clients = server.ws && server.ws.clients;
+    if (!clients) return;
+    for (const client of clients) {
+      const sock = (client && client.socket) || client;
+      if (!sock || typeof sock.ping !== "function") continue;
+      if (!lastPong.has(sock)) {
+        lastPong.set(sock, Date.now());
+        sock.on("pong", () => lastPong.set(sock, Date.now()));
+      }
+      if (Date.now() - lastPong.get(sock) > 60000) {
+        try { sock.terminate(); } catch {}
+      } else {
+        try { sock.ping(); } catch {}
+      }
+    }
+  } catch {}
+}, 20000);
+if (cullTimer.unref) cullTimer.unref();
 void tellMako("serving", 7, [1000, 3000, 8000, 15000, 30000, 60000]);
 // Watcher lifecycle in the boot log: "ready" proves the polling scan
 // finished (inotify is dead in this VM, so a silent watcher means frozen

--- a/app/src/components/AppV2Workspace.tsx
+++ b/app/src/components/AppV2Workspace.tsx
@@ -89,6 +89,41 @@ const TerminalResizeHandle = styled(PanelResizeHandle)(({ theme }) => ({
   },
 }));
 
+const HIDDEN_PAUSE_MS = 10 * 60 * 1000;
+
+/**
+ * True once this document has been hidden for HIDDEN_PAUSE_MS straight.
+ * A tab left in the background holds its HMR iframe and pty websockets
+ * open indefinitely; those sockets read as "someone is watching" to the
+ * box's idle reaper AND as activity to E2B's 10-minute auto-pause — which
+ * is how a dev box billed hours of idle time. Pausing unmounts the dev
+ * preview and terminals (dtach keeps the sessions; they replay on return).
+ */
+function useHiddenPause(): boolean {
+  const [paused, setPaused] = useState(false);
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onChange = () => {
+      if (document.visibilityState === "hidden") {
+        timer ??= setTimeout(() => setPaused(true), HIDDEN_PAUSE_MS);
+      } else {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        setPaused(false);
+      }
+    };
+    onChange();
+    document.addEventListener("visibilitychange", onChange);
+    return () => {
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onChange);
+    };
+  }, []);
+  return paused;
+}
+
 function TerminalPanel({
   appId,
   workspaceId,
@@ -451,6 +486,7 @@ function TerminalTabs({
   // reattaches to the same running shells (scrollback and all), VS Code
   // style. Only the tab LIST is persisted; which tab is active is not worth
   // remembering.
+  const hiddenPaused = useHiddenPause();
   const [shells, setShells] = useState<string[]>(() => {
     try {
       const saved = JSON.parse(
@@ -578,7 +614,7 @@ function TerminalTabs({
               display: active === "dev" ? "block" : "none",
             }}
           >
-            {slug && (devRunning || active === "dev") ? (
+            {!hiddenPaused && slug && (devRunning || active === "dev") ? (
               // The dev server runs in a dtach session named like any other
               // (mako-term-dev-<slug>) — this is a normal terminal attached
               // to it: colors, native scrollback, prefit history, and Ctrl-C
@@ -593,25 +629,26 @@ function TerminalTabs({
               />
             ) : null}
           </Box>
-          {shells.map((id, index) => (
-            <Box
-              key={id}
-              sx={{
-                flex: 1,
-                minHeight: 0,
-                display: active === id ? "block" : "none",
-              }}
-            >
-              <TerminalPanel
-                appId={appId}
-                workspaceId={workspaceId}
-                termId={id}
-                label={`bash ${index + 1}`}
-                fresh={freshIds.current.has(id)}
-                onSessionEnd={() => closeShell(id, { killRemote: false })}
-              />
-            </Box>
-          ))}
+          {!hiddenPaused &&
+            shells.map((id, index) => (
+              <Box
+                key={id}
+                sx={{
+                  flex: 1,
+                  minHeight: 0,
+                  display: active === id ? "block" : "none",
+                }}
+              >
+                <TerminalPanel
+                  appId={appId}
+                  workspaceId={workspaceId}
+                  termId={id}
+                  label={`bash ${index + 1}`}
+                  fresh={freshIds.current.has(id)}
+                  onSessionEnd={() => closeShell(id, { killRemote: false })}
+                />
+              </Box>
+            ))}
         </Box>
       </Panel>
       <SessionsResizeHandle />
@@ -923,6 +960,7 @@ export default function AppV2Workspace({
   const runningDevApps = useAppsV2Store(s => s.runningDevApps);
   const devRunning = slug ? runningDevApps.includes(slug) : false;
   const viewUrl = useAppsV2Store(s => s.viewUrlByApp[appId]);
+  const hiddenPaused = useHiddenPause();
   // Durable, session-authorized URL for the published app — for normal tabs.
   // The token URL (viewUrl) exists ONLY for the sandboxed iframe, whose
   // opaque origin cannot send cookies; tokens are short-lived and in-memory,
@@ -1306,6 +1344,12 @@ export default function AppV2Workspace({
                 <code>&quot;.e2b.app&quot;</code>. Use{" "}
                 <strong>Restart dev session</strong> to let Mako run it, or add
                 that host to the app&apos;s <code>vite.config</code>.
+              </Alert>
+            ) : hiddenPaused ? (
+              <Alert severity="info" sx={{ m: 2 }}>
+                Preview paused after 10 minutes in the background — its sockets
+                are released so the sandbox can sleep. It resumes when you come
+                back.
               </Alert>
             ) : preview?.url ? (
               <iframe


### PR DESCRIPTION
A dev server survived 3 hours with nobody using Mako. Two leaks, both on
the 'someone is watching' signal:

- A laptop sleeping mid-session leaves its HMR websocket ESTABLISHED in
  the sandbox for hours; vite's client set never shrinks on its own, so
  the launcher kept reporting ws>=1 and the idle reaper never fired. The
  launcher now pings every 20s and terminates sockets silent for 60s.
- An open-but-background tab holds live iframe + pty sockets forever —
  legitimately connected, never active. Both the reaper (viewer count)
  and E2B's 10-minute auto-pause (network activity) read that as usage.
  After 10 minutes hidden, the workbench unmounts the dev preview iframe
  and terminal panels (dtach keeps the sessions; everything replays when
  the tab returns), so the box can wind down: reap in ~20min, auto-pause
  10min later.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
