### PR TITLE
fix(secrets): keep the connected-repo opt-in and tunnel identity per-machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,10 @@ The cloud environment starts with no `.env`. Bootstrap:
 2. Machine-local variables are deliberately never synced; set them per
    environment: `APPS_V2_SANDBOX_PROVIDER=e2b` (E2B key IS synced),
    `NODE_ENV=development`, and leave `APPS_V2_GIT_ROOT`/`APPS_V2_SESSIONS_ROOT`
-   unset for defaults. `GITHUB_DEV_TOKEN` and `APPS_V2_CONNECTED_REPO_PUSH`
-   are opt-in per machine — without them, mirror pushes to customer repos are
-   refused (safe default for a fresh environment).
+   unset for defaults. `GITHUB_DEV_TOKEN` syncs via
+   Secret Manager, but `APPS_V2_CONNECTED_REPO_PUSH` is opt-in per machine —
+   without it, mirror pushes to customer repos are refused (safe default for
+   a fresh environment); set it deliberately where pushes belong.
 3. Sandboxes cannot reach the environment's localhost:8080, so `pnpm dev`
    needs the cloudflared tunnel (`scripts/sandbox-tunnel.sh`); without a named
    tunnel it supervises an ephemeral trycloudflare URL. Terminals work without

--- a/scripts/secrets.ts
+++ b/scripts/secrets.ts
@@ -47,6 +47,14 @@ const LOCAL_ONLY = new Set([
   "APPS_V2_GIT_ROOT",
   "APPS_V2_SESSIONS_ROOT",
   "NODE_ENV",
+  // The connected-repo push OPT-IN is per-machine by doctrine (§13.17):
+  // dev DBs are prod clones carrying real customer bindings, so a synced
+  // "allow" would arm mirror pushes on every machine that pulls .env.
+  "APPS_V2_CONNECTED_REPO_PUSH",
+  // A named tunnel is one machine's identity; its credentials live in that
+  // machine's ~/.cloudflared and the hostname is useless anywhere else.
+  "APPS_V2_TUNNEL_NAME",
+  "APPS_V2_TUNNEL_HOSTNAME",
 ]);
 
 interface Assignment {


### PR DESCRIPTION
secrets:push uploaded APPS_V2_CONNECTED_REPO_PUSH=allow and this machine's
tunnel name/hostname — none of which belong in the shared store: the push
opt-in is per-machine by §13.17 doctrine (dev DBs are prod clones), and a
named tunnel is one machine's identity. Added to LOCAL_ONLY; the stray
secrets were deleted from mako-ai-dev. GITHUB_DEV_TOKEN stays synced on
purpose (inert without the opt-in flag; cloud environments need it).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
