### PR TITLE
chore(apps): retire the apps-v2 backwards-compat shims

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -191,10 +191,7 @@ jobs:
       # Apps sandboxes (E2B Firecracker microVMs).
       E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       APPS_SANDBOX_PROVIDER: e2b
-      # External E2B template artifact — still published under its pre-rename
-      # alias. To retire it: `pnpm --filter api run apps:build-template` with
-      # E2B_TEMPLATE_ALIAS=mako-apps, then flip this value.
-      APPS_E2B_TEMPLATE: mako-apps-v2
+      APPS_E2B_TEMPLATE: mako-apps
       # Apps cloud repos (Mako-hosted GitHub storage under mako-ai-cloud).
       # All previews share the staging DB, so they share the "staging" prefix:
       # same workspace -> same repo regardless of which PR created it.
@@ -874,10 +871,7 @@ jobs:
       # Apps sandboxes (E2B Firecracker microVMs).
       E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       APPS_SANDBOX_PROVIDER: e2b
-      # External E2B template artifact — still published under its pre-rename
-      # alias. To retire it: `pnpm --filter api run apps:build-template` with
-      # E2B_TEMPLATE_ALIAS=mako-apps, then flip this value.
-      APPS_E2B_TEMPLATE: mako-apps-v2
+      APPS_E2B_TEMPLATE: mako-apps
       # Apps cloud repos (Mako-hosted GitHub storage under mako-ai-cloud).
       MAKO_CLOUD_GITHUB_ORG: ${{ vars.MAKO_CLOUD_GITHUB_ORG }}
       MAKO_CLOUD_GITHUB_APP_ID: ${{ vars.MAKO_CLOUD_GITHUB_APP_ID }}

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -51,11 +51,7 @@ const GITHUB_API = "https://api.github.com";
 
 /** Overridable so tests can point mirrors at file:// remotes. */
 function remoteBase(): string {
-  return (
-    process.env.APPS_GITHUB_REMOTE_BASE ||
-    process.env.APPS_V2_GITHUB_REMOTE_BASE || // pre-rename name
-    "https://github.com"
-  );
+  return process.env.APPS_GITHUB_REMOTE_BASE || "https://github.com";
 }
 
 function remoteUrl(owner: string, repo: string): string {

--- a/api/src/apps/config.ts
+++ b/api/src/apps/config.ts
@@ -10,14 +10,8 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-/**
- * Read an env var under its current name, falling back to the pre-rename
- * `APPS_V2_*` name. Deployed environments and developer `.env` files were
- * provisioned under the old names; a rename must not silently un-configure
- * them.
- */
 function appsEnv(name: string): string | undefined {
-  return process.env[`APPS_${name}`] || process.env[`APPS_V2_${name}`];
+  return process.env[`APPS_${name}`];
 }
 
 /**

--- a/api/src/services/dashboard-artifact-store.service.ts
+++ b/api/src/services/dashboard-artifact-store.service.ts
@@ -618,9 +618,7 @@ export function getDashboardArtifactStore(): DashboardArtifactStore {
  * null, and callers read from the main store exactly as before.
  */
 export function getArtifactSourceStore(): DashboardArtifactStore | null {
-  const bucket =
-    process.env.APPS_ARTIFACT_SOURCE_BUCKET ||
-    process.env.APPS_V2_ARTIFACT_SOURCE_BUCKET; // pre-rename name
+  const bucket = process.env.APPS_ARTIFACT_SOURCE_BUCKET; // pre-rename name
   if (!bucket) return null;
   return new GcsDashboardArtifactStore(bucket);
 }

--- a/app/src/components/AppWorkspace.tsx
+++ b/app/src/components/AppWorkspace.tsx
@@ -490,10 +490,7 @@ function TerminalTabs({
   const [shells, setShells] = useState<string[]>(() => {
     try {
       const saved = JSON.parse(
-        localStorage.getItem(`apps-shells:${appId}`) ??
-          // Pre-rename key, so open shells survive the upgrade.
-          localStorage.getItem(`apps-v2-shells:${appId}`) ??
-          "[]",
+        localStorage.getItem(`apps-shells:${appId}`) ?? "[]",
       ) as unknown;
       if (
         Array.isArray(saved) &&
@@ -519,9 +516,7 @@ function TerminalTabs({
       // waits for) a dev server, which must not happen on mount just because
       // it was focused last time. Restore a saved BASH tab only; the dev tab
       // is entered by an explicit click (apps.md §13.11).
-      const saved =
-        localStorage.getItem(`apps-term-active:${appId}`) ??
-        localStorage.getItem(`apps-v2-term-active:${appId}`);
+      const saved = localStorage.getItem(`apps-term-active:${appId}`);
       if (saved && /^[0-9]{1,6}$/.test(saved)) return saved;
     } catch {
       // Storage unavailable — default below.

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -92,9 +92,7 @@ export function UrlSync() {
     // Don't hydrate if not authenticated or no workspace
     if (isHydrated.current || !currentWorkspace || !user) return;
 
-    // Apps deep links moved from /a2/ to /a/ with the apps-v2 → apps rename;
-    // keep old bookmarks working by matching them as their new form.
-    const path = window.location.pathname.replace(/^\/a2\//, "/apps/");
+    const path = window.location.pathname;
 
     // Reload vs deep link, and they deserve opposite answers. The URL follows
     // the active TAB, so on a plain reload the handlers below would move the

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -40,9 +40,9 @@ export const TAB_DEEP_LINK_PATTERNS = {
   dashboard: /^\/d\/([a-zA-Z0-9-]+)\/?$/,
   "dashboard-data-source": /^\/d\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9_-]+)/,
   "table-data": /^\/t\/([a-zA-Z0-9-]+)\/([^/]+)\/([^/]+)\/?$/,
-  // Apps live at /apps/:slug (folder name). /a2 stays accepted for old links.
-  app: /^\/(?:apps|a2)\/([a-zA-Z0-9-]+)\/?$/,
-  "app-file": /^\/(?:apps|a2)\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
+  // Apps live at /apps/:slug (the folder name in the workspace repo).
+  app: /^\/apps\/([a-zA-Z0-9-]+)\/?$/,
+  "app-file": /^\/apps\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
   "app-diff": null,
   plan: /^\/p\/([a-zA-Z0-9-]+)/,
   settings: /^\/settings\/([a-z-]+)$/,

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -2052,23 +2052,6 @@ export const useConsoleStore = create<ConsoleStore>()(
                 if (tab.isSaved === undefined) {
                   tab.isSaved = !!tab.filePath;
                 }
-                // Tabs persisted before the apps-v2 → apps rename carry the
-                // old kind strings and metadata keys; map them forward so
-                // open app tabs survive the upgrade.
-                if (
-                  typeof tab.kind === "string" &&
-                  tab.kind.startsWith("app-v2")
-                ) {
-                  tab.kind = tab.kind.replace(/^app-v2/, "app");
-                }
-                if (tab.metadata?.appV2Id !== undefined) {
-                  tab.metadata.appId ??= tab.metadata.appV2Id;
-                  delete tab.metadata.appV2Id;
-                }
-                if (tab.metadata?.appV2Slug !== undefined) {
-                  tab.metadata.appSlug ??= tab.metadata.appV2Slug;
-                  delete tab.metadata.appV2Slug;
-                }
                 delete tab.initialContent;
                 delete tab.dbContentHash;
                 delete tab.savedConnectionId;

--- a/scripts/secrets.ts
+++ b/scripts/secrets.ts
@@ -47,9 +47,6 @@ const LOCAL_ONLY = new Set([
   "APPS_GIT_ROOT",
   "APPS_SESSIONS_ROOT",
   // Pre-rename names — keep excluded so stale .env entries never sync.
-  "APPS_V2_SANDBOX_PROVIDER",
-  "APPS_V2_GIT_ROOT",
-  "APPS_V2_SESSIONS_ROOT",
   "APPS_SANDBOX_PROVIDER",
   "APPS_GIT_ROOT",
   "APPS_SESSIONS_ROOT",
@@ -57,12 +54,9 @@ const LOCAL_ONLY = new Set([
   // The connected-repo push OPT-IN is per-machine by doctrine (§13.17):
   // dev DBs are prod clones carrying real customer bindings, so a synced
   // "allow" would arm mirror pushes on every machine that pulls .env.
-  "APPS_V2_CONNECTED_REPO_PUSH",
   "APPS_CONNECTED_REPO_PUSH",
   // A named tunnel is one machine's identity; its credentials live in that
   // machine's ~/.cloudflared and the hostname is useless anywhere else.
-  "APPS_V2_TUNNEL_NAME",
-  "APPS_V2_TUNNEL_HOSTNAME",
   "APPS_TUNNEL_NAME",
   "APPS_TUNNEL_HOSTNAME",
 ]);


### PR DESCRIPTION
The rename (#820) is deployed and the data migration has moved the stored
names, so the transition layers go: /a2 URL acceptance and rewrite, the
persisted tab-kind/metadata rehydrate migration, terminal localStorage
old-key fallbacks, the APPS_V2_* env dual-reads (the deploy workflow sets
the new names on the service), and the two pre-rename env reads nothing
sets. The E2B template pin flips to the freshly published mako-apps alias.

Deliberately KEPT: the /api/apps-v2-git and /api/apps-v2-box route
aliases — live and paused sandboxes have those URLs baked into their
clones and box agents, and breaking them would strand uncommitted work;
delete once every pre-rename box has been recycled. The legacy on-disk
~/.mako/apps-v2 root honoring stays for the same reason (existing repos).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
