### PR TITLE
fix(migration): rename migration must not send unique:null index specs

### DIFF
--- a/api/src/migrations/2026-08-30-120000_apps_v2_rename.ts
+++ b/api/src/migrations/2026-08-30-120000_apps_v2_rename.ts
@@ -83,8 +83,13 @@ export async function up(db: Db): Promise<void> {
     await db.collection(from).drop();
     for (const index of INDEXES[to] ?? []) {
       await db.collection(to).createIndex(index.keys, {
-        unique: index.unique,
-        sparse: index.sparse,
+        // Spread-only-when-set: passing `unique: undefined` reaches the
+        // server as `unique: null`, which Mongo rejects — this is exactly
+        // how the first prod run died halfway (app_projects renamed, index
+        // ensure failed, worktrees + flag rename never reached; restored by
+        // hand before this fix).
+        ...(index.unique ? { unique: true } : {}),
+        ...(index.sparse ? { sparse: true } : {}),
       });
     }
     log.info("Merged legacy collection into renamed one", { from, to });


### PR DESCRIPTION
createIndex received {unique: undefined, sparse: undefined} for plain
indexes; the driver serializes undefined as null and Mongo rejects the
spec. The first prod run died halfway on exactly this (app_projects
renamed under still-serving pre-rename code — restored by hand); the
ensure path triggers whenever the migration runner's Mongoose boot
auto-creates the empty target collection, so it must be bulletproof.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tos24ZyBQKW6YndHogwz4x
