### PR TITLE
fix(apps): published apps must serve on every instance and from pre-rename deployments

### DIFF
--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -39,6 +39,37 @@ export function deploymentKey(
   return `apps/${projectId}/deployments/${sha}/${assetPath}`;
 }
 
+/**
+ * Where deployments lived before the `apps-v2 → apps` rename (#820). The
+ * rename changed this prefix but not the objects already in the store, so
+ * every app published before it vanished behind "Not found" in production.
+ * Reads fall back to the old key; writes only ever use the new one. Keep
+ * until every store's `apps-v2/` prefix has been copied under `apps/`.
+ */
+export function legacyDeploymentKey(
+  projectId: string,
+  sha: string,
+  assetPath: string,
+): string {
+  return `apps-v2/${projectId}/deployments/${sha}/${assetPath}`;
+}
+
+/** The key that actually holds `assetPath` for this deployment, or null. */
+async function existingDeploymentKey(
+  projectId: string,
+  sha: string,
+  assetPath: string,
+): Promise<string | null> {
+  const store = getDashboardArtifactStore();
+  for (const key of [
+    deploymentKey(projectId, sha, assetPath),
+    legacyDeploymentKey(projectId, sha, assetPath),
+  ]) {
+    if (await store.exists(key)) return key;
+  }
+  return null;
+}
+
 /** Content types for what a Vite build actually emits. */
 const CONTENT_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -108,7 +139,7 @@ export async function uploadDeployment(
   const store = getDashboardArtifactStore();
 
   // index.html is the marker: if it is already there, this sha is deployed.
-  if (await store.exists(deploymentKey(projectId, sha, "index.html"))) {
+  if (await deploymentExists(projectId, sha)) {
     logger.info("Apps deployment already present; reusing", {
       projectId,
       sha,
@@ -159,9 +190,7 @@ export async function deploymentExists(
   projectId: string,
   sha: string,
 ): Promise<boolean> {
-  return getDashboardArtifactStore().exists(
-    deploymentKey(projectId, sha, "index.html"),
-  );
+  return (await existingDeploymentKey(projectId, sha, "index.html")) !== null;
 }
 
 export interface DeploymentAsset {
@@ -189,7 +218,8 @@ export async function readDeploymentAsset(
   if (!path.extname(clean)) candidates.push("index.html");
 
   for (const candidate of candidates) {
-    const key = deploymentKey(projectId, sha, candidate);
+    const key = await existingDeploymentKey(projectId, sha, candidate);
+    if (!key) continue;
     const stream = await store.openReadStream(key);
     if (stream) {
       return {

--- a/api/src/apps/preview.service.test.ts
+++ b/api/src/apps/preview.service.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mintPreviewGrant,
+  mintPublishedGrant,
+  resolvePreviewGrant,
+} from "./preview.service";
+
+const ws = "6846e6a01b05af0948070582";
+const project = "23d9b603172c133a8427e812";
+const sha = "38ce8e7b28e8ace0c1d83bdacb95e28df3d5175b";
+
+describe("published preview grants are stateless", () => {
+  beforeEach(() => {
+    process.env.SESSION_SECRET = "test-secret-0123456789abcdef";
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.SESSION_SECRET;
+  });
+
+  it("resolves a minted token with no registry — any instance can serve it", () => {
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+    });
+    expect(grant.token.startsWith("pub.")).toBe(true);
+    // A token is only ever used in a URL path segment: it must not contain "/".
+    expect(grant.token).not.toContain("/");
+
+    const resolved = resolvePreviewGrant(grant.token);
+    expect(resolved).toEqual({
+      token: grant.token,
+      workspaceId: ws,
+      projectId: project,
+      publishedSha: sha,
+      expiresAt: grant.expiresAt,
+    });
+  });
+
+  it("rejects a token whose payload was tampered with", () => {
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+    });
+    const [prefix, body, sig] = grant.token.split(".");
+    const forged = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+    forged.s = "0000000000000000000000000000000000000000";
+    const forgedBody = Buffer.from(JSON.stringify(forged)).toString(
+      "base64url",
+    );
+    expect(resolvePreviewGrant(`${prefix}.${forgedBody}.${sig}`)).toBeNull();
+    // Damaged signature (different length) must be a null, not a throw.
+    expect(resolvePreviewGrant(`${prefix}.${body}.${sig.slice(1)}`)).toBeNull();
+    expect(resolvePreviewGrant("pub.garbage")).toBeNull();
+    expect(resolvePreviewGrant("pub..")).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+    });
+    process.env.SESSION_SECRET = "another-secret";
+    expect(resolvePreviewGrant(grant.token)).toBeNull();
+  });
+
+  it("expires after the TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-31T10:00:00Z"));
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+    });
+    vi.setSystemTime(new Date("2026-08-31T10:29:00Z"));
+    expect(resolvePreviewGrant(grant.token)).not.toBeNull();
+    vi.setSystemTime(new Date("2026-08-31T10:31:00Z"));
+    expect(resolvePreviewGrant(grant.token)).toBeNull();
+  });
+
+  it("static grants still resolve from the in-process registry", () => {
+    const grant = mintPreviewGrant({
+      workspaceId: ws,
+      projectId: project,
+      rootDir: "/tmp/dist",
+    });
+    expect(grant.token.startsWith("pub.")).toBe(false);
+    expect(resolvePreviewGrant(grant.token)?.rootDir).toBe("/tmp/dist");
+    expect(resolvePreviewGrant("nope")).toBeNull();
+  });
+});

--- a/api/src/apps/preview.service.ts
+++ b/api/src/apps/preview.service.ts
@@ -11,10 +11,20 @@
  *   credential: the serving route is cookie-free and the iframe embeds it
  *   with sandbox="allow-scripts" (opaque origin), so previewed app code
  *   never runs with Mako's origin or cookies.
- * - Tokens are held in-process (single-instance dev API). Fine for the
- *   pilot; a shared store comes with the E2B/multi-instance phase.
+ * - STATIC grants (a built dist/ staged on this instance's disk) are held
+ *   in-process: the directory they serve exists only on the instance that
+ *   staged it, so a shared registry would buy nothing.
+ * - PUBLISHED grants are STATELESS: an HMAC-signed token carrying
+ *   (workspace, project, sha, expiry). Production runs many API instances
+ *   behind one load balancer with no session affinity, so a token minted
+ *   by one instance is routinely presented to another; when these lived in
+ *   a per-process Map, every published app in production intermittently
+ *   rendered "Preview expired" seconds after the token was minted. The
+ *   deployment a published token names is immutable and lives in the shared
+ *   artifact store, so nothing about it is instance-local — the signature
+ *   is all any instance needs to trust the token.
  */
-import { randomBytes } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -51,7 +61,7 @@ function sweep(): void {
 
 function mint(
   input: { workspaceId: string; projectId: string; token?: string },
-  scope: Pick<PreviewGrant, "rootDir" | "publishedSha">,
+  scope: Pick<PreviewGrant, "rootDir">,
   dedupe: (grant: PreviewGrant) => boolean,
 ): PreviewGrant {
   sweep();
@@ -87,17 +97,107 @@ export function mintPreviewGrant(input: {
   );
 }
 
-/** Published grant: serves an immutable deployment from the artifact store. */
+/**
+ * Published grant: serves an immutable deployment from the artifact store.
+ *
+ * Stateless — see the module comment. The token is `pub.<payload>.<sig>`
+ * where payload is base64url JSON and sig is HMAC-SHA256 over it (same
+ * construction as git-token.service). No registry, so nothing to sweep and
+ * nothing to lose across instances or restarts.
+ */
+const PUBLISHED_TOKEN_PREFIX = "pub.";
+
+interface PublishedTokenPayload {
+  v: 1;
+  w: string;
+  p: string;
+  s: string;
+  /** Epoch milliseconds. */
+  exp: number;
+}
+
+function resolveSecret(): string {
+  const secret = process.env.SESSION_SECRET || process.env.ENCRYPTION_KEY;
+  if (!secret) {
+    throw new Error(
+      "Missing HMAC secret: set SESSION_SECRET or ENCRYPTION_KEY",
+    );
+  }
+  return secret;
+}
+
+function sign(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("base64url");
+}
+
 export function mintPublishedGrant(input: {
   workspaceId: string;
   projectId: string;
   sha: string;
 }): PreviewGrant {
-  return mint(
-    { workspaceId: input.workspaceId, projectId: input.projectId },
-    { publishedSha: input.sha },
-    grant => grant.publishedSha === input.sha,
+  const payload: PublishedTokenPayload = {
+    v: 1,
+    w: input.workspaceId,
+    p: input.projectId,
+    s: input.sha,
+    exp: Date.now() + PREVIEW_TTL_MS,
+  };
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url",
   );
+  const token = `${PUBLISHED_TOKEN_PREFIX}${body}.${sign(body, resolveSecret())}`;
+  return {
+    token,
+    workspaceId: input.workspaceId,
+    projectId: input.projectId,
+    publishedSha: input.sha,
+    expiresAt: payload.exp,
+  };
+}
+
+function resolvePublishedGrant(token: string): PreviewGrant | null {
+  const [body, signature] = token
+    .slice(PUBLISHED_TOKEN_PREFIX.length)
+    .split(".");
+  if (!body || !signature) return null;
+  let secret: string;
+  try {
+    secret = resolveSecret();
+  } catch {
+    return null;
+  }
+  const expected = Buffer.from(sign(body, secret), "utf8");
+  const actual = Buffer.from(signature, "utf8");
+  // Length-check first: timingSafeEqual THROWS on a length mismatch rather
+  // than returning false, which would turn a forged token into a 500.
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    return null;
+  }
+  let payload: PublishedTokenPayload;
+  try {
+    payload = JSON.parse(
+      Buffer.from(body, "base64url").toString("utf8"),
+    ) as PublishedTokenPayload;
+  } catch {
+    return null;
+  }
+  if (
+    payload.v !== 1 ||
+    typeof payload.w !== "string" ||
+    typeof payload.p !== "string" ||
+    typeof payload.s !== "string" ||
+    typeof payload.exp !== "number" ||
+    payload.exp <= Date.now()
+  ) {
+    return null;
+  }
+  return {
+    token,
+    workspaceId: payload.w,
+    projectId: payload.p,
+    publishedSha: payload.s,
+    expiresAt: payload.exp,
+  };
 }
 
 /**
@@ -109,6 +209,9 @@ export function mintPublishedGrant(input: {
  * click that reuses that already-running process.
  */
 export function resolvePreviewGrant(token: string): PreviewGrant | null {
+  if (token.startsWith(PUBLISHED_TOKEN_PREFIX)) {
+    return resolvePublishedGrant(token);
+  }
   sweep();
   return grants.get(token) ?? null;
 }

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       "src/apps/git-endpoint.test.ts",
       "src/apps/migrate-v1-apps.test.ts",
       "src/apps/box-state.service.test.ts",
+      "src/apps/preview.service.test.ts",
     ],
     exclude: ["**/node_modules/**"],
     // Real git, real sandbox: slower than a unit test by design.


### PR DESCRIPTION
## Why

All 32 published apps in the RealAdvisor workspace on prod were broken:

- **`Not found`** — the `apps-v2 → apps` rename (#820) changed the deployment key prefix in the artifact store (`apps-v2/<project>/deployments/…` → `apps/…`) without moving the objects. Verified: the prod bucket had 53 `index.html` under `apps-v2/` and zero under `apps/`.
- **`Preview expired — rebuild to get a new link`** — `POST /apps/:id/view-token` stored the token in a per-process `Map`; prod runs up to 15 Cloud Run instances, so the iframe's `/api/apps-preview/<token>/` request usually hit an instance that never minted it.

## What

- Deployment reads fall back to the legacy `apps-v2/` key (writes keep the new prefix). Prod's `apps-v2/` prefix has also been rsynced under `apps/` (additive; the old prefix is untouched).
- Published-app tokens are now stateless HMAC-signed (`pub.<payload>.<sig>`, same construction as `git-token.service`), carrying workspace/project/sha/expiry. Static dev-preview grants stay in-process — the staged `dist/` they serve is genuinely on one instance's disk.
- New `preview.service.test.ts` (tamper, wrong secret, expiry, static grants) added to the apps vitest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
