### PR TITLE
fix(apps): the binding scheduler must project `slug`, or it reads zero bindings

### DIFF
--- a/api/src/inngest/functions/apps-binding-refresh.ts
+++ b/api/src/inngest/functions/apps-binding-refresh.ts
@@ -27,8 +27,13 @@ export const appsBindingSchedulerFunction = inngest.createFunction(
   },
   { cron: "*/15 * * * *" },
   async ({ step }) => {
+    // `slug` is not optional here: readBindings locates the app's files at
+    // `apps/<slug>/…` (appRootFor), and without it the lookup falls back to
+    // `apps/<mongoId>/…` — a folder that does not exist — so every project
+    // silently read ZERO bindings and this scheduler triggered nothing in
+    // production for weeks while reporting success.
     const projects = await step.run("list-projects", async () =>
-      AppProject.find({}).select("_id workspaceId defaultBranch").lean(),
+      AppProject.find({}).select("_id workspaceId defaultBranch slug").lean(),
     );
     let triggered = 0;
     for (const project of projects as Array<{


### PR DESCRIPTION
## Why

Prod's `scheduled-apps-binding-refresh` has been running every 15 minutes reporting `projects: 59, triggered: 0`. `readBindings` resolves an app's folder with `appRootFor(project)` = `apps/<slug>`, but the scheduler's `.select("_id workspaceId defaultBranch")` dropped `slug`, so the path became `apps/<mongoId>` (nonexistent) → zero bindings per project, silently.

Consequence: none of the 172 scheduled bindings in the RealAdvisor workspace were ever materialized on prod — including the 28 former v1 "live" bindings that have no v1 parquet to carry over, so those tables 404 in the published apps until this runs.

## What

Add `slug` to the projection, with a comment explaining why it is load-bearing. Only `AppProject` projection in the codebase that lacked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
