### PR TITLE
fix(tabs): one preview tab for every kind — the store owns the invariant, each kind pins on modification

### DIFF
--- a/app/src/components/AppFileEditor.tsx
+++ b/app/src/components/AppFileEditor.tsx
@@ -11,6 +11,7 @@ import { Database as DatabaseIcon, Play as PlayIcon } from "lucide-react";
 import MonacoEditor from "@monaco-editor/react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppsStore } from "../store/appsStore";
+import { useConsoleStore } from "../store/consoleStore";
 import {
   configureMonacoForJsx,
   languageForPath,
@@ -96,6 +97,8 @@ export default function AppFileEditor({
   const handleChange = useCallback(
     (value: string | undefined) => {
       updateFileLocal(appId, path, value ?? "");
+      // First keystroke pins the tab (preview -> permanent), as for consoles.
+      useConsoleStore.getState().updateDirty(_tabId, true);
       if (saveTimer.current) clearTimeout(saveTimer.current);
       if (workspaceId) {
         saveTimer.current = setTimeout(() => {
@@ -103,7 +106,7 @@ export default function AppFileEditor({
         }, 1000);
       }
     },
-    [appId, path, workspaceId, updateFileLocal, saveFile],
+    [appId, path, workspaceId, updateFileLocal, saveFile, _tabId],
   );
 
   return (

--- a/app/src/components/AppWorkspace.tsx
+++ b/app/src/components/AppWorkspace.tsx
@@ -995,6 +995,14 @@ export default function AppWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appId, workspaceId]);
 
+  // Entering edit mode is "modifying the content" for an app tab: it pins
+  // the tab (consoleStore's preview invariant), so a workbench with a dev
+  // server and terminals is never replaced by the next app you click. A
+  // merely viewed app stays a preview tab, like a file you only looked at.
+  useEffect(() => {
+    if (editing) useConsoleStore.getState().updateDirty(_tabId, true);
+  }, [editing, _tabId]);
+
   // The consumer view's token is short-lived, so it is fetched when this app
   // is opened for viewing and again whenever a publish moves the app on.
   useEffect(() => {

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -11,6 +11,7 @@
  * command that produced them.
  */
 
+import { useConsoleStore } from "../store/consoleStore";
 import {
   lazy,
   Suspense,
@@ -344,6 +345,8 @@ export default function DbtFileEditor({
   const handleChange = useCallback(
     (value: string | undefined) => {
       writeFile(projectId, path, value ?? "");
+      // First keystroke pins the tab (preview -> permanent), as for consoles.
+      useConsoleStore.getState().updateDirty(tabId, true);
       if (saveTimer.current) clearTimeout(saveTimer.current);
       if (workspaceId) {
         saveTimer.current = setTimeout(() => {
@@ -353,7 +356,7 @@ export default function DbtFileEditor({
         }, 1200);
       }
     },
-    [projectId, path, workspaceId, writeFile, persistFile],
+    [projectId, path, workspaceId, writeFile, persistFile, tabId],
   );
 
   const saveNow = useCallback(() => {

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2798,6 +2798,7 @@ function Editor({
                     />
                   ) : tab.kind === "flow-editor" ? (
                     <FlowEditor
+                      tabId={tab.id}
                       flowId={tab.metadata?.flowId as string | undefined}
                       isNew={tab.metadata?.isNew as boolean | undefined}
                       flowType={

--- a/app/src/components/FlowEditor.tsx
+++ b/app/src/components/FlowEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type RefObject } from "react";
+import { useConsoleStore } from "../store/consoleStore";
 import { Alert, Box, Tab, Tabs } from "@mui/material";
 import { SyncFlowForm } from "./SyncFlowForm";
 import { DbFlowForm, type DbFlowFormRef } from "./DbFlowForm";
@@ -12,6 +13,8 @@ import EntityLoadErrorState, {
 import { missingEntityError } from "../lib/entity-labels";
 
 interface FlowEditorProps {
+  /** The hosting tab, pinned when editing starts (preview-tab invariant). */
+  tabId?: string;
   flowId?: string;
   isNew?: boolean;
   /**
@@ -32,6 +35,7 @@ interface FlowSavedOptions {
 }
 
 export function FlowEditor({
+  tabId,
   flowId,
   isNew = false,
   flowType = "sync",
@@ -40,6 +44,13 @@ export function FlowEditor({
   dbFlowFormRef,
 }: FlowEditorProps) {
   const [isEditing, setIsEditing] = useState(isNew);
+  // Editing a flow (or creating one) is "modifying the content": pin the tab
+  // so the next open cannot replace a half-filled form.
+  useEffect(() => {
+    if (isEditing && tabId) {
+      useConsoleStore.getState().updateDirty(tabId, true);
+    }
+  }, [isEditing, tabId]);
   const [currentFlowId, setCurrentFlowId] = useState<string | undefined>(
     flowId,
   );

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -66,6 +66,9 @@ export function focusDbtConsoleTab(projectId: string, title: string): string {
       },
       { replacePristine: false },
     );
+  // A project's console is a durable document, not a preview: pin it at open
+  // (as notebooks do) so the next open cannot replace it.
+  consoleStore.updateDirty(tabId, true);
 
   useDbtStore.getState().setActiveProject(projectId);
   consoleStore.setActiveTab(tabId);

--- a/app/src/store/consoleStore.test.ts
+++ b/app/src/store/consoleStore.test.ts
@@ -172,3 +172,61 @@ describe("consoleStore saved baseline reconciliation", () => {
     expect(hasUnsavedLocalEdits(id)).toBe(true);
   });
 });
+
+describe("consoleStore preview-tab invariant (kind-agnostic)", () => {
+  beforeEach(() => {
+    resetConsoleStore();
+  });
+
+  function openApp(id: string, appId: string): string {
+    return useConsoleStore.getState().openTab({
+      id,
+      title: appId,
+      content: "",
+      kind: "app",
+      metadata: { appId },
+    });
+  }
+
+  it("opening a second app replaces the first app's preview tab", () => {
+    openApp("a1", "app-1");
+    openApp("a2", "app-2");
+    expect(useConsoleStore.getState().tabOrder).toEqual(["a2"]);
+    expect(useConsoleStore.getState().tabs.a1).toBeUndefined();
+  });
+
+  it("a pinned app tab is never replaced", () => {
+    openApp("a1", "app-1");
+    useConsoleStore.getState().updateDirty("a1", true);
+    openApp("a2", "app-2");
+    expect(useConsoleStore.getState().tabOrder).toEqual(["a1", "a2"]);
+  });
+
+  it("the preview tab is replaced across kinds — a console preview by an app", () => {
+    useConsoleStore.getState().openTab({
+      id: "c1",
+      title: "Untitled",
+      content: "",
+      kind: "console",
+    });
+    openApp("a1", "app-1");
+    expect(useConsoleStore.getState().tabOrder).toEqual(["a1"]);
+  });
+
+  it("replacePristine: false keeps the existing preview tab", () => {
+    openApp("a1", "app-1");
+    useConsoleStore
+      .getState()
+      .openTab(
+        { id: "n1", title: "Notebook", content: "", kind: "notebook" },
+        { replacePristine: false },
+      );
+    expect(useConsoleStore.getState().tabOrder).toEqual(["a1", "n1"]);
+  });
+
+  it("re-opening an existing tab id never counts itself as the pristine victim", () => {
+    openApp("a1", "app-1");
+    openApp("a1", "app-1");
+    expect(useConsoleStore.getState().tabOrder).toEqual(["a1"]);
+  });
+});

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -579,19 +579,27 @@ export const useConsoleStore = create<ConsoleStore>()(
         const id = tab.id || generateObjectId();
         const content = tab.content || "";
 
-        // Replace first pristine tab if present. Only an untouched CONSOLE
-        // is preview-tab fodder: for every other kind (app workbench,
-        // dashboard, connector) "not dirty" is its normal resting state, not
-        // a sign it is disposable — the old !isDirty check silently closed
-        // an open app's tab whenever a second app was opened.
+        // The preview-tab invariant (VS Code): at most ONE preview tab is
+        // open at a time. A tab is a preview until it is pinned (`isDirty`,
+        // rendered italic until then); opening another tab replaces it.
+        // This rule is kind-agnostic — the store owns the invariant, and
+        // each kind owns exactly one duty: pin the tab when its content is
+        // modified (console: first keystroke; app-file / dbt-file: first
+        // keystroke; app workbench: entering edit mode; flow: entering edit;
+        // dashboard: its own shouldPin; notebook / dbt-console / connector /
+        // plan: durable documents, pinned at open). A double-click on the
+        // tab title pins any kind.
+        //
+        // History: this used to check `kind === "console"` only. That was
+        // added when opening a second app closed the first app's tab — but
+        // the real defect was that the app workbench never pinned itself
+        // when work started in it, so the "fix" quietly dropped the
+        // invariant for every non-console kind and app tabs piled up.
         const replacePristine = options?.replacePristine ?? true;
         const pristineTabId = replacePristine
           ? Object.keys(get().tabs).find(tabId => {
               const candidate = get().tabs[tabId];
-              return (
-                (!candidate.kind || candidate.kind === "console") &&
-                !candidate.isDirty
-              );
+              return tabId !== id && !candidate.isDirty;
             })
           : undefined;
 


### PR DESCRIPTION
## Why

App tabs piled up on every click even though their titles rendered italic (preview). Consoles behaved correctly.

The preview primitive (`tab.isDirty` = pinned; italic until then) is generic, but the replacement rule in `consoleStore.openTab` was guarded with `kind === "console"` in 9c92b3a8 — added when opening a second app closed the first app's tab. The real defect at the time was that the app workbench never pinned itself once work started in it; the guard "fixed" that by dropping the one-preview-tab invariant for every non-console kind. Since then each kind reinvented "don't get eaten" locally (notebooks: `replacePristine:false` + pin at open; connectors: `isDirty:true` at open; dashboards: `shouldPin`), and apps got nothing.

## What

- `openTab` replaces the current preview tab regardless of kind (still honours `replacePristine: false`; never counts the tab being (re)opened as the victim).
- Each kind pins on its own modification event:
  - app workbench: entering edit mode (`AppWorkspace`)
  - app-file / dbt-file: first keystroke
  - flow editor: entering edit / new (`tabId` now passed from `Editor`)
  - dbt-console: pinned at open (durable document, like notebooks)
  - console (keystroke), dashboard (`shouldPin`), connector / data source / plan (open pinned): unchanged
- 5 new `consoleStore` tests: cross-kind replacement, pinned survives, `replacePristine:false`, self-reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
