### PR TITLE
feat(apps): bring back sharing — Share… in the tree opens the people dialog

### DIFF
--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -80,6 +80,10 @@ import {
 import { APPS_EXEC_MAX_TIMEOUT_MS, previewStagingDir } from "../apps/config";
 import { registerPublicShareRoutes } from "./lib/public-share-routes";
 import {
+  registerCollaboratorRoutes,
+  registerSharingSettingsRoutes,
+} from "./lib/collaborator-routes";
+import {
   buildApp,
   buildLogPath,
   deployBuild,
@@ -671,6 +675,7 @@ appsRoutes.openapi(
             // Who restricted it — the sidebar files a private app someone
             // else shared with you under "Shared with me", not "My Apps".
             owner_id: state?.owner_id,
+            workspaceRole: state?.workspaceRole,
             publishedSha: state?.publishedSha,
             publishedAt: state?.publishedAt,
           };
@@ -2314,35 +2319,48 @@ appsRoutes.openapi(
 appsRoutes.get("/:id/live", serveLive);
 appsRoutes.get("/:id/live/*", serveLive);
 
-// Public-link sharing, reusing the exact primitive dashboards and v1 apps use
-// (bcrypt password + AES copy for reveal, token rotation, owner/admin gate).
-// The anonymous consumption side lives in routes/public-share.ts.
+// Sharing — the SAME primitive dashboards and consoles use, all three
+// surfaces of it: per-user collaborators (viewer/editor), general access
+// (private/workspace + workspace role) and public links (bcrypt password +
+// AES copy for reveal, token rotation, owner/admin gate). The v1 rip-out
+// (#816) took the collaborator and sharing routes with it and left only the
+// public link, so the Share dialog had nothing to talk to for apps. The
+// anonymous consumption side lives in routes/public-share.ts.
+const loadShareableApp = async (c: AuthenticatedContext) => {
+  const id = c.req.param("id");
+  const workspaceId = c.req.param("workspaceId");
+  if (!id || !workspaceId) return null;
+  const ref = id.replace(/^apps\//, "");
+  const existing = Types.ObjectId.isValid(ref)
+    ? await AppProject.findOne({
+        _id: new Types.ObjectId(ref),
+        workspaceId: new Types.ObjectId(workspaceId),
+      })
+    : await AppProject.findOne({
+        slug: ref,
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+  if (existing) return existing;
+
+  // Sharing is one of the three things that gives an app a database row
+  // (§13.6) — a share token and its password hash cannot live in a repo the
+  // customer can clone. So if the app exists only as a folder, materialize
+  // the row now, with the id derived from (workspace, folder) so every
+  // artifact key stays stable.
+  const folder = await synthesizeProjectFromFolder(workspaceId, ref);
+  if (!folder) return null;
+  return ensureProjectRow(folder, actingUserId(c) ?? "");
+};
+registerCollaboratorRoutes(appsRoutes, {
+  resourceName: "App",
+  load: loadShareableApp,
+});
+registerSharingSettingsRoutes(appsRoutes, {
+  resourceName: "App",
+  load: loadShareableApp,
+});
 registerPublicShareRoutes(appsRoutes, {
   resourceName: "App",
-  load: async c => {
-    const id = c.req.param("id");
-    const workspaceId = c.req.param("workspaceId");
-    if (!id || !workspaceId) return null;
-    const ref = id.replace(/^apps\//, "");
-    const existing = Types.ObjectId.isValid(ref)
-      ? await AppProject.findOne({
-          _id: new Types.ObjectId(ref),
-          workspaceId: new Types.ObjectId(workspaceId),
-        })
-      : await AppProject.findOne({
-          slug: ref,
-          workspaceId: new Types.ObjectId(workspaceId),
-        });
-    if (existing) return existing;
-
-    // Sharing is one of the three things that gives an app a database row
-    // (§13.6) — a share token and its password hash cannot live in a repo the
-    // customer can clone. So if the app exists only as a folder, materialize
-    // the row now, with the id derived from (workspace, folder) so every
-    // artifact key stays stable.
-    const folder = await synthesizeProjectFromFolder(workspaceId, ref);
-    if (!folder) return null;
-    return ensureProjectRow(folder, actingUserId(c) ?? "");
-  },
+  load: loadShareableApp,
   getTitle: doc => (doc as unknown as IAppProject).title,
 });

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -4222,6 +4222,59 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/collaborators": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List App collaborators */
+        get: operations["get_api_workspaces_workspaceId_apps_id_collaborators"];
+        put?: never;
+        /** Add a App collaborator */
+        post: operations["post_api_workspaces_workspaceId_apps_id_collaborators"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/collaborators/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a App collaborator */
+        delete: operations["delete_api_workspaces_workspaceId_apps_id_collaborators_userId"];
+        options?: never;
+        head?: never;
+        /** Update a App collaborator's role */
+        patch: operations["patch_api_workspaces_workspaceId_apps_id_collaborators_userId"];
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/sharing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update App general access */
+        patch: operations["patch_api_workspaces_workspaceId_apps_id_sharing"];
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/public-share": {
         parameters: {
             query?: never;
@@ -18771,6 +18824,237 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_collaborators: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_apps_id_collaborators: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    userId: string;
+                    /** @enum {string} */
+                    role?: "viewer" | "editor";
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    delete_api_workspaces_workspaceId_apps_id_collaborators_userId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    patch_api_workspaces_workspaceId_apps_id_collaborators_userId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    role?: "viewer" | "editor";
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    patch_api_workspaces_workspaceId_apps_id_sharing: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    access?: "private" | "workspace";
+                    /** @enum {string} */
+                    workspaceRole?: "viewer" | "editor";
+                };
+            };
+        };
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -34,6 +34,7 @@ import {
   Github as LinkIcon,
   RefreshCw as RefreshIcon,
   Trash2 as DeleteIcon,
+  UserPlus as ShareMenuIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
@@ -43,6 +44,8 @@ import {
 import { SECTION_LABELS } from "../pages/settings/sections";
 import { useAppsStore, type AppFileEntry } from "../store/appsStore";
 import { useAuth } from "../contexts/auth-context";
+import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
+import ShareDialog from "./ShareDialog";
 import { focusAppsFileTab, focusAppsTab } from "../apps-runtime/shell";
 import {
   useExplorerRevealStore,
@@ -224,6 +227,8 @@ export default function AppsExplorer() {
     [expandedFolders],
   );
   const [createOpen, setCreateOpen] = useState(false);
+  const [shareAppId, setShareAppId] = useState<string | null>(null);
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const [newTitle, setNewTitle] = useState("");
   const [creating, setCreating] = useState(false);
 
@@ -427,6 +432,18 @@ export default function AppsExplorer() {
       if (parsed.kind !== "app") return null;
       return [
         <MenuItem
+          key="share"
+          onClick={() => {
+            helpers.closeMenu();
+            setShareAppId(parsed.appId);
+          }}
+        >
+          <ListItemIcon>
+            <ShareMenuIcon size={16} />
+          </ListItemIcon>
+          Share…
+        </MenuItem>,
+        <MenuItem
           key="delete"
           onClick={() => {
             helpers.closeMenu();
@@ -442,6 +459,8 @@ export default function AppsExplorer() {
     },
     [handleDelete],
   );
+
+  const shareApp = shareAppId ? apps.find(a => a.id === shareAppId) : null;
 
   const actions = (
     <>
@@ -643,6 +662,37 @@ export default function AppsExplorer() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {shareApp && (
+        <ShareDialog
+          open={!!shareAppId}
+          onClose={() => setShareAppId(null)}
+          resourceType="app"
+          resourceId={shareApp.id}
+          resourceName={shareApp.title}
+          ownerId={shareApp.owner_id}
+          access={shareApp.access ?? "workspace"}
+          workspaceRole={shareApp.workspaceRole ?? "viewer"}
+          canManage={
+            !shareApp.owner_id ||
+            shareApp.owner_id === userId ||
+            isWorkspaceAdmin
+          }
+          onSharingChanged={changes => {
+            useAppsStore.setState(s => {
+              const app = s.apps.find(a => a.id === shareApp.id);
+              if (!app) return;
+              if (changes.access) app.access = changes.access;
+              if (changes.workspaceRole) {
+                app.workspaceRole = changes.workspaceRole;
+              }
+            });
+            // A folder-only app gets its row (and a real id) on first share;
+            // the list is the only place that learns about it.
+            if (workspaceId) void fetchApps(workspaceId);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/app/src/components/ShareDialog.tsx
+++ b/app/src/components/ShareDialog.tsx
@@ -71,12 +71,15 @@ export interface ShareDialogProps {
 const RESOURCE_LABEL: Record<ShareResourceType, string> = {
   dashboard: "dashboard",
   console: "console",
+  app: "app",
 };
 
 /** Public links are only available where snapshot data exists. */
 const SUPPORTS_PUBLIC: Record<ShareResourceType, boolean> = {
   dashboard: true,
   console: false,
+  // A published app is served from its immutable deployment.
+  app: true,
 };
 
 // Stable fallback so the Zustand selector never returns a fresh `[]` per call

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -36,6 +36,8 @@ export interface AppMeta {
    * personally — the sidebar's "Shared with me" section.
    */
   owner_id?: string;
+  /** What workspace members may do with a workspace-access app. */
+  workspaceRole?: "viewer" | "editor";
 }
 
 export interface AppFileEntry {

--- a/app/src/store/shareStore.test.ts
+++ b/app/src/store/shareStore.test.ts
@@ -10,6 +10,7 @@ import {
 const TAB_PATTERN_FOR_RESOURCE: Record<ShareResourceType, RegExp> = {
   dashboard: TAB_DEEP_LINK_PATTERNS.dashboard,
   console: TAB_DEEP_LINK_PATTERNS.console,
+  app: TAB_DEEP_LINK_PATTERNS.app,
 };
 
 describe("buildWorkspaceResourceUrl", () => {

--- a/app/src/store/shareStore.ts
+++ b/app/src/store/shareStore.ts
@@ -30,7 +30,7 @@ const PUBLIC_SHARE_BASE = {
  * public links with optional password (dashboards + apps).
  */
 
-export type ShareResourceType = "dashboard" | "console";
+export type ShareResourceType = "dashboard" | "console" | "app";
 export type ShareRole = "viewer" | "editor";
 export type ShareAccess = "private" | "workspace";
 
@@ -92,6 +92,7 @@ export function buildPublicShareUrl(
 const RESOURCE_URL_PREFIX: Record<ShareResourceType, string> = {
   dashboard: "d",
   console: "c",
+  app: "apps",
 };
 
 /**

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -25868,6 +25868,473 @@
         "operationId": "get_api_workspaces_workspaceId_apps_id_eyes_shots_shot"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/collaborators": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "List App collaborators",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_collaborators"
+      },
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Add a App collaborator",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "viewer",
+                      "editor"
+                    ]
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_apps_id_collaborators"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/collaborators/{userId}": {
+      "patch": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Update a App collaborator's role",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "viewer",
+                      "editor"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patch_api_workspaces_workspaceId_apps_id_collaborators_userId"
+      },
+      "delete": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Remove a App collaborator",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "delete_api_workspaces_workspaceId_apps_id_collaborators_userId"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/sharing": {
+      "patch": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Update App general access",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "workspace"
+                    ]
+                  },
+                  "workspaceRole": {
+                    "type": "string",
+                    "enum": [
+                      "viewer",
+                      "editor"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patch_api_workspaces_workspaceId_apps_id_sharing"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/public-share": {
       "post": {
         "tags": [


### PR DESCRIPTION
## Why

Right-click on an app offered only "Delete app". The v1 rip-out (#816) removed the v1 explorer's share menu **and** the `app` resource type from `ShareDialog`/`shareStore`, and the API kept only the public-link routes — so there was no way to share an app with specific people.

## What

- API: `registerCollaboratorRoutes` + `registerSharingSettingsRoutes` for apps (same helper dashboards/consoles use; the existing public-share registration now shares the same `loadShareableApp`). List payload gains `workspaceRole`.
- App: `app` back in `ShareResourceType` (deep link `/apps/<id>`), `RESOURCE_LABEL` / `SUPPORTS_PUBLIC`; `AppMeta.workspaceRole`; **Share…** context-menu item in the apps tree opens `ShareDialog` (collaborators viewer/editor, private/workspace + role, public link with password). `canManage` = owner, no recorded owner, or workspace admin.
- OpenAPI spec + generated client types regenerated; share store test covers the app deep link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
