### PR TITLE
feat(apps): an actionable, bounded History panel — view changes, restore, go live, copy sha

### DIFF
--- a/api/src/apps/box.ts
+++ b/api/src/apps/box.ts
@@ -627,6 +627,55 @@ export interface BoxCommitResult {
  * be, except that it is a commit on a branch, visible to git, and reachable
  * from any other clone.
  */
+/**
+ * Set one folder of the working copy back to its content at `sha` — the
+ * working-copy half of "restore this version". Tracked files under `root`
+ * are removed first so files that did not exist at `sha` disappear too
+ * (`git checkout <sha> -- <dir>` alone only adds and overwrites); ignored
+ * files (node_modules, dist) are untouched. Nothing is committed here.
+ */
+export async function boxRestoreTreeFrom(
+  ctx: SandboxExecContext,
+  sha: string,
+  root: string,
+): Promise<void> {
+  if (!/^[0-9a-f]{7,40}$/.test(sha)) throw new Error("Invalid commit sha");
+  const exists = await boxExec(
+    ctx,
+    boxGit(ctx, "cat-file", "-e", `${sha}^{commit}`),
+    { timeoutMs: 30_000 },
+  );
+  if (exists.exitCode !== 0) {
+    // The box clones from Mako's endpoint; a commit that landed there since
+    // the last pull is one fetch away.
+    await boxExec(ctx, boxGit(ctx, "fetch", "-q", "origin"), {
+      timeoutMs: 120_000,
+    });
+  }
+  const removed = await boxExec(
+    ctx,
+    boxGit(ctx, "rm", "-r", "-q", "--ignore-unmatch", "--", root),
+    { timeoutMs: 120_000 },
+  );
+  if (removed.exitCode !== 0) {
+    throw new Error(`Could not clear ${root}: ${removed.stderr.slice(-300)}`);
+  }
+  const restored = await boxExec(
+    ctx,
+    boxGit(ctx, "checkout", sha, "--", root),
+    { timeoutMs: 120_000 },
+  );
+  if (restored.exitCode !== 0) {
+    // Put the working copy back the way it was before failing.
+    await boxExec(ctx, boxGit(ctx, "checkout", "HEAD", "--", root), {
+      timeoutMs: 120_000,
+    }).catch(() => undefined);
+    throw new Error(
+      `This version has no "${root}" to restore: ${restored.stderr.slice(-300)}`,
+    );
+  }
+}
+
 export async function boxCommitAll(input: {
   ctx: SandboxExecContext;
   message: string;

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -59,6 +59,7 @@ import {
   boxFileVersions,
   boxPorcelain,
   type BoxFileVersions,
+  boxRestoreTreeFrom,
 } from "./box";
 import { publishRealtimeEvent } from "../services/realtime.service";
 import {
@@ -82,6 +83,7 @@ import {
   initRepo,
   listTree,
   log as repoLog,
+  diffNameStatus,
   readBlob,
   repoDirFor,
   repoExists,
@@ -1460,6 +1462,81 @@ export async function gitPathsAction(
 }
 
 /** HEAD / index / working-tree contents of one repo-relative path, for diffs. */
+/** The empty tree: what a root commit's "parent" diffs against. */
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/**
+ * What one commit changed INSIDE this app (paths app-relative), and its
+ * parent — the unit the History panel's "View changes" works in. Read from
+ * the bare repo: no sandbox, no working copy.
+ */
+export async function commitChanges(
+  project: IAppProject,
+  sha: string,
+): Promise<{ sha: string; parent: string | null; files: ChangedFile[] }> {
+  const repoDir = await repoFor(project);
+  const oid = await resolveCommit(repoDir, sha);
+  if (!oid) throw new Error(`No such commit: ${sha}`);
+  const parent = await resolveCommit(repoDir, `${oid}^`);
+  const root = appRootFor(project);
+  const files = (await diffNameStatus(repoDir, parent ?? EMPTY_TREE, oid))
+    .filter(f => f.path.startsWith(`${root}/`))
+    .map(f => ({ ...f, path: f.path.slice(root.length + 1) }));
+  return { sha: oid, parent, files };
+}
+
+/** One app file before and after a commit (null = absent on that side). */
+export async function commitFileVersions(
+  project: IAppProject,
+  sha: string,
+  relPath: string,
+): Promise<{ before: string | null; after: string | null; binary: boolean }> {
+  const repoDir = await repoFor(project);
+  const oid = await resolveCommit(repoDir, sha);
+  if (!oid) throw new Error(`No such commit: ${sha}`);
+  const parent = await resolveCommit(repoDir, `${oid}^`);
+  const full = appPath(project, relPath);
+  const read = async (ref: string | null) => {
+    if (!ref) return null;
+    try {
+      return await readBlob(repoDir, ref, full);
+    } catch {
+      return null;
+    }
+  };
+  const [before, after] = await Promise.all([read(parent), read(oid)]);
+  return {
+    before: before?.isBinary ? null : (before?.contents ?? null),
+    after: after?.isBinary ? null : (after?.contents ?? null),
+    binary: Boolean(before?.isBinary || after?.isBinary),
+  };
+}
+
+/**
+ * "Restore this version": set the app's folder back to its content at `sha`
+ * and commit that as a NEW commit on the actor's branch (then push, like
+ * every commit). History is append-only — the versions in between stay in
+ * the log, which is what makes this safe to offer from a list of commits.
+ */
+export async function restoreWorktreeTo(
+  handle: WorktreeHandle,
+  sha: string,
+  author?: GitAuthor,
+): Promise<CommitResult> {
+  const repoDir = handle.repoDir;
+  const oid = await resolveCommit(repoDir, sha);
+  if (!oid) throw new Error(`No such commit: ${sha}`);
+  const [info] = await repoLog(repoDir, oid, 1);
+  const ctx = await ensureBox(handle);
+  await boxRestoreTreeFrom(ctx, oid, handle.appRoot);
+  const subject = info?.subject ? ` "${info.subject}"` : "";
+  return commitWorktree(
+    handle,
+    `Restore${subject} (${oid.slice(0, 7)})`,
+    author,
+  );
+}
+
 export async function fileVersions(
   handle: WorktreeHandle,
   relPath: string,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -70,6 +70,9 @@ import {
   listFiles,
   mergeBranchToMain,
   projectHistory,
+  commitChanges,
+  commitFileVersions,
+  restoreWorktreeTo,
   promoteToMain,
   readFile,
   synthesizeProjectFromFolder,
@@ -1147,6 +1150,15 @@ appsRoutes.openapi(
             p => !p.startsWith("/") && !p.split("/").includes(".."),
             "path must stay inside the repository",
           ),
+        /**
+         * With a commit: the file before and after THAT commit (app-relative
+         * path), read from the repo — no sandbox. Without: HEAD / index /
+         * working tree of the caller's box.
+         */
+        sha: z
+          .string()
+          .regex(/^[0-9a-f]{7,40}$/)
+          .optional(),
       }),
     },
     responses: OPEN_RESPONSES,
@@ -1155,7 +1167,11 @@ appsRoutes.openapi(
     try {
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
-      const { path: relPath } = c.req.valid("query");
+      const { path: relPath, sha } = c.req.valid("query");
+      if (sha) {
+        const versions = await commitFileVersions(loaded.project, sha, relPath);
+        return c.json({ success: true as const, versions }, 200);
+      }
       const handle = await ensureWorktree(
         loaded.project,
         loaded.userId ?? "api-key",
@@ -1284,6 +1300,76 @@ appsRoutes.openapi(
         loaded.userId ?? "api-key",
       );
       return c.json({ success: true as const, ...result }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+appsRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/git/commit",
+    tags: ["Apps"],
+    summary: "What one commit changed in this app",
+    description:
+      "The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam,
+      query: z.object({ sha: z.string().regex(/^[0-9a-f]{7,40}$/) }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: false });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const { sha } = c.req.valid("query");
+      const commit = await commitChanges(loaded.project, sha);
+      return c.json({ success: true as const, commit }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+appsRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/{id}/restore",
+    tags: ["Apps"],
+    summary: "Restore the app to a previous version (as a new commit)",
+    description:
+      "Sets the app's files back to their content at `sha` and commits that on the caller's branch, then pushes. Nothing is rewritten: the versions in between stay in the history. Runs in the caller's sandbox (starting it if needed), like any edit.",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam,
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: z.object({ sha: z.string().regex(/^[0-9a-f]{7,40}$/) }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: true });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const userId = loaded.userId ?? "api-key";
+      const { sha } = c.req.valid("json");
+      const user = c.get("user");
+      const handle = await ensureWorktree(loaded.project, userId);
+      const result = await restoreWorktreeTo(
+        handle,
+        sha,
+        user?.email ? { name: user.email, email: user.email } : undefined,
+      );
+      return c.json({ success: true as const, result }, 200);
     } catch (error) {
       return handleError(c, error);
     }

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3851,6 +3851,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/git/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * What one commit changed in this app
+         * @description The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.
+         */
+        get: operations["get_api_workspaces_workspaceId_apps_id_git_commit"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore the app to a previous version (as a new commit)
+         * @description Sets the app's files back to their content at `sha` and commits that on the caller's branch, then pushes. Nothing is rewritten: the versions in between stay in the history. Runs in the caller's sandbox (starting it if needed), like any edit.
+         */
+        post: operations["post_api_workspaces_workspaceId_apps_id_restore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/checkout": {
         parameters: {
             query?: never;
@@ -17862,6 +17902,7 @@ export interface operations {
         parameters: {
             query: {
                 path: string;
+                sha?: string;
             };
             header?: never;
             path: {
@@ -17996,6 +18037,96 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_git_commit: {
+        parameters: {
+            query: {
+                sha: string;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_apps_id_restore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    sha: string;
+                };
+            };
+        };
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/apps-runtime/shell.ts
+++ b/app/src/apps-runtime/shell.ts
@@ -73,30 +73,39 @@ export function focusAppsFileTab(
 export function focusAppsDiffTab(
   appId: string,
   path: string,
-  mode: "working" | "index",
+  mode: "working" | "index" | "commit",
   slug?: string,
+  /** "commit" mode: the commit whose change to `path` is shown. */
+  sha?: string,
 ): string {
   const consoleStore = useConsoleStore.getState();
   const existingTab = Object.values(consoleStore.tabs).find(
     (tab: {
       kind?: string;
-      metadata?: { appId?: string; path?: string; mode?: string };
+      metadata?: { appId?: string; path?: string; mode?: string; sha?: string };
     }) =>
       tab.kind === "app-diff" &&
       tab.metadata?.appId === appId &&
       tab.metadata?.path === path &&
-      tab.metadata?.mode === mode,
+      tab.metadata?.mode === mode &&
+      (mode !== "commit" || tab.metadata?.sha === sha),
   );
   if (existingTab) {
     consoleStore.setActiveTab(existingTab.id);
     return existingTab.id;
   }
   const fileName = path.split("/").pop() || path;
+  const label =
+    mode === "commit"
+      ? (sha ?? "").slice(0, 7)
+      : mode === "index"
+        ? "Index"
+        : "Working Tree";
   const tabId = consoleStore.openTab({
-    title: `${fileName} (${mode === "index" ? "Index" : "Working Tree"})`,
+    title: `${fileName} (${label})`,
     content: "",
     kind: "app-diff",
-    metadata: { appId: appId, appSlug: slug, path, mode },
+    metadata: { appId: appId, appSlug: slug, path, mode, sha },
   });
   consoleStore.setActiveTab(tabId);
   return tabId;

--- a/app/src/components/AppDiffTab.tsx
+++ b/app/src/components/AppDiffTab.tsx
@@ -24,14 +24,18 @@ export default function AppDiffTab({
   appId,
   path,
   mode,
+  sha,
 }: {
   appId: string;
   path: string;
-  mode: "working" | "index";
+  /** "commit": what `sha` did to this file (parent → sha), from the repo. */
+  mode: "working" | "index" | "commit";
+  sha?: string;
 }) {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
   const fetchFileVersions = useAppsStore(s => s.fetchFileVersions);
+  const fetchCommitFileVersions = useAppsStore(s => s.fetchCommitFileVersions);
   const apps = useAppsStore(s => s.apps);
   // The row for this path in the pushed status: any change to it (staged,
   // discarded, edited in a shell) is the cue to re-read the versions.
@@ -50,7 +54,22 @@ export default function AppDiffTab({
     if (!workspaceId) return;
     let cancelled = false;
     setLoading(true);
-    void fetchFileVersions(workspaceId, appId, path).then(v => {
+    const load =
+      mode === "commit" && sha
+        ? // A commit is immutable: fold its two sides into the same shape
+          // the box versions use, so the rest of this view is unchanged.
+          fetchCommitFileVersions(workspaceId, appId, sha, path).then(v =>
+            v
+              ? {
+                  head: v.before,
+                  index: v.after,
+                  working: v.after,
+                  binary: v.binary,
+                }
+              : null,
+          )
+        : fetchFileVersions(workspaceId, appId, path);
+    void load.then(v => {
       if (cancelled) return;
       setVersions(v);
       setLoading(false);
@@ -58,11 +77,20 @@ export default function AppDiffTab({
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, appId, path, mode, stamp, fetchFileVersions]);
+  }, [
+    workspaceId,
+    appId,
+    path,
+    mode,
+    sha,
+    stamp,
+    fetchFileVersions,
+    fetchCommitFileVersions,
+  ]);
 
   const original =
-    mode === "index" ? versions?.head : (versions?.index ?? versions?.head);
-  const modified = mode === "index" ? versions?.index : versions?.working;
+    mode === "working" ? (versions?.index ?? versions?.head) : versions?.head;
+  const modified = mode === "working" ? versions?.working : versions?.index;
 
   // "Open File": only when the path lives inside an app this window knows,
   // since file tabs are addressed app-relatively.
@@ -103,7 +131,13 @@ export default function AppDiffTab({
         </Typography>
         <Chip
           size="small"
-          label={mode === "index" ? "HEAD → Index" : "Index → Working Tree"}
+          label={
+            mode === "commit"
+              ? `${(sha ?? "").slice(0, 7)}^ → ${(sha ?? "").slice(0, 7)}`
+              : mode === "index"
+                ? "HEAD → Index"
+                : "Index → Working Tree"
+          }
           sx={{ height: 18, fontSize: "0.65rem" }}
         />
         <Box sx={{ flex: 1 }} />

--- a/app/src/components/AppHistoryPopover.tsx
+++ b/app/src/components/AppHistoryPopover.tsx
@@ -1,0 +1,476 @@
+/**
+ * The app's commit history, from the workbench toolbar — readable and
+ * actionable, not a disabled menu.
+ *
+ * Every commit can be inspected (its changed files, each opening the real
+ * diff for that commit), restored (a NEW commit that sets the app back to
+ * that content — history is append-only, so nothing is lost) and, when a
+ * build for it is still stored, made the live version again (a repoint, no
+ * rebuild). The popover is capped: it scrolls instead of taking the screen.
+ */
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Popover,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ChevronDown as ExpandIcon,
+  ChevronRight as CollapsedIcon,
+  Copy as CopyIcon,
+  FileDiff as DiffIcon,
+  MoreHorizontal as MoreIcon,
+  Rocket as LiveIcon,
+  Undo2 as RestoreIcon,
+} from "lucide-react";
+import { useAppsStore, type AppCommit } from "../store/appsStore";
+import { focusAppsDiffTab } from "../apps-runtime/shell";
+
+const STATUS_LETTER: Record<string, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof Error && e.message ? e.message : fallback;
+}
+
+export default function AppHistoryPopover({
+  anchorEl,
+  onClose,
+  workspaceId,
+  appId,
+  slug,
+  branch,
+  publishedSha,
+}: {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  workspaceId: string;
+  appId: string;
+  slug?: string;
+  branch: string;
+  publishedSha?: string;
+}) {
+  const history = useAppsStore(s => s.historyByApp[appId]);
+  const commitFiles = useAppsStore(s => s.commitFilesByApp[appId]);
+  const fetchCommitFiles = useAppsStore(s => s.fetchCommitFiles);
+  const restoreVersion = useAppsStore(s => s.restoreVersion);
+  const rollbackTo = useAppsStore(s => s.rollbackTo);
+
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [menu, setMenu] = useState<{
+    anchor: HTMLElement;
+    commit: AppCommit;
+  } | null>(null);
+  const [confirm, setConfirm] = useState<{
+    kind: "restore" | "rollback";
+    commit: AppCommit;
+  } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const open = Boolean(anchorEl);
+  useEffect(() => {
+    if (!open) {
+      setExpanded(null);
+      setMenu(null);
+      setError(null);
+    }
+  }, [open]);
+
+  const toggleFiles = useCallback(
+    (oid: string) => {
+      const next = expanded === oid ? null : oid;
+      setExpanded(next);
+      if (next) void fetchCommitFiles(workspaceId, appId, next);
+    },
+    [expanded, fetchCommitFiles, workspaceId, appId],
+  );
+
+  const runConfirmed = useCallback(async () => {
+    if (!confirm) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (confirm.kind === "restore") {
+        await restoreVersion(workspaceId, appId, confirm.commit.oid);
+        setNotice(
+          `Restored "${confirm.commit.subject}" as a new commit on ${branch}.`,
+        );
+      } else {
+        await rollbackTo(workspaceId, appId, confirm.commit.oid);
+        setNotice(`The live app now serves ${confirm.commit.oid.slice(0, 7)}.`);
+      }
+      setConfirm(null);
+    } catch (e) {
+      setError(
+        errorMessage(
+          e,
+          confirm.kind === "restore"
+            ? "Could not restore this version"
+            : "Could not roll back the live app",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [confirm, restoreVersion, rollbackTo, workspaceId, appId, branch]);
+
+  const commits = history ?? [];
+  const headOid = commits[0]?.oid;
+
+  return (
+    <>
+      <Popover
+        anchorEl={anchorEl}
+        open={open}
+        onClose={onClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{
+          paper: {
+            sx: {
+              width: 560,
+              maxWidth: "calc(100vw - 32px)",
+              maxHeight: "60vh",
+              display: "flex",
+              flexDirection: "column",
+            },
+          },
+        }}
+      >
+        <Box
+          sx={{
+            px: 2,
+            py: 1,
+            borderBottom: 1,
+            borderColor: "divider",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            flexShrink: 0,
+          }}
+        >
+          <Typography variant="subtitle2">History</Typography>
+          <Chip size="small" label={branch} sx={{ height: 20 }} />
+          <Box sx={{ flex: 1 }} />
+          {history === undefined && <CircularProgress size={14} />}
+        </Box>
+        {(error || notice) && (
+          <Alert
+            severity={error ? "error" : "success"}
+            onClose={() => {
+              setError(null);
+              setNotice(null);
+            }}
+            sx={{ borderRadius: 0, flexShrink: 0 }}
+          >
+            {error ?? notice}
+          </Alert>
+        )}
+        <Box sx={{ overflowY: "auto", minHeight: 0 }}>
+          {history !== undefined && commits.length === 0 && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ px: 2, py: 2 }}
+            >
+              No commits yet.
+            </Typography>
+          )}
+          {commits.map(c => {
+            const isLive = !!publishedSha && c.oid === publishedSha;
+            const isHead = c.oid === headOid;
+            const isOpen = expanded === c.oid;
+            const files = commitFiles?.[c.oid];
+            return (
+              <Box key={c.oid} sx={{ borderBottom: 1, borderColor: "divider" }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 0.5,
+                    px: 1,
+                    py: 1,
+                    cursor: "pointer",
+                    "&:hover": { bgcolor: "action.hover" },
+                  }}
+                  onClick={() => toggleFiles(c.oid)}
+                >
+                  <Box sx={{ pt: 0.25, color: "text.secondary" }}>
+                    {isOpen ? (
+                      <ExpandIcon size={16} />
+                    ) : (
+                      <CollapsedIcon size={16} />
+                    )}
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        color: "text.primary",
+                        overflowWrap: "anywhere",
+                        display: "-webkit-box",
+                        WebkitLineClamp: isOpen ? "unset" : 2,
+                        WebkitBoxOrient: "vertical",
+                        overflow: "hidden",
+                      }}
+                    >
+                      {c.subject}
+                    </Typography>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                        mt: 0.25,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontFamily: "monospace" }}
+                      >
+                        {c.oid.slice(0, 7)}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {c.author} · {new Date(c.timestamp).toLocaleString()}
+                      </Typography>
+                      {isLive && (
+                        <Chip
+                          size="small"
+                          color="success"
+                          icon={<LiveIcon size={12} />}
+                          label="Live"
+                          sx={{ height: 18, fontSize: "0.65rem" }}
+                        />
+                      )}
+                      {isHead && (
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          label="Latest"
+                          sx={{ height: 18, fontSize: "0.65rem" }}
+                        />
+                      )}
+                    </Box>
+                  </Box>
+                  <Tooltip title="Actions">
+                    <IconButton
+                      size="small"
+                      onClick={e => {
+                        e.stopPropagation();
+                        setMenu({ anchor: e.currentTarget, commit: c });
+                      }}
+                    >
+                      <MoreIcon size={16} />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+                <Collapse in={isOpen} unmountOnExit>
+                  <Box sx={{ pl: 4, pr: 1, pb: 1 }}>
+                    {!files ? (
+                      <CircularProgress size={14} sx={{ ml: 1, my: 0.5 }} />
+                    ) : files.length === 0 ? (
+                      <Typography variant="caption" color="text.secondary">
+                        No files of this app changed in this commit.
+                      </Typography>
+                    ) : (
+                      files.map(f => (
+                        <Box
+                          key={f.path}
+                          onClick={e => {
+                            e.stopPropagation();
+                            focusAppsDiffTab(
+                              appId,
+                              f.path,
+                              "commit",
+                              slug,
+                              c.oid,
+                            );
+                            onClose();
+                          }}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1,
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: 1,
+                            cursor: "pointer",
+                            "&:hover": { bgcolor: "action.hover" },
+                          }}
+                        >
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontFamily: "monospace",
+                              width: 12,
+                              color:
+                                f.status === "deleted"
+                                  ? "error.main"
+                                  : f.status === "added"
+                                    ? "success.main"
+                                    : "text.secondary",
+                            }}
+                          >
+                            {STATUS_LETTER[f.status] ?? "M"}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontFamily: "monospace",
+                              color: "text.primary",
+                              overflowWrap: "anywhere",
+                            }}
+                          >
+                            {f.path}
+                          </Typography>
+                          <Box sx={{ flex: 1 }} />
+                          <DiffIcon size={13} style={{ opacity: 0.6 }} />
+                        </Box>
+                      ))
+                    )}
+                  </Box>
+                </Collapse>
+              </Box>
+            );
+          })}
+        </Box>
+      </Popover>
+
+      <Menu
+        anchorEl={menu?.anchor ?? null}
+        open={Boolean(menu)}
+        onClose={() => setMenu(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            if (menu) toggleFiles(menu.commit.oid);
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <DiffIcon size={16} />
+          </ListItemIcon>
+          <ListItemText>View changes</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!!menu && menu.commit.oid === headOid}
+          onClick={() => {
+            if (menu) setConfirm({ kind: "restore", commit: menu.commit });
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <RestoreIcon size={16} />
+          </ListItemIcon>
+          <ListItemText
+            primary="Restore this version…"
+            secondary="New commit on your branch; nothing is lost"
+          />
+        </MenuItem>
+        <MenuItem
+          disabled={
+            !!menu && !!publishedSha && menu.commit.oid === publishedSha
+          }
+          onClick={() => {
+            if (menu) setConfirm({ kind: "rollback", commit: menu.commit });
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <LiveIcon size={16} />
+          </ListItemIcon>
+          <ListItemText
+            primary="Make this the live version…"
+            secondary="Only versions that were published before"
+          />
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (menu) void navigator.clipboard?.writeText(menu.commit.oid);
+            setMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <CopyIcon size={16} />
+          </ListItemIcon>
+          <ListItemText>Copy commit SHA</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <Dialog open={Boolean(confirm)} onClose={() => !busy && setConfirm(null)}>
+        <DialogTitle>
+          {confirm?.kind === "restore"
+            ? "Restore this version?"
+            : "Make this the live version?"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {confirm?.kind === "restore" ? (
+              <>
+                The app's files go back to what they were in{" "}
+                <b>{confirm.commit.subject}</b> (
+                <code>{confirm.commit.oid.slice(0, 7)}</code>), as a new commit
+                on <b>{branch}</b>. Everything after it stays in the history, so
+                this can itself be undone. The live app is not affected until
+                you publish.
+              </>
+            ) : confirm ? (
+              <>
+                Viewers get the build of{" "}
+                <code>{confirm.commit.oid.slice(0, 7)}</code> (
+                <b>{confirm.commit.subject}</b>) immediately — no rebuild. This
+                only works for versions that were published before; otherwise
+                restore it and publish.
+              </>
+            ) : null}
+          </DialogContentText>
+          {error && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {error}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirm(null)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void runConfirmed()}
+            disabled={busy}
+          >
+            {busy
+              ? "Working…"
+              : confirm?.kind === "restore"
+                ? "Restore"
+                : "Go live"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/app/src/components/AppWorkspace.tsx
+++ b/app/src/components/AppWorkspace.tsx
@@ -22,9 +22,6 @@ import {
   Chip,
   CircularProgress,
   IconButton,
-  ListItemText,
-  Menu,
-  MenuItem,
   Tooltip,
   Typography,
   styled,
@@ -45,6 +42,7 @@ import "@xterm/xterm/css/xterm.css";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useRealtimeStore } from "../store/realtimeStore";
 import { useAppsStore } from "../store/appsStore";
+import AppHistoryPopover from "./AppHistoryPopover";
 import { useConsoleStore } from "../store/consoleStore";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { setIframeDragGuard } from "../lib/iframe-drag-guard";
@@ -932,7 +930,6 @@ export default function AppWorkspace({
 
   const app = useAppsStore(s => s.apps.find(a => a.id === appId));
   const status = useAppsStore(s => s.statusByApp[appId]);
-  const history = useAppsStore(s => s.historyByApp[appId]);
   const branches = useAppsStore(s => s.branchesByApp[appId]);
   const preview = useAppsStore(s => s.previewByApp[appId]);
   const publishedSha = app?.publishedSha;
@@ -1415,24 +1412,15 @@ export default function AppWorkspace({
         </PanelGroup>
       )}
 
-      {/* History menu */}
-      <Menu
+      <AppHistoryPopover
         anchorEl={historyAnchor}
-        open={Boolean(historyAnchor)}
         onClose={() => setHistoryAnchor(null)}
-      >
-        {(history ?? []).length === 0 && (
-          <MenuItem disabled>No commits yet</MenuItem>
-        )}
-        {(history ?? []).map(c => (
-          <MenuItem key={c.oid} disabled sx={{ opacity: 1 }}>
-            <ListItemText
-              primary={c.subject}
-              secondary={`${c.oid.slice(0, 8)} · ${c.author} · ${new Date(c.timestamp).toLocaleString()}`}
-            />
-          </MenuItem>
-        ))}
-      </Menu>
+        workspaceId={workspaceId}
+        appId={appId}
+        slug={app?.slug}
+        branch={status?.branch ?? "main"}
+        publishedSha={app?.publishedSha}
+      />
     </Box>
   );
 }

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2861,8 +2861,12 @@ function Editor({
                       appId={tab.metadata?.appId as string}
                       path={tab.metadata?.path as string}
                       mode={
-                        (tab.metadata?.mode as "working" | "index") ?? "working"
+                        (tab.metadata?.mode as
+                          | "working"
+                          | "index"
+                          | "commit") ?? "working"
                       }
+                      sha={tab.metadata?.sha as string | undefined}
                     />
                   ) : tab.kind === "app-file" ? (
                     <AppFileEditor

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -111,6 +111,19 @@ export interface AppCommit {
   subject: string;
 }
 
+/** One file a commit touched, app-relative (from GET /git/commit). */
+export interface AppCommitFile {
+  path: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+}
+
+/** A file before/after one commit (null = absent on that side). */
+export interface AppCommitFileVersions {
+  before: string | null;
+  after: string | null;
+  binary: boolean;
+}
+
 export interface AppTerminalEntry {
   id: string;
   command: string;
@@ -211,6 +224,8 @@ interface AppsStore {
    */
   viewUrlByApp: Record<string, string | undefined>;
   historyByApp: Record<string, AppCommit[]>;
+  /** Files per commit, per app — the History panel's "View changes". */
+  commitFilesByApp: Record<string, Record<string, AppCommitFile[]>>;
   /** Repo-wide graph (Source Control panel) — same repo, no app pathspec. */
   repoHistoryByApp: Record<string, AppCommit[]>;
   branchesByApp: Record<string, AppBranch[]>;
@@ -341,6 +356,33 @@ interface AppsStore {
     action: "stage" | "unstage" | "discard",
     paths: string[],
   ) => Promise<{ ok: boolean; error?: string }>;
+  /** What one commit changed in this app. Cached per (app, sha). */
+  fetchCommitFiles: (
+    workspaceId: string,
+    appId: string,
+    sha: string,
+  ) => Promise<AppCommitFile[] | null>;
+  fetchCommitFileVersions: (
+    workspaceId: string,
+    appId: string,
+    sha: string,
+    path: string,
+  ) => Promise<AppCommitFileVersions | null>;
+  /**
+   * Restore the app to `sha` as a NEW commit on the caller's branch. Throws
+   * with the server's message so the caller can show it where it acted.
+   */
+  restoreVersion: (
+    workspaceId: string,
+    appId: string,
+    sha: string,
+  ) => Promise<void>;
+  /** Repoint the live (published) app at a previously published sha. */
+  rollbackTo: (
+    workspaceId: string,
+    appId: string,
+    sha: string,
+  ) => Promise<void>;
   fetchFileVersions: (
     workspaceId: string,
     appId: string,
@@ -455,6 +497,7 @@ export const useAppsStore = create<AppsStore>()(
     editingByApp: {},
     viewUrlByApp: {},
     historyByApp: {},
+    commitFilesByApp: {},
     repoHistoryByApp: {},
     runningDevApps: [],
     boxStatus: undefined,
@@ -1092,6 +1135,84 @@ export const useAppsStore = create<AppsStore>()(
       } catch (e) {
         return { ok: false, error: message(e, `Could not ${action}`) };
       }
+    },
+
+    fetchCommitFiles: async (workspaceId, appId, sha) => {
+      const cached = get().commitFilesByApp[appId]?.[sha];
+      if (cached) return cached;
+      try {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/git/commit", {
+            params: { path: { workspaceId, id: appId }, query: { sha } },
+          }),
+        ) as { commit?: { files?: AppCommitFile[] } };
+        const files = body.commit?.files ?? [];
+        set(s => {
+          (s.commitFilesByApp[appId] ??= {})[sha] = files;
+        });
+        return files;
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to load the commit");
+        });
+        return null;
+      }
+    },
+
+    fetchCommitFileVersions: async (workspaceId, appId, sha, path) => {
+      try {
+        const body = unwrapBody(
+          await api.GET(
+            "/api/workspaces/{workspaceId}/apps/{id}/git/file-versions",
+            {
+              params: {
+                path: { workspaceId, id: appId },
+                query: { path, sha },
+              },
+            },
+          ),
+        ) as { versions?: AppCommitFileVersions };
+        return body.versions ?? null;
+      } catch {
+        return null;
+      }
+    },
+
+    restoreVersion: async (workspaceId, appId, sha) => {
+      unwrapBody(
+        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/restore", {
+          params: { path: { workspaceId, id: appId } },
+          body: { sha },
+        }),
+      );
+      // Same cache hygiene as discard: contents changed under every open tab.
+      set(s => {
+        for (const key of Object.keys(s.fileContents)) {
+          if (key.startsWith(`${appId}\u0000`)) delete s.fileContents[key];
+        }
+      });
+      void get().fetchFiles(workspaceId, appId);
+      void get().fetchStatus(workspaceId, appId);
+      void get().fetchHistory(workspaceId, appId);
+      const selected = get().selectedFile[appId];
+      if (selected) void get().openFile(workspaceId, appId, selected);
+    },
+
+    rollbackTo: async (workspaceId, appId, sha) => {
+      unwrapBody(
+        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/rollback", {
+          params: { path: { workspaceId, id: appId } },
+          body: { sha },
+        }),
+      );
+      set(s => {
+        const app = s.apps.find(a => a.id === appId);
+        if (app) {
+          app.publishedSha = sha;
+          app.publishedAt = new Date().toISOString();
+        }
+      });
+      void get().fetchViewUrl(workspaceId, appId);
     },
 
     fetchFileVersions: async (workspaceId, appId, path) => {

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -23927,6 +23927,15 @@
             "required": true,
             "name": "path",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{7,40}$"
+            },
+            "required": false,
+            "name": "sha",
+            "in": "query"
           }
         ],
         "responses": {
@@ -24219,6 +24228,190 @@
           }
         },
         "operationId": "post_api_workspaces_workspaceId_apps_id_bindings_name_materialize"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/git/commit": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "What one commit changed in this app",
+        "description": "The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{7,40}$"
+            },
+            "required": true,
+            "name": "sha",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_git_commit"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/restore": {
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Restore the app to a previous version (as a new commit)",
+        "description": "Sets the app's files back to their content at `sha` and commits that on the caller's branch, then pushes. Nothing is rewritten: the versions in between stay in the history. Runs in the caller's sandbox (starting it if needed), like any edit.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sha": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{7,40}$"
+                  }
+                },
+                "required": [
+                  "sha"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_apps_id_restore"
       }
     },
     "/api/workspaces/{workspaceId}/apps/{id}/checkout": {


### PR DESCRIPTION
## Why

The History button opened an MUI `Menu` of **disabled** items with no max width/height: it grew to the whole viewport, every line rendered greyed-out, and there was nothing to do with a commit.

## What

**Popover** capped at 560px × 60vh (scrolls), regular text, `Live` chip on the published sha and `Latest` on HEAD. Per commit (row click or ⋯ menu):

- **View changes** — expands the app files the commit touched (A/M/D/R); clicking one opens the diff tab in a new `commit` mode (`sha^ → sha`), read from the repo, no sandbox.
- **Restore this version…** — confirmation, then a *new* commit on the caller's branch that sets the app folder back to that content (tracked files removed first so files that didn't exist then disappear; ignored files like `node_modules` untouched), pushed like every commit. Append-only → undoable. Live app unaffected until publish.
- **Make this the live version…** — the existing `/rollback` repoint (only for shas with a stored deployment; the dialog explains the alternative: restore + publish).
- **Copy commit SHA**.

**API**
- `GET /apps/:id/git/commit?sha=` → `{ sha, parent, files[] }` (app-relative).
- `GET /apps/:id/git/file-versions?path&sha=` → `{ before, after, binary }` for one commit (bare repo; the box path is unchanged when `sha` is absent).
- `POST /apps/:id/restore { sha }` → `boxRestoreTreeFrom` + `commitWorktree`.
- Spec + client types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
