### PR TITLE
fix(apps): fan the binding scheduler out — one event per due binding, bounded worker

### DIFF
--- a/api/src/inngest/functions/apps-binding-refresh.ts
+++ b/api/src/inngest/functions/apps-binding-refresh.ts
@@ -2,23 +2,67 @@
  * Scheduled refresh for Apps data bindings (Block 4 of the bindings plan).
  *
  * Schedules live IN the binding files ("-- schedule: <cron>" front matter on
- * main) — no Mongo copy of the definition. Every 15 minutes this scans v2
- * projects, reads their bindings from git (main), and materializes the due
- * ones. Scale note: fine while project counts are small; the recorded
- * scale-up is a derived schedule index maintained on merge-to-main so the
- * scan does not touch git at all.
+ * main) — no Mongo copy of the definition. Every 15 minutes the scheduler
+ * scans projects, reads their bindings from git (main), and emits ONE EVENT
+ * per due binding; the worker below materializes them with bounded
+ * concurrency per workspace.
+ *
+ * It used to materialize inline, sequentially, inside the cron function. With
+ * ~170 bindings due at once (the first sweep after a migration) and ~28 of
+ * them on a 15-minute schedule, every tick re-ran those 28 first, spent the
+ * whole tick on them, and never reached the tail: bindings late in project
+ * order were never built while the log showed steady "materialized" lines.
+ * A tick now finishes in seconds; the backlog drains in parallel; a slow or
+ * broken binding delays nothing but itself.
+ *
+ * Scale note: fine while project counts are small; the recorded scale-up is
+ * a derived schedule index maintained on merge-to-main so the scan does not
+ * touch git at all.
  */
 import { inngest } from "../client";
 import { loggers } from "../../logging";
-import { AppProject } from "../../database/workspace-schema";
+import { AppProject, type IAppProject } from "../../database/workspace-schema";
 import {
   getBindingState,
   materializeAppBinding,
   readBindings,
+  type AppBinding,
 } from "../../apps/bindings.service";
 import { isDashboardMaterializationDue } from "../../services/dashboard-materialization-schedule.service";
 
 const log = loggers.inngest();
+
+export const APPS_BINDING_MATERIALIZE_EVENT = "apps/binding.materialize";
+
+interface MaterializeEventData {
+  workspaceId: string;
+  projectId: string;
+  binding: string;
+  /** `${projectId}:${binding}` — the concurrency key (one build per binding). */
+  key: string;
+}
+
+/**
+ * Due = the binding's cron has a run after its last ATTEMPT (not its last
+ * success): a binding whose query is broken would otherwise be due on every
+ * tick and re-run its failing warehouse query every 15 minutes forever.
+ */
+async function isBindingDue(
+  projectId: string,
+  binding: AppBinding,
+): Promise<boolean> {
+  if (!binding.schedule) return false;
+  const state = await getBindingState(projectId, binding.name);
+  const lastAttempt = state?.history?.at(-1)?.at ?? null;
+  return isDashboardMaterializationDue({
+    schedule: {
+      enabled: true,
+      cron: binding.schedule,
+      timezone: binding.timezone,
+    },
+    lastRefreshedAt: lastAttempt ?? state?.lastMaterializedAt ?? null,
+  });
+}
 
 export const appsBindingSchedulerFunction = inngest.createFunction(
   {
@@ -32,81 +76,107 @@ export const appsBindingSchedulerFunction = inngest.createFunction(
     // `apps/<mongoId>/…` — a folder that does not exist — so every project
     // silently read ZERO bindings and this scheduler triggered nothing in
     // production for weeks while reporting success.
-    const projects = await step.run("list-projects", async () =>
+    const projects = (await step.run("list-projects", async () =>
       AppProject.find({}).select("_id workspaceId defaultBranch slug").lean(),
-    );
-    let triggered = 0;
-    for (const project of projects as Array<{
-      _id: { toString(): string };
-    }>) {
-      const projectId = project._id.toString();
-      let bindings;
-      try {
-        // undefined actor = the user-less view -> the app's main branch.
-        bindings = await readBindings(project as never, undefined as never);
-      } catch (error) {
-        log.warn("Skipping project with unreadable bindings", {
-          projectId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        continue;
-      }
-      for (const binding of bindings) {
-        if (!binding.schedule) continue;
-        let due = false;
+    )) as Array<
+      Pick<IAppProject, "_id" | "workspaceId" | "defaultBranch" | "slug">
+    >;
+
+    const due = await step.run("find-due-bindings", async () => {
+      const out: MaterializeEventData[] = [];
+      for (const project of projects) {
+        const projectId = project._id.toString();
+        let bindings: AppBinding[];
         try {
-          const state = await getBindingState(projectId, binding.name);
-          // The last ATTEMPT, not the last success: a binding whose query is
-          // broken would otherwise be due on every tick and re-run its
-          // failing warehouse query every 15 minutes forever.
-          const lastAttempt = state?.history?.at(-1)?.at ?? null;
-          due = isDashboardMaterializationDue({
-            schedule: {
-              enabled: true,
-              cron: binding.schedule,
-              timezone: binding.timezone,
-            },
-            lastRefreshedAt: lastAttempt ?? state?.lastMaterializedAt ?? null,
-          });
+          // undefined actor = the user-less view -> the app's main branch.
+          bindings = await readBindings(
+            project as IAppProject,
+            undefined as never,
+          );
         } catch (error) {
-          log.warn("Invalid binding schedule", {
+          log.warn("Skipping project with unreadable bindings", {
             projectId,
-            binding: binding.name,
             error: error instanceof Error ? error.message : String(error),
           });
           continue;
         }
-        if (!due) continue;
-        // One binding's failure must not abort the run: a thrown step fails
-        // the whole function, every binding after it in the list is skipped,
-        // and the next tick starts over from the top and hits the same one.
-        // materializeAppBinding already records the error in the binding's
-        // state (and the backoff above keys on it); here it only needs to be
-        // logged and stepped over.
-        await step.run(`materialize-${projectId}-${binding.name}`, async () => {
+        for (const binding of bindings) {
+          if (!binding.schedule) continue;
           try {
-            await materializeAppBinding(
-              project as never,
-              binding.name,
-              "scheduler",
-            );
-            return { ok: true };
+            if (!(await isBindingDue(projectId, binding))) continue;
           } catch (error) {
-            log.warn("Scheduled binding materialization failed", {
+            log.warn("Invalid binding schedule", {
               projectId,
               binding: binding.name,
               error: error instanceof Error ? error.message : String(error),
             });
-            return { ok: false };
+            continue;
           }
-        });
-        triggered++;
+          out.push({
+            workspaceId: project.workspaceId.toString(),
+            projectId,
+            binding: binding.name,
+            key: `${projectId}:${binding.name}`,
+          });
+        }
       }
+      return out;
+    });
+
+    if (due.length > 0) {
+      await step.sendEvent(
+        "materialize",
+        due.map(data => ({ name: APPS_BINDING_MATERIALIZE_EVENT, data })),
+      );
     }
     log.info("Apps binding scheduler run", {
-      projects: (projects as unknown[]).length,
-      triggered,
+      projects: projects.length,
+      triggered: due.length,
     });
-    return { projects: (projects as unknown[]).length, triggered };
+    return { projects: projects.length, triggered: due.length };
+  },
+);
+
+export const appsBindingMaterializeFunction = inngest.createFunction(
+  {
+    id: "apps-binding-materialize",
+    name: "Materialize Apps Data Binding",
+    concurrency: [
+      // A workspace's warehouse sees at most this many builds at once.
+      { scope: "fn", key: "event.data.workspaceId", limit: 4 },
+      // Never two builds of the same binding at once.
+      { scope: "fn", key: "event.data.key", limit: 1 },
+    ],
+    // materializeAppBinding records the failure in the binding's state and
+    // the next due check backs off from it; retrying here would re-run a
+    // broken warehouse query for nothing.
+    retries: 0,
+  },
+  { event: APPS_BINDING_MATERIALIZE_EVENT },
+  async ({ event, step }) => {
+    const { projectId, binding: name } = event.data as MaterializeEventData;
+    return step.run("materialize", async () => {
+      const project = await AppProject.findById(projectId);
+      if (!project) return { skipped: "project-gone" as const };
+      const bindings = await readBindings(project, undefined as never);
+      const binding = bindings.find(b => b.name === name);
+      if (!binding) return { skipped: "binding-gone" as const };
+      // A later tick may have queued this binding again while the backlog
+      // was still draining; if a build landed in between, this one is moot.
+      if (!(await isBindingDue(projectId, binding))) {
+        return { skipped: "not-due" as const };
+      }
+      try {
+        const result = await materializeAppBinding(project, name, "scheduler");
+        return { ok: true as const, rowCount: result.rowCount };
+      } catch (error) {
+        log.warn("Scheduled binding materialization failed", {
+          projectId,
+          binding: name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { ok: false as const };
+      }
+    });
   },
 );

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -21,7 +21,10 @@ import {
   appBindingMaterializeFunction,
   appBindingSchedulerFunction,
 } from "./functions/app-binding-materialize";
-import { appsBindingSchedulerFunction } from "./functions/apps-binding-refresh";
+import {
+  appsBindingMaterializeFunction,
+  appsBindingSchedulerFunction,
+} from "./functions/apps-binding-refresh";
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
 import { cdcRepartitionFunction } from "./functions/cdc-repartition";
 import { usageReportingFunction } from "./functions/usage-reporting";
@@ -52,6 +55,7 @@ const baseFunctions = [
   dashboardRefreshFunction,
   cleanupAbandonedMaterializationRunsFunction,
   appBindingMaterializeFunction,
+  appsBindingMaterializeFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
@@ -144,6 +148,7 @@ export {
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
   appBindingMaterializeFunction,
+  appsBindingMaterializeFunction,
   appBindingSchedulerFunction,
   appsBindingSchedulerFunction,
   usageReportingFunction,


### PR DESCRIPTION
## Why

After #833 the scheduler *worked* but never finished a sweep: it materialized due bindings inline and sequentially inside the cron function. With ~170 due at once and ~28 on `*/15`, each tick re-ran those 28 first (one warehouse query each), spent the whole tick on them, and never reached the tail — 10 bindings in the last four apps were never built, and no tick ever logged its run summary.

## What

- Scheduler: `list-projects` → `find-due-bindings` → `step.sendEvent` with one `apps/binding.materialize` event per due binding. A tick completes in seconds.
- New `apps-binding-materialize` worker: concurrency 4 per workspace and 1 per binding key; re-checks "due" on arrival (queued duplicates are free); `retries: 0` — failures are recorded in binding state (already the case) and logged, and the next due check backs off from the last attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
