### PR TITLE
perf(apps): instant explorer — shell-owned skeleton, persisted list cache, one git call per list

### DIFF
--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -2055,22 +2055,56 @@ export interface AppFolder {
  * clone: who may see the app, what sha is deployed, and a share token with its
  * password hash. Those are server state ABOUT an app, not the app.
  */
+/**
+ * The folder list, memoized per (workspace, main commit). A list is a pure
+ * function of the tree at `main`, so the cache key is the commit: one cheap
+ * `rev-parse` per request, and the git work below runs once per push per
+ * API instance instead of once per sidebar open. Bounded: one entry per
+ * workspace, replaced when main moves.
+ */
+const appFoldersCache = new Map<
+  string,
+  { sha: string; folders: AppFolder[] }
+>();
+
 export async function listAppFolders(
   workspaceId: string,
 ): Promise<AppFolder[]> {
   const repoDir = await repoForWorkspace(workspaceId);
-  const entries = await listTree(repoDir, DEFAULT_BRANCH).catch(() => []);
-  const manifests = entries.filter(e =>
-    /^apps\/[^/]+\/mako\.json$/.test(e.path),
-  );
+  const sha = await resolveCommit(repoDir, DEFAULT_BRANCH);
+  if (!sha) return [];
+  const cached = appFoldersCache.get(workspaceId);
+  if (cached && cached.sha === sha) return cached.folders;
 
-  const folders: AppFolder[] = [];
-  for (const entry of manifests) {
-    const slug = entry.path.split("/")[1];
+  // Only the first level under apps/ — NOT `ls-tree -r` over the whole
+  // monorepo, which listed every file of every app (lockfiles included) to
+  // find 58 manifests.
+  let slugs: string[] = [];
+  try {
+    const { stdout } = await runGit([
+      "-C",
+      repoDir,
+      "ls-tree",
+      "-z",
+      "--name-only",
+      `${DEFAULT_BRANCH}:apps`,
+    ]);
+    slugs = stdout.split("\0").filter(Boolean);
+  } catch {
+    // No apps/ directory yet: an empty workspace, not an error.
+  }
+
+  const readFolder = async (slug: string): Promise<AppFolder | null> => {
+    let blob;
+    try {
+      blob = await readBlob(repoDir, DEFAULT_BRANCH, `apps/${slug}/mako.json`);
+    } catch {
+      // Not an app folder (no manifest) — e.g. a stray file under apps/.
+      return null;
+    }
     let title = slug;
     let description: string | undefined;
     try {
-      const blob = await readBlob(repoDir, DEFAULT_BRANCH, entry.path);
       const manifest = JSON.parse(blob.contents) as {
         title?: unknown;
         description?: unknown;
@@ -2082,13 +2116,23 @@ export async function listAppFolders(
         description = manifest.description;
       }
     } catch {
-      // An unreadable or malformed manifest must not hide the app: the folder
-      // is the app, and a broken mako.json is something the user needs to SEE
-      // in order to fix.
+      // A malformed manifest must not hide the app: the folder is the app,
+      // and a broken mako.json is something the user needs to SEE to fix.
     }
-    folders.push({ slug, title, description });
+    return { slug, title, description };
+  };
+
+  // Manifests are read in parallel, a few at a time — one git process each,
+  // so a bounded fan-out rather than 58 subprocesses at once.
+  const folders: AppFolder[] = [];
+  const CHUNK = 8;
+  for (let i = 0; i < slugs.length; i += CHUNK) {
+    const part = await Promise.all(slugs.slice(i, i + CHUNK).map(readFolder));
+    for (const f of part) if (f) folders.push(f);
   }
-  return folders.sort((a, b) => a.slug.localeCompare(b.slug));
+  folders.sort((a, b) => a.slug.localeCompare(b.slug));
+  appFoldersCache.set(workspaceId, { sha, folders });
+  return folders;
 }
 
 /**

--- a/app/src/components/ExplorerShell.tsx
+++ b/app/src/components/ExplorerShell.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   IconButton,
   InputBase,
+  Skeleton,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -44,6 +45,40 @@ export interface ExplorerShellProps {
    * like "show 'no matches' hint".
    */
   children: (ctx: { searchQuery: string; rawSearchQuery: string }) => ReactNode;
+}
+
+/**
+ * The loading state every explorer gets for free: a few tree rows (chevron,
+ * icon, label) at the tree's own indentation. Explorers used to opt in with
+ * their own `skeleton` — three did, each differently, and the rest showed an
+ * empty rail until the list arrived. The shell owns it now; `skeleton` is
+ * still accepted for an explorer with a genuinely different shape.
+ */
+export function ExplorerSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <Box sx={{ px: 1.5, py: 1 }} aria-busy>
+      {Array.from({ length: rows }, (_, i) => (
+        <Box
+          key={i}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            height: 28,
+            pl: i % 3 === 0 ? 0 : 2,
+          }}
+        >
+          <Skeleton variant="rounded" width={12} height={12} />
+          <Skeleton variant="rounded" width={16} height={16} />
+          <Skeleton
+            variant="text"
+            width={`${45 + ((i * 37) % 40)}%`}
+            sx={{ fontSize: "0.875rem" }}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
 }
 
 export default function ExplorerShell({
@@ -195,8 +230,8 @@ export default function ExplorerShell({
           the content, so a selected row's highlight reaches the container's
           true edge instead of stopping at a scrollbar gutter. */}
       <VSScrollArea style={{ flex: 1, minHeight: 0 }}>
-        {loading && skeleton
-          ? skeleton
+        {loading
+          ? (skeleton ?? <ExplorerSkeleton />)
           : children({ searchQuery: debouncedQuery, rawSearchQuery: rawQuery })}
       </VSScrollArea>
     </Box>

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -12,6 +12,7 @@
  */
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+import { persist } from "zustand/middleware";
 import { api, unwrapBody, ApiError } from "../api";
 import { apiClient } from "../lib/api-client";
 import { reconcileAppsTabs } from "../apps-runtime/shell";
@@ -192,6 +193,13 @@ interface AppsStore {
   /** Connected workspace repos (0..N; the product default is one). */
   repos: AppRepoBinding[];
   apps: AppMeta[];
+  /**
+   * The last list per workspace, persisted (localStorage) so the sidebar
+   * renders instantly on the next visit and refreshes in the background —
+   * the same trick the database catalog uses. Only ever seeded INTO `apps`;
+   * everything else reads `apps`.
+   */
+  appsCacheByWorkspace: Record<string, AppMeta[]>;
   appsLoading: boolean;
   error: string | null;
 
@@ -482,1357 +490,1398 @@ function message(e: unknown, fallback: string): string {
 }
 
 export const useAppsStore = create<AppsStore>()(
-  immer((set, get) => ({
-    enabled: undefined,
-    canCreate: undefined,
-    repos: [],
-    apps: [],
-    appsLoading: false,
-    error: null,
-    filesByApp: {},
-    filesTruncatedByApp: {},
-    fileContents: {},
-    selectedFile: {},
-    statusByApp: {},
-    editingByApp: {},
-    viewUrlByApp: {},
-    historyByApp: {},
-    commitFilesByApp: {},
-    repoHistoryByApp: {},
-    runningDevApps: [],
-    boxStatus: undefined,
-    boxSandboxId: null,
-    boxTerminals: [],
-    currentUserId: null,
-    branchesByApp: {},
-    terminalByApp: {},
-    execRunning: {},
-    previewByApp: {},
-    viewMode: {},
+  persist(
+    immer((set, get) => ({
+      enabled: undefined,
+      canCreate: undefined,
+      repos: [],
+      apps: [],
+      appsCacheByWorkspace: {},
+      appsLoading: false,
+      error: null,
+      filesByApp: {},
+      filesTruncatedByApp: {},
+      fileContents: {},
+      selectedFile: {},
+      statusByApp: {},
+      editingByApp: {},
+      viewUrlByApp: {},
+      historyByApp: {},
+      commitFilesByApp: {},
+      repoHistoryByApp: {},
+      runningDevApps: [],
+      boxStatus: undefined,
+      boxSandboxId: null,
+      boxTerminals: [],
+      currentUserId: null,
+      branchesByApp: {},
+      terminalByApp: {},
+      execRunning: {},
+      previewByApp: {},
+      viewMode: {},
 
-    probeEnabled: async workspaceId => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/status-probe", {
-            params: { path: { workspaceId } },
-          }),
-        ) as {
-          enabled?: boolean;
-          canCreate?: boolean;
-          repos?: AppRepoBinding[];
-        };
-        set(s => {
-          s.enabled = Boolean(body?.enabled);
-          s.canCreate = Boolean(body?.canCreate);
-          s.repos = body?.repos ?? [];
-        });
-      } catch {
-        // Older backend without the route (or transient failure): hide.
-        set(s => {
-          s.enabled = false;
-        });
-      }
-    },
-
-    fetchGithubStatus: async workspaceId => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/github-status", {
-            params: { path: { workspaceId } },
-          }),
-        ) as {
-          installations?: AppGithubInstallation[];
-          appSlug?: string | null;
-          repos?: AppRepoBinding[];
-        };
-        set(s => {
-          s.repos = body.repos ?? [];
-          s.canCreate = s.canCreate || (body.repos ?? []).length > 0;
-        });
-        return {
-          installations: body.installations ?? [],
-          appSlug: body.appSlug ?? null,
-        };
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to load GitHub status");
-        });
-        return { installations: [], appSlug: null };
-      }
-    },
-
-    getGitHubInstallUrl: async workspaceId => {
-      try {
-        const response = await apiClient.get<{ success: boolean; url: string }>(
-          `/workspaces/${workspaceId}/dbt/github/install-url`,
-        );
-        return response.url ?? null;
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to start GitHub App install");
-        });
-        return null;
-      }
-    },
-
-    fetchGithubBranches: async (workspaceId, owner, repo, installationId) => {
-      try {
-        const params = new URLSearchParams({ owner, repo });
-        if (installationId) {
-          params.set("installationId", String(installationId));
-        }
-        // TODO(workspace-repos): reuses dbt's raw branches route until repos
-        // get their own workspace-level GitHub surface.
-        const response = await apiClient.get<{
-          success: boolean;
-          branches: string[];
-        }>(`/workspaces/${workspaceId}/dbt/github/branches?${params}`);
-        return response.branches ?? [];
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to list branches");
-        });
-        return [];
-      }
-    },
-
-    getGitHubSyncUrl: async workspaceId => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/github-sync-url", {
-            params: { path: { workspaceId } },
-          }),
-        ) as { url?: string };
-        return body.url ?? null;
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to start GitHub sync");
-        });
-        return null;
-      }
-    },
-
-    fetchGithubRepos: async (workspaceId, installationId) => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/github-repos", {
-            params: {
-              path: { workspaceId },
-              query: { installationId },
-            },
-          }),
-        ) as { repos?: AppGithubRepo[] };
-        return body.repos ?? [];
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to list repositories");
-        });
-        return [];
-      }
-    },
-
-    connectRepo: async (workspaceId, input) => {
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/link", {
-            params: { path: { workspaceId } },
-            body: input,
-          }),
-        ) as {
-          repo?: AppRepoBinding;
-          adoption?: "imported" | "seeded" | "fresh" | "deferred";
-        };
-        set(s => {
-          s.canCreate = true;
-          if (body.repo) {
-            s.repos = [
-              ...s.repos.filter(
-                r =>
-                  !(r.owner === body.repo?.owner && r.repo === body.repo.repo),
-              ),
-              body.repo,
-            ];
-          }
-        });
-        // An import can make apps appear instantly; refetch either way.
-        void get().fetchApps(workspaceId);
-        return { ok: true, adoption: body.adoption };
-      } catch (e) {
-        return { ok: false, error: message(e, "Failed to connect repo") };
-      }
-    },
-
-    disconnectRepo: async (workspaceId, owner, repo) => {
-      try {
-        unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/unlink", {
-            params: { path: { workspaceId } },
-            body: { owner, repo },
-          }),
-        );
-        set(s => {
-          s.repos = s.repos.filter(
-            r => !(r.owner === owner && r.repo === repo),
-          );
-        });
-        // canCreate may still be true via cloud storage — let the probe say.
-        void get().probeEnabled(workspaceId);
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to disconnect repo");
-        });
-      }
-    },
-
-    disconnectGithubInstallation: async (workspaceId, installationId) => {
-      try {
-        unwrapBody(
-          await api.DELETE(
-            "/api/workspaces/{workspaceId}/apps/github-installations/{installationId}",
-            { params: { path: { workspaceId, installationId } } },
-          ),
-        );
-        return { ok: true as const };
-      } catch (e) {
-        return {
-          ok: false as const,
-          error: message(e, "Failed to disconnect installation"),
-        };
-      }
-    },
-
-    fetchApps: async workspaceId => {
-      set(s => {
-        s.appsLoading = true;
-        s.error = null;
-      });
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps", {
-            params: { path: { workspaceId } },
-          }),
-        ) as { apps?: AppMeta[] };
-        const apps = body.apps ?? [];
-        set(s => {
-          s.apps = apps;
-          s.appsLoading = false;
-        });
-        // Drop tabs pointing at apps this workspace does not have, so a
-        // deleted app cannot leave a working-looking workspace view behind.
-        reconcileAppsTabs(new Set(apps.map(a => a.id)));
-      } catch (e) {
-        set(s => {
-          s.appsLoading = false;
-          // A 404 here means the flag is off — not an error worth surfacing.
-          if (!(e instanceof ApiError && e.status === 404)) {
-            s.error = message(e, "Failed to load apps");
-          }
-        });
-      }
-    },
-
-    setAppAccess: async (workspaceId, appId, access) => {
-      // Optimistic: the row moves sections immediately; server truth on error.
-      set(s => {
-        const app = s.apps.find(a => a.id === appId);
-        if (app) app.access = access;
-      });
-      try {
-        unwrapBody(
-          await api.PATCH("/api/workspaces/{workspaceId}/apps/{id}/access", {
-            params: { path: { workspaceId, id: appId } },
-            body: { access },
-          }),
-        );
-      } catch {
-        void get().fetchApps(workspaceId);
-      }
-    },
-
-    createApp: async (workspaceId, title, description) => {
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps", {
-            params: { path: { workspaceId } },
-            body: { title, description },
-          }),
-        ) as { app?: AppMeta };
-        if (body.app) {
+      probeEnabled: async workspaceId => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/status-probe", {
+              params: { path: { workspaceId } },
+            }),
+          ) as {
+            enabled?: boolean;
+            canCreate?: boolean;
+            repos?: AppRepoBinding[];
+          };
           set(s => {
-            s.apps.unshift(body.app as AppMeta);
+            s.enabled = Boolean(body?.enabled);
+            s.canCreate = Boolean(body?.canCreate);
+            s.repos = body?.repos ?? [];
           });
-          return body.app;
+        } catch {
+          // Older backend without the route (or transient failure): hide.
+          set(s => {
+            s.enabled = false;
+          });
         }
-        return null;
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to create app");
-        });
-        return null;
-      }
-    },
+      },
 
-    deleteApp: async (workspaceId, appId) => {
-      try {
-        unwrapBody(
-          await api.DELETE("/api/workspaces/{workspaceId}/apps/{id}", {
-            params: { path: { workspaceId, id: appId } },
-          }),
-        );
-        set(s => {
-          s.apps = s.apps.filter(a => a.id !== appId);
-          delete s.filesByApp[appId];
-          delete s.statusByApp[appId];
-          delete s.historyByApp[appId];
-          delete s.repoHistoryByApp[appId];
-          delete s.terminalByApp[appId];
-          delete s.previewByApp[appId];
-        });
-        return true;
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to delete app");
-        });
-        return false;
-      }
-    },
-
-    // Browsing leaves it out and never touches a sandbox — that is what keeps
-    // opening an app cheap, and working while its sandbox is asleep.
-    fetchFiles: async (workspaceId, appId) => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/files", {
-            params: {
-              path: { workspaceId, id: appId },
-            },
-          }),
-        ) as {
-          files?: AppFileEntry[];
-          truncated?: boolean;
-          total?: number;
-        };
-        set(s => {
-          s.filesByApp[appId] = body.files ?? [];
-          if (body.truncated) {
-            s.filesTruncatedByApp[appId] = {
-              shown: body.files?.length ?? 0,
-              total: body.total,
-            };
-          } else {
-            delete s.filesTruncatedByApp[appId];
-          }
-        });
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to list files");
-        });
-      }
-    },
-
-    openFile: async (workspaceId, appId, path) => {
-      set(s => {
-        s.selectedFile[appId] = path;
-      });
-      const key = fileKey(appId, path);
-      const cached = get().fileContents[key];
-      if (cached?.dirty) return; // Never clobber unsaved local edits.
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/file", {
-            params: { path: { workspaceId, id: appId }, query: { path } },
-          }),
-        ) as { file?: { contents: string; isBinary: boolean } };
-        set(s => {
-          s.fileContents[key] = {
-            contents: body.file?.isBinary
-              ? "(binary file)"
-              : (body.file?.contents ?? ""),
-            dirty: false,
+      fetchGithubStatus: async workspaceId => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/github-status", {
+              params: { path: { workspaceId } },
+            }),
+          ) as {
+            installations?: AppGithubInstallation[];
+            appSlug?: string | null;
+            repos?: AppRepoBinding[];
           };
-        });
-      } catch (e) {
-        set(s => {
-          s.error = message(e, `Failed to read ${path}`);
-        });
-      }
-    },
-
-    updateFileLocal: (appId, path, contents) => {
-      set(s => {
-        s.fileContents[fileKey(appId, path)] = { contents, dirty: true };
-      });
-    },
-
-    saveFile: async (workspaceId, appId, path) => {
-      const entry = get().fileContents[fileKey(appId, path)];
-      if (!entry?.dirty) return;
-      try {
-        unwrapBody(
-          await api.PUT("/api/workspaces/{workspaceId}/apps/{id}/file", {
-            params: { path: { workspaceId, id: appId } },
-            body: { path, contents: entry.contents },
-          }),
-        );
-        set(s => {
-          const cur = s.fileContents[fileKey(appId, path)];
-          // Only clear dirty if no further local edits raced the save.
-          if (cur && cur.contents === entry.contents) cur.dirty = false;
-        });
-        void get().fetchStatus(workspaceId, appId);
-        void get().fetchFiles(workspaceId, appId);
-      } catch (e) {
-        set(s => {
-          s.error = message(e, `Failed to save ${path}`);
-        });
-      }
-    },
-
-    runCommand: async (workspaceId, appId, command) => {
-      const entryId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      set(s => {
-        s.execRunning[appId] = true;
-        (s.terminalByApp[appId] ??= []).push({
-          id: entryId,
-          command,
-          stdout: "",
-          stderr: "",
-          exitCode: null,
-          running: true,
-          at: Date.now(),
-        });
-      });
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/exec", {
-            params: { path: { workspaceId, id: appId } },
-            body: { command },
-          }),
-        ) as {
-          result?: {
-            exitCode: number;
-            stdout: string;
-            stderr: string;
-            timedOut: boolean;
-            durationMs: number;
+          set(s => {
+            s.repos = body.repos ?? [];
+            s.canCreate = s.canCreate || (body.repos ?? []).length > 0;
+          });
+          return {
+            installations: body.installations ?? [],
+            appSlug: body.appSlug ?? null,
           };
-        };
-        set(s => {
-          const entry = (s.terminalByApp[appId] ?? []).find(
-            t => t.id === entryId,
-          );
-          if (entry && body.result) {
-            entry.stdout = body.result.stdout;
-            entry.stderr = body.result.stderr;
-            entry.exitCode = body.result.exitCode;
-            entry.timedOut = body.result.timedOut;
-            entry.durationMs = body.result.durationMs;
-            entry.running = false;
-          }
-          s.execRunning[appId] = false;
-        });
-        // A shell command can change anything: refresh the read model.
-        void get().fetchFiles(workspaceId, appId);
-        void get().fetchStatus(workspaceId, appId);
-        const selected = get().selectedFile[appId];
-        if (selected) {
-          const key = fileKey(appId, selected);
-          const cur = get().fileContents[key];
-          if (cur && !cur.dirty) {
-            void get().openFile(workspaceId, appId, selected);
-          }
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to load GitHub status");
+          });
+          return { installations: [], appSlug: null };
         }
-      } catch (e) {
-        set(s => {
-          const entry = (s.terminalByApp[appId] ?? []).find(
-            t => t.id === entryId,
-          );
-          if (entry) {
-            entry.stderr = message(e, "Command failed");
-            entry.exitCode = -1;
-            entry.running = false;
+      },
+
+      getGitHubInstallUrl: async workspaceId => {
+        try {
+          const response = await apiClient.get<{
+            success: boolean;
+            url: string;
+          }>(`/workspaces/${workspaceId}/dbt/github/install-url`);
+          return response.url ?? null;
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to start GitHub App install");
+          });
+          return null;
+        }
+      },
+
+      fetchGithubBranches: async (workspaceId, owner, repo, installationId) => {
+        try {
+          const params = new URLSearchParams({ owner, repo });
+          if (installationId) {
+            params.set("installationId", String(installationId));
           }
-          s.execRunning[appId] = false;
-        });
-      }
-    },
+          // TODO(workspace-repos): reuses dbt's raw branches route until repos
+          // get their own workspace-level GitHub surface.
+          const response = await apiClient.get<{
+            success: boolean;
+            branches: string[];
+          }>(`/workspaces/${workspaceId}/dbt/github/branches?${params}`);
+          return response.branches ?? [];
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to list branches");
+          });
+          return [];
+        }
+      },
 
-    clearTerminal: appId => {
-      set(s => {
-        s.terminalByApp[appId] = [];
-      });
-    },
+      getGitHubSyncUrl: async workspaceId => {
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/github-sync-url",
+              {
+                params: { path: { workspaceId } },
+              },
+            ),
+          ) as { url?: string };
+          return body.url ?? null;
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to start GitHub sync");
+          });
+          return null;
+        }
+      },
 
-    fetchStatus: async (workspaceId, appId) => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/status", {
-            params: {
-              path: { workspaceId, id: appId },
-            },
-          }),
-        ) as { status?: AppStatus | null };
+      fetchGithubRepos: async (workspaceId, installationId) => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/github-repos", {
+              params: {
+                path: { workspaceId },
+                query: { installationId },
+              },
+            }),
+          ) as { repos?: AppGithubRepo[] };
+          return body.repos ?? [];
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to list repositories");
+          });
+          return [];
+        }
+      },
+
+      connectRepo: async (workspaceId, input) => {
+        try {
+          const body = unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/link", {
+              params: { path: { workspaceId } },
+              body: input,
+            }),
+          ) as {
+            repo?: AppRepoBinding;
+            adoption?: "imported" | "seeded" | "fresh" | "deferred";
+          };
+          set(s => {
+            s.canCreate = true;
+            if (body.repo) {
+              s.repos = [
+                ...s.repos.filter(
+                  r =>
+                    !(
+                      r.owner === body.repo?.owner && r.repo === body.repo.repo
+                    ),
+                ),
+                body.repo,
+              ];
+            }
+          });
+          // An import can make apps appear instantly; refetch either way.
+          void get().fetchApps(workspaceId);
+          return { ok: true, adoption: body.adoption };
+        } catch (e) {
+          return { ok: false, error: message(e, "Failed to connect repo") };
+        }
+      },
+
+      disconnectRepo: async (workspaceId, owner, repo) => {
+        try {
+          unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/unlink", {
+              params: { path: { workspaceId } },
+              body: { owner, repo },
+            }),
+          );
+          set(s => {
+            s.repos = s.repos.filter(
+              r => !(r.owner === owner && r.repo === repo),
+            );
+          });
+          // canCreate may still be true via cloud storage — let the probe say.
+          void get().probeEnabled(workspaceId);
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to disconnect repo");
+          });
+        }
+      },
+
+      disconnectGithubInstallation: async (workspaceId, installationId) => {
+        try {
+          unwrapBody(
+            await api.DELETE(
+              "/api/workspaces/{workspaceId}/apps/github-installations/{installationId}",
+              { params: { path: { workspaceId, installationId } } },
+            ),
+          );
+          return { ok: true as const };
+        } catch (e) {
+          return {
+            ok: false as const,
+            error: message(e, "Failed to disconnect installation"),
+          };
+        }
+      },
+
+      fetchApps: async workspaceId => {
         set(s => {
-          s.statusByApp[appId] = body.status ?? null;
+          // Instant paint from the persisted list while the request runs; a
+          // cache miss (first visit) shows the skeleton instead.
+          const cached = s.appsCacheByWorkspace[workspaceId];
+          if (cached && s.apps.length === 0) s.apps = cached;
+          s.appsLoading = true;
+          s.error = null;
         });
-      } catch {
-        // Status is advisory; stale data is acceptable.
-      }
-    },
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps", {
+              params: { path: { workspaceId } },
+            }),
+          ) as { apps?: AppMeta[] };
+          const apps = body.apps ?? [];
+          set(s => {
+            s.apps = apps;
+            s.appsCacheByWorkspace[workspaceId] = apps;
+            s.appsLoading = false;
+          });
+          // Drop tabs pointing at apps this workspace does not have, so a
+          // deleted app cannot leave a working-looking workspace view behind.
+          reconcileAppsTabs(new Set(apps.map(a => a.id)));
+        } catch (e) {
+          set(s => {
+            s.appsLoading = false;
+            // A 404 here means the flag is off — not an error worth surfacing.
+            if (!(e instanceof ApiError && e.status === 404)) {
+              s.error = message(e, "Failed to load apps");
+            }
+          });
+        }
+      },
 
-    fetchHistory: async (workspaceId, appId, scope = "app") => {
-      try {
-        // Show the branch the user's box is actually on (VS Code's graph
-        // follows HEAD); the server falls back to the default branch when
-        // the ref is unknown, so a stale value degrades gracefully. The
-        // Source Control panel asks for repo scope — its CHANGES list is
-        // repo-wide, and a graph that hides your own cross-app commit is
-        // worse than useless.
-        const ref = get().statusByApp[appId]?.branch;
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/history", {
-            params: {
-              path: { workspaceId, id: appId },
-              query: { ...(ref ? { ref } : {}), scope },
-            },
-          }),
-        ) as { commits?: AppCommit[] };
+      setAppAccess: async (workspaceId, appId, access) => {
+        // Optimistic: the row moves sections immediately; server truth on error.
         set(s => {
-          if (scope === "repo") s.repoHistoryByApp[appId] = body.commits ?? [];
-          else s.historyByApp[appId] = body.commits ?? [];
+          const app = s.apps.find(a => a.id === appId);
+          if (app) app.access = access;
         });
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to load history");
-        });
-      }
-    },
+        try {
+          unwrapBody(
+            await api.PATCH("/api/workspaces/{workspaceId}/apps/{id}/access", {
+              params: { path: { workspaceId, id: appId } },
+              body: { access },
+            }),
+          );
+        } catch {
+          void get().fetchApps(workspaceId);
+        }
+      },
 
-    fetchViewUrl: async (workspaceId, appId) => {
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/view-token", {
-            params: { path: { workspaceId, id: appId } },
-          }),
-        ) as { url?: string };
-        set(s => {
-          s.viewUrlByApp[appId] = body.url;
-        });
-      } catch {
-        // Not published, or the token could not be minted. The workspace
-        // shows its "nothing to view yet" state rather than a broken frame.
-        set(s => {
-          s.viewUrlByApp[appId] = undefined;
-        });
-      }
-    },
+      createApp: async (workspaceId, title, description) => {
+        try {
+          const body = unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps", {
+              params: { path: { workspaceId } },
+              body: { title, description },
+            }),
+          ) as { app?: AppMeta };
+          if (body.app) {
+            set(s => {
+              s.apps.unshift(body.app as AppMeta);
+            });
+            return body.app;
+          }
+          return null;
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to create app");
+          });
+          return null;
+        }
+      },
 
-    setEditing: (workspaceId, appId, editing) => {
-      set(s => {
-        s.editingByApp[appId] = editing;
-      });
-      // NOT persisted to localStorage. Whether the workbench opens is derived
-      // from box truth (a running dev server), decided on mount — persisting a
-      // flag here auto-opened the workbench over an empty box and disagreed
-      // with the green dot (apps.md §13.11: the box is the one source of
-      // truth for "is this running").
-      // Entering edit mode starts a sandbox, and the sandbox is what reads
-      // are served from — so re-read once it exists, or the tree stays on the
-      // committed view until something else changes.
-      if (editing) {
-        void get().fetchFiles(workspaceId, appId);
-        void get().fetchStatus(workspaceId, appId);
-      }
-    },
+      deleteApp: async (workspaceId, appId) => {
+        try {
+          unwrapBody(
+            await api.DELETE("/api/workspaces/{workspaceId}/apps/{id}", {
+              params: { path: { workspaceId, id: appId } },
+            }),
+          );
+          set(s => {
+            s.apps = s.apps.filter(a => a.id !== appId);
+            delete s.filesByApp[appId];
+            delete s.statusByApp[appId];
+            delete s.historyByApp[appId];
+            delete s.repoHistoryByApp[appId];
+            delete s.terminalByApp[appId];
+            delete s.previewByApp[appId];
+          });
+          return true;
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to delete app");
+          });
+          return false;
+        }
+      },
 
-    fetchBranches: async (workspaceId, appId) => {
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/branches", {
-            params: { path: { workspaceId, id: appId } },
-          }),
-        ) as { branches?: AppBranch[] };
-        set(s => {
-          s.branchesByApp[appId] = body.branches ?? [];
-        });
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to load branches");
-        });
-      }
-    },
-
-    checkoutBranch: async (workspaceId, appId, branch, options) => {
-      try {
-        unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/checkout", {
-            params: { path: { workspaceId, id: appId } },
-            body: { branch, ...(options?.create ? { create: true } : {}) },
-          }),
-        );
-        // Everything on screen was showing the OLD branch.
-        await Promise.all([
-          get().fetchFiles(workspaceId, appId),
-          get().fetchStatus(workspaceId, appId),
-          get().fetchBranches(workspaceId, appId),
-        ]);
-        return null;
-      } catch (e) {
-        return message(e, `Failed to switch to ${branch}`);
-      }
-    },
-
-    mergeBranch: async (workspaceId, appId, branch) => {
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/merge", {
-            params: { path: { workspaceId, id: appId } },
-            body: { branch },
-          }),
-        ) as { result?: { merged: boolean; reason?: string } };
-        // Merge moves main: refresh everything the UI shows.
-        void get().fetchBranches(workspaceId, appId);
-        void get().fetchFiles(workspaceId, appId);
-        void get().fetchStatus(workspaceId, appId);
-        void get().fetchHistory(workspaceId, appId);
-        const selected = get().selectedFile[appId];
-        if (selected) void get().openFile(workspaceId, appId, selected);
-        if (body.result?.merged) return { ok: true };
-        return {
-          ok: false,
-          error: body.result?.reason ?? "Nothing to merge",
-        };
-      } catch (e) {
-        return { ok: false, error: message(e, "Merge failed") };
-      }
-    },
-
-    commit: async (workspaceId, appId, msg, options) => {
-      try {
-        const body = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/commit", {
-            params: { path: { workspaceId, id: appId } },
-            body: { message: msg, stagedOnly: options?.stagedOnly },
-          }),
-        ) as { result?: { committed: boolean; reason?: string } };
-        void get().fetchStatus(workspaceId, appId);
-        void get().fetchHistory(workspaceId, appId);
-        void get().fetchHistory(workspaceId, appId, "repo");
-        if (body.result?.committed) return { ok: true };
-        return { ok: false, error: body.result?.reason ?? "Nothing to commit" };
-      } catch (e) {
-        return { ok: false, error: message(e, "Commit failed") };
-      }
-    },
-
-    gitPaths: async (workspaceId, appId, action, paths) => {
-      try {
-        await api.POST(
-          `/api/workspaces/{workspaceId}/apps/{id}/git/${action}` as "/api/workspaces/{workspaceId}/apps/{id}/git/stage",
-          { params: { path: { workspaceId, id: appId } }, body: { paths } },
-        );
-        return { ok: true };
-      } catch (e) {
-        return { ok: false, error: message(e, `Could not ${action}`) };
-      }
-    },
-
-    fetchCommitFiles: async (workspaceId, appId, sha) => {
-      const cached = get().commitFilesByApp[appId]?.[sha];
-      if (cached) return cached;
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/git/commit", {
-            params: { path: { workspaceId, id: appId }, query: { sha } },
-          }),
-        ) as { commit?: { files?: AppCommitFile[] } };
-        const files = body.commit?.files ?? [];
-        set(s => {
-          (s.commitFilesByApp[appId] ??= {})[sha] = files;
-        });
-        return files;
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to load the commit");
-        });
-        return null;
-      }
-    },
-
-    fetchCommitFileVersions: async (workspaceId, appId, sha, path) => {
-      try {
-        const body = unwrapBody(
-          await api.GET(
-            "/api/workspaces/{workspaceId}/apps/{id}/git/file-versions",
-            {
+      // Browsing leaves it out and never touches a sandbox — that is what keeps
+      // opening an app cheap, and working while its sandbox is asleep.
+      fetchFiles: async (workspaceId, appId) => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/{id}/files", {
               params: {
                 path: { workspaceId, id: appId },
-                query: { path, sha },
               },
-            },
-          ),
-        ) as { versions?: AppCommitFileVersions };
-        return body.versions ?? null;
-      } catch {
-        return null;
-      }
-    },
-
-    restoreVersion: async (workspaceId, appId, sha) => {
-      unwrapBody(
-        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/restore", {
-          params: { path: { workspaceId, id: appId } },
-          body: { sha },
-        }),
-      );
-      // Same cache hygiene as discard: contents changed under every open tab.
-      set(s => {
-        for (const key of Object.keys(s.fileContents)) {
-          if (key.startsWith(`${appId}\u0000`)) delete s.fileContents[key];
+            }),
+          ) as {
+            files?: AppFileEntry[];
+            truncated?: boolean;
+            total?: number;
+          };
+          set(s => {
+            s.filesByApp[appId] = body.files ?? [];
+            if (body.truncated) {
+              s.filesTruncatedByApp[appId] = {
+                shown: body.files?.length ?? 0,
+                total: body.total,
+              };
+            } else {
+              delete s.filesTruncatedByApp[appId];
+            }
+          });
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to list files");
+          });
         }
-      });
-      void get().fetchFiles(workspaceId, appId);
-      void get().fetchStatus(workspaceId, appId);
-      void get().fetchHistory(workspaceId, appId);
-      const selected = get().selectedFile[appId];
-      if (selected) void get().openFile(workspaceId, appId, selected);
-    },
+      },
 
-    rollbackTo: async (workspaceId, appId, sha) => {
-      unwrapBody(
-        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/rollback", {
-          params: { path: { workspaceId, id: appId } },
-          body: { sha },
-        }),
-      );
-      set(s => {
-        const app = s.apps.find(a => a.id === appId);
-        if (app) {
-          app.publishedSha = sha;
-          app.publishedAt = new Date().toISOString();
+      openFile: async (workspaceId, appId, path) => {
+        set(s => {
+          s.selectedFile[appId] = path;
+        });
+        const key = fileKey(appId, path);
+        const cached = get().fileContents[key];
+        if (cached?.dirty) return; // Never clobber unsaved local edits.
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/{id}/file", {
+              params: { path: { workspaceId, id: appId }, query: { path } },
+            }),
+          ) as { file?: { contents: string; isBinary: boolean } };
+          set(s => {
+            s.fileContents[key] = {
+              contents: body.file?.isBinary
+                ? "(binary file)"
+                : (body.file?.contents ?? ""),
+              dirty: false,
+            };
+          });
+        } catch (e) {
+          set(s => {
+            s.error = message(e, `Failed to read ${path}`);
+          });
         }
-      });
-      void get().fetchViewUrl(workspaceId, appId);
-    },
+      },
 
-    fetchFileVersions: async (workspaceId, appId, path) => {
-      try {
-        const body = unwrapBody(
-          await api.GET(
-            "/api/workspaces/{workspaceId}/apps/{id}/git/file-versions",
-            { params: { path: { workspaceId, id: appId }, query: { path } } },
-          ),
-        ) as { versions?: AppFileVersions };
-        return body.versions ?? null;
-      } catch {
-        return null;
-      }
-    },
+      updateFileLocal: (appId, path, contents) => {
+        set(s => {
+          s.fileContents[fileKey(appId, path)] = { contents, dirty: true };
+        });
+      },
 
-    discard: async (workspaceId, appId) => {
-      try {
+      saveFile: async (workspaceId, appId, path) => {
+        const entry = get().fileContents[fileKey(appId, path)];
+        if (!entry?.dirty) return;
+        try {
+          unwrapBody(
+            await api.PUT("/api/workspaces/{workspaceId}/apps/{id}/file", {
+              params: { path: { workspaceId, id: appId } },
+              body: { path, contents: entry.contents },
+            }),
+          );
+          set(s => {
+            const cur = s.fileContents[fileKey(appId, path)];
+            // Only clear dirty if no further local edits raced the save.
+            if (cur && cur.contents === entry.contents) cur.dirty = false;
+          });
+          void get().fetchStatus(workspaceId, appId);
+          void get().fetchFiles(workspaceId, appId);
+        } catch (e) {
+          set(s => {
+            s.error = message(e, `Failed to save ${path}`);
+          });
+        }
+      },
+
+      runCommand: async (workspaceId, appId, command) => {
+        const entryId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        set(s => {
+          s.execRunning[appId] = true;
+          (s.terminalByApp[appId] ??= []).push({
+            id: entryId,
+            command,
+            stdout: "",
+            stderr: "",
+            exitCode: null,
+            running: true,
+            at: Date.now(),
+          });
+        });
+        try {
+          const body = unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/{id}/exec", {
+              params: { path: { workspaceId, id: appId } },
+              body: { command },
+            }),
+          ) as {
+            result?: {
+              exitCode: number;
+              stdout: string;
+              stderr: string;
+              timedOut: boolean;
+              durationMs: number;
+            };
+          };
+          set(s => {
+            const entry = (s.terminalByApp[appId] ?? []).find(
+              t => t.id === entryId,
+            );
+            if (entry && body.result) {
+              entry.stdout = body.result.stdout;
+              entry.stderr = body.result.stderr;
+              entry.exitCode = body.result.exitCode;
+              entry.timedOut = body.result.timedOut;
+              entry.durationMs = body.result.durationMs;
+              entry.running = false;
+            }
+            s.execRunning[appId] = false;
+          });
+          // A shell command can change anything: refresh the read model.
+          void get().fetchFiles(workspaceId, appId);
+          void get().fetchStatus(workspaceId, appId);
+          const selected = get().selectedFile[appId];
+          if (selected) {
+            const key = fileKey(appId, selected);
+            const cur = get().fileContents[key];
+            if (cur && !cur.dirty) {
+              void get().openFile(workspaceId, appId, selected);
+            }
+          }
+        } catch (e) {
+          set(s => {
+            const entry = (s.terminalByApp[appId] ?? []).find(
+              t => t.id === entryId,
+            );
+            if (entry) {
+              entry.stderr = message(e, "Command failed");
+              entry.exitCode = -1;
+              entry.running = false;
+            }
+            s.execRunning[appId] = false;
+          });
+        }
+      },
+
+      clearTerminal: appId => {
+        set(s => {
+          s.terminalByApp[appId] = [];
+        });
+      },
+
+      fetchStatus: async (workspaceId, appId) => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/{id}/status", {
+              params: {
+                path: { workspaceId, id: appId },
+              },
+            }),
+          ) as { status?: AppStatus | null };
+          set(s => {
+            s.statusByApp[appId] = body.status ?? null;
+          });
+        } catch {
+          // Status is advisory; stale data is acceptable.
+        }
+      },
+
+      fetchHistory: async (workspaceId, appId, scope = "app") => {
+        try {
+          // Show the branch the user's box is actually on (VS Code's graph
+          // follows HEAD); the server falls back to the default branch when
+          // the ref is unknown, so a stale value degrades gracefully. The
+          // Source Control panel asks for repo scope — its CHANGES list is
+          // repo-wide, and a graph that hides your own cross-app commit is
+          // worse than useless.
+          const ref = get().statusByApp[appId]?.branch;
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/{id}/history", {
+              params: {
+                path: { workspaceId, id: appId },
+                query: { ...(ref ? { ref } : {}), scope },
+              },
+            }),
+          ) as { commits?: AppCommit[] };
+          set(s => {
+            if (scope === "repo") {
+              s.repoHistoryByApp[appId] = body.commits ?? [];
+            } else s.historyByApp[appId] = body.commits ?? [];
+          });
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to load history");
+          });
+        }
+      },
+
+      fetchViewUrl: async (workspaceId, appId) => {
+        try {
+          const body = unwrapBody(
+            await api.POST(
+              "/api/workspaces/{workspaceId}/apps/{id}/view-token",
+              {
+                params: { path: { workspaceId, id: appId } },
+              },
+            ),
+          ) as { url?: string };
+          set(s => {
+            s.viewUrlByApp[appId] = body.url;
+          });
+        } catch {
+          // Not published, or the token could not be minted. The workspace
+          // shows its "nothing to view yet" state rather than a broken frame.
+          set(s => {
+            s.viewUrlByApp[appId] = undefined;
+          });
+        }
+      },
+
+      setEditing: (workspaceId, appId, editing) => {
+        set(s => {
+          s.editingByApp[appId] = editing;
+        });
+        // NOT persisted to localStorage. Whether the workbench opens is derived
+        // from box truth (a running dev server), decided on mount — persisting a
+        // flag here auto-opened the workbench over an empty box and disagreed
+        // with the green dot (apps.md §13.11: the box is the one source of
+        // truth for "is this running").
+        // Entering edit mode starts a sandbox, and the sandbox is what reads
+        // are served from — so re-read once it exists, or the tree stays on the
+        // committed view until something else changes.
+        if (editing) {
+          void get().fetchFiles(workspaceId, appId);
+          void get().fetchStatus(workspaceId, appId);
+        }
+      },
+
+      fetchBranches: async (workspaceId, appId) => {
+        try {
+          const body = unwrapBody(
+            await api.GET("/api/workspaces/{workspaceId}/apps/{id}/branches", {
+              params: { path: { workspaceId, id: appId } },
+            }),
+          ) as { branches?: AppBranch[] };
+          set(s => {
+            s.branchesByApp[appId] = body.branches ?? [];
+          });
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to load branches");
+          });
+        }
+      },
+
+      checkoutBranch: async (workspaceId, appId, branch, options) => {
+        try {
+          unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/{id}/checkout", {
+              params: { path: { workspaceId, id: appId } },
+              body: { branch, ...(options?.create ? { create: true } : {}) },
+            }),
+          );
+          // Everything on screen was showing the OLD branch.
+          await Promise.all([
+            get().fetchFiles(workspaceId, appId),
+            get().fetchStatus(workspaceId, appId),
+            get().fetchBranches(workspaceId, appId),
+          ]);
+          return null;
+        } catch (e) {
+          return message(e, `Failed to switch to ${branch}`);
+        }
+      },
+
+      mergeBranch: async (workspaceId, appId, branch) => {
+        try {
+          const body = unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/{id}/merge", {
+              params: { path: { workspaceId, id: appId } },
+              body: { branch },
+            }),
+          ) as { result?: { merged: boolean; reason?: string } };
+          // Merge moves main: refresh everything the UI shows.
+          void get().fetchBranches(workspaceId, appId);
+          void get().fetchFiles(workspaceId, appId);
+          void get().fetchStatus(workspaceId, appId);
+          void get().fetchHistory(workspaceId, appId);
+          const selected = get().selectedFile[appId];
+          if (selected) void get().openFile(workspaceId, appId, selected);
+          if (body.result?.merged) return { ok: true };
+          return {
+            ok: false,
+            error: body.result?.reason ?? "Nothing to merge",
+          };
+        } catch (e) {
+          return { ok: false, error: message(e, "Merge failed") };
+        }
+      },
+
+      commit: async (workspaceId, appId, msg, options) => {
+        try {
+          const body = unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/{id}/commit", {
+              params: { path: { workspaceId, id: appId } },
+              body: { message: msg, stagedOnly: options?.stagedOnly },
+            }),
+          ) as { result?: { committed: boolean; reason?: string } };
+          void get().fetchStatus(workspaceId, appId);
+          void get().fetchHistory(workspaceId, appId);
+          void get().fetchHistory(workspaceId, appId, "repo");
+          if (body.result?.committed) return { ok: true };
+          return {
+            ok: false,
+            error: body.result?.reason ?? "Nothing to commit",
+          };
+        } catch (e) {
+          return { ok: false, error: message(e, "Commit failed") };
+        }
+      },
+
+      gitPaths: async (workspaceId, appId, action, paths) => {
+        try {
+          await api.POST(
+            `/api/workspaces/{workspaceId}/apps/{id}/git/${action}` as "/api/workspaces/{workspaceId}/apps/{id}/git/stage",
+            { params: { path: { workspaceId, id: appId } }, body: { paths } },
+          );
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: message(e, `Could not ${action}`) };
+        }
+      },
+
+      fetchCommitFiles: async (workspaceId, appId, sha) => {
+        const cached = get().commitFilesByApp[appId]?.[sha];
+        if (cached) return cached;
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/git/commit",
+              {
+                params: { path: { workspaceId, id: appId }, query: { sha } },
+              },
+            ),
+          ) as { commit?: { files?: AppCommitFile[] } };
+          const files = body.commit?.files ?? [];
+          set(s => {
+            (s.commitFilesByApp[appId] ??= {})[sha] = files;
+          });
+          return files;
+        } catch (e) {
+          set(s => {
+            s.error = message(e, "Failed to load the commit");
+          });
+          return null;
+        }
+      },
+
+      fetchCommitFileVersions: async (workspaceId, appId, sha, path) => {
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/git/file-versions",
+              {
+                params: {
+                  path: { workspaceId, id: appId },
+                  query: { path, sha },
+                },
+              },
+            ),
+          ) as { versions?: AppCommitFileVersions };
+          return body.versions ?? null;
+        } catch {
+          return null;
+        }
+      },
+
+      restoreVersion: async (workspaceId, appId, sha) => {
         unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/discard", {
+          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/restore", {
             params: { path: { workspaceId, id: appId } },
+            body: { sha },
           }),
         );
+        // Same cache hygiene as discard: contents changed under every open tab.
         set(s => {
-          // Drop caches — contents may have reverted.
           for (const key of Object.keys(s.fileContents)) {
             if (key.startsWith(`${appId}\u0000`)) delete s.fileContents[key];
           }
         });
         void get().fetchFiles(workspaceId, appId);
         void get().fetchStatus(workspaceId, appId);
+        void get().fetchHistory(workspaceId, appId);
         const selected = get().selectedFile[appId];
         if (selected) void get().openFile(workspaceId, appId, selected);
-      } catch (e) {
-        set(s => {
-          s.error = message(e, "Failed to discard changes");
-        });
-      }
-    },
+      },
 
-    publishApp: async (workspaceId, appId) => {
-      set(s => {
-        s.previewByApp[appId] = {
-          ...(s.previewByApp[appId] ?? { url: null }),
-          building: true,
-          publishing: true,
-          buildOutput: "",
-          error: null,
-        };
-      });
-      // Tail the sandbox build log while the publish runs, so the terminal
-      // shows npm install + vite build live instead of a silent spinner.
-      let stopTail = false;
-      const tail = (async () => {
-        let offset = 0;
-        while (!stopTail) {
-          try {
-            const res = await fetch(
-              `/api/workspaces/${workspaceId}/apps/${appId}/build/log?offset=${offset}`,
-              { credentials: "include" },
-            );
-            if (res.ok) {
-              const body = (await res.json()) as {
-                size?: number;
-                chunk?: string;
-              };
-              if (body.chunk) {
-                set(s => {
-                  const p = s.previewByApp[appId];
-                  if (p) p.buildOutput = (p.buildOutput ?? "") + body.chunk;
-                });
-              }
-              offset = body.size ?? offset;
-            }
-          } catch {
-            // A missed poll is fine; the next one resumes from `offset`.
+      rollbackTo: async (workspaceId, appId, sha) => {
+        unwrapBody(
+          await api.POST("/api/workspaces/{workspaceId}/apps/{id}/rollback", {
+            params: { path: { workspaceId, id: appId } },
+            body: { sha },
+          }),
+        );
+        set(s => {
+          const app = s.apps.find(a => a.id === appId);
+          if (app) {
+            app.publishedSha = sha;
+            app.publishedAt = new Date().toISOString();
           }
-          await new Promise(r => setTimeout(r, 500));
-        }
-      })();
-      try {
-        const res = await api.POST(
-          "/api/workspaces/{workspaceId}/apps/{id}/publish",
-          {
-            params: { path: { workspaceId, id: appId } },
-            body: {},
-          },
-        );
-        const raw = (res.data ?? res.error) as
-          | { success?: boolean; sha?: string; error?: string; output?: string }
-          | undefined;
-        if (res.response.ok && raw?.sha) {
-          set(s => {
-            const app = s.apps.find(a => a.id === appId);
-            if (app) {
-              app.publishedSha = raw.sha;
-              app.publishedAt = new Date().toISOString();
-            }
-            const p = s.previewByApp[appId];
-            s.previewByApp[appId] = {
-              ...(p ?? { url: null }),
-              building: false,
-              publishing: false,
-              error: null,
-            };
-          });
-        } else {
-          // Surface the build output (tsc/vite errors) — without it a failed
-          // publish is just "Build failed" with nothing to act on. The full
-          // build log is already in `buildOutput` (tailed live above).
-          const detail = [raw?.error, raw?.output].filter(Boolean).join("\n\n");
-          set(s => {
-            const p = s.previewByApp[appId];
-            s.previewByApp[appId] = {
-              ...(p ?? { url: null }),
-              building: false,
-              publishing: false,
-              error: detail || "Publish failed",
-            };
-          });
-        }
-      } catch (e) {
-        set(s => {
-          const p = s.previewByApp[appId];
-          s.previewByApp[appId] = {
-            ...(p ?? { url: null }),
-            building: false,
-            publishing: false,
-            error: message(e, "Publish failed"),
-          };
         });
-      } finally {
-        stopTail = true;
-        void tail;
-      }
-    },
+        void get().fetchViewUrl(workspaceId, appId);
+      },
 
-    buildPreview: async (workspaceId, appId) => {
-      set(s => {
-        s.previewByApp[appId] = {
-          ...(s.previewByApp[appId] ?? { url: null }),
-          building: true,
-          error: null,
-        };
-      });
-      try {
-        const res = await api.POST(
-          "/api/workspaces/{workspaceId}/apps/{id}/preview",
-          {
-            params: { path: { workspaceId, id: appId } },
-            body: undefined,
-          },
-        );
-        const raw = (res.data ?? res.error) as
-          | {
-              success?: boolean;
-              url?: string;
-              buildOutput?: string;
-              error?: string;
-              stdout?: string;
-              stderr?: string;
+      fetchFileVersions: async (workspaceId, appId, path) => {
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/git/file-versions",
+              { params: { path: { workspaceId, id: appId }, query: { path } } },
+            ),
+          ) as { versions?: AppFileVersions };
+          return body.versions ?? null;
+        } catch {
+          return null;
+        }
+      },
+
+      discard: async (workspaceId, appId) => {
+        try {
+          unwrapBody(
+            await api.POST("/api/workspaces/{workspaceId}/apps/{id}/discard", {
+              params: { path: { workspaceId, id: appId } },
+            }),
+          );
+          set(s => {
+            // Drop caches — contents may have reverted.
+            for (const key of Object.keys(s.fileContents)) {
+              if (key.startsWith(`${appId}\u0000`)) delete s.fileContents[key];
             }
-          | undefined;
-        if (res.response.ok && raw?.url) {
-          set(s => {
-            s.previewByApp[appId] = {
-              url: raw.url ?? null,
-              building: false,
-              error: null,
-              buildOutput: raw.buildOutput,
-              builtAt: Date.now(),
-              mode: "static",
-            };
-            s.viewMode[appId] = "preview";
           });
-        } else {
-          const detail = [raw?.error, raw?.stdout, raw?.stderr]
-            .filter(Boolean)
-            .join("\n");
+          void get().fetchFiles(workspaceId, appId);
+          void get().fetchStatus(workspaceId, appId);
+          const selected = get().selectedFile[appId];
+          if (selected) void get().openFile(workspaceId, appId, selected);
+        } catch (e) {
           set(s => {
-            s.previewByApp[appId] = {
-              ...(s.previewByApp[appId] ?? { url: null }),
-              building: false,
-              error: detail || "Build failed",
-            };
+            s.error = message(e, "Failed to discard changes");
           });
         }
-        void get().fetchStatus(workspaceId, appId);
-      } catch (e) {
+      },
+
+      publishApp: async (workspaceId, appId) => {
         set(s => {
           s.previewByApp[appId] = {
             ...(s.previewByApp[appId] ?? { url: null }),
-            building: false,
-            error: message(e, "Build failed"),
-          };
-        });
-      }
-    },
-
-    fetchSandboxStats: async (workspaceId, appId) => {
-      const body = unwrapBody(
-        await api.GET("/api/workspaces/{workspaceId}/apps/{id}/sandbox", {
-          params: { path: { workspaceId, id: appId } },
-        }),
-      );
-      return (body ?? null) as Record<string, unknown> | null;
-    },
-
-    recycleSandbox: async (workspaceId, appId) => {
-      await api.POST(
-        "/api/workspaces/{workspaceId}/apps/{id}/sandbox/recycle",
-        { params: { path: { workspaceId, id: appId } } },
-      );
-    },
-
-    stopDev: async (workspaceId, appId) => {
-      // Kill ALL sessions server-side, not just the dev one: leaving old
-      // shells alive meant re-entering dev mode reattached a museum of
-      // terminals with their history. Best effort — an unreachable API
-      // still flips the UI, and the box agent reconciles the dot.
-      try {
-        await api.DELETE(
-          "/api/workspaces/{workspaceId}/apps/{id}/terminal-sessions",
-          { params: { path: { workspaceId, id: appId } } },
-        );
-      } catch {
-        // Best effort.
-      }
-      try {
-        localStorage.removeItem(`apps-shells:${appId}`);
-        localStorage.removeItem(`apps-term-active:${appId}`);
-      } catch {
-        // Best effort.
-      }
-      get().markDevDown(appId);
-      get().setEditing(workspaceId, appId, false);
-    },
-
-    fetchAppBindings: async (workspaceId, appId) => {
-      const body = unwrapBody(
-        await api.GET("/api/workspaces/{workspaceId}/apps/{id}/bindings", {
-          params: { path: { workspaceId, id: appId } },
-        }),
-      ) as { bindings?: Array<Record<string, unknown> & { name: string }> };
-      return body.bindings ?? [];
-    },
-
-    materializeAppBinding: async (workspaceId, appId, name) => {
-      return unwrapBody(
-        await api.POST(
-          "/api/workspaces/{workspaceId}/apps/{id}/bindings/{name}/materialize",
-          { params: { path: { workspaceId, id: appId, name } } },
-        ),
-      ) as Record<string, unknown>;
-    },
-
-    fetchRunningDevApps: async workspaceId => {
-      const appId = get().apps[0]?.id;
-      if (!appId) return;
-      try {
-        const body = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/dev-servers", {
-            params: { path: { workspaceId, id: appId } },
-          }),
-        ) as { running?: string[] };
-        // A poll answered before a recycle must not overwrite the offline
-        // push that arrived while it was in flight (§13.11: pushes win).
-        if (get().boxStatus === "offline") return;
-        set(s => {
-          s.runningDevApps = body.running ?? [];
-        });
-      } catch {
-        // Advisory dots; a failed probe changes nothing.
-      }
-    },
-
-    killTerminalSession: async (workspaceId, appId, termId) => {
-      try {
-        await api.DELETE(
-          "/api/workspaces/{workspaceId}/apps/{id}/terminal-sessions/{termId}",
-          { params: { path: { workspaceId, id: appId, termId } } },
-        );
-      } catch {
-        // Best effort — an unreachable API still lets the tab close; the
-        // sandbox-side reaper collects orphans later.
-      }
-    },
-
-    checkDevStatus: async (workspaceId, appId) => {
-      try {
-        const body = unwrapBody(
-          await api.GET(
-            "/api/workspaces/{workspaceId}/apps/{id}/dev-preview/status",
-            { params: { path: { workspaceId, id: appId } } },
-          ),
-        ) as { serving?: boolean; url?: string; reachable?: boolean };
-        // Stale probe vs offline push: the push wins (§13.11). A response
-        // computed before the box died must not repaint dead-sandbox URLs.
-        if (get().boxStatus === "offline") return;
-        const url = body.url;
-        if (body.serving && url) {
-          // Discovery: a dev server is ALREADY running for this app (started
-          // in another tab, another browser, or before a reload that lost
-          // client state). Show it — do not make the user "start" a thing
-          // that is running.
-          get().markDevServing(appId, url, body.reachable);
-          return;
-        }
-        if (body.serving === false) get().markDevDown(appId);
-      } catch {
-        // Advisory: an unreachable probe must not kill a working preview.
-      }
-    },
-
-    markDevServing: (appId, url, reachable) => {
-      try {
-        localStorage.setItem(`apps-devurl:${appId}`, url);
-      } catch {
-        // Best effort.
-      }
-      set(s => {
-        const current = s.previewByApp[appId];
-        if (current?.building) return;
-        if (current?.url !== url) {
-          s.previewByApp[appId] = {
-            url,
-            building: false,
+            building: true,
+            publishing: true,
+            buildOutput: "",
             error: null,
-            builtAt: Date.now(),
-            mode: "dev",
-            reachable,
           };
-          s.viewMode[appId] = "preview";
-        } else if (current && current.reachable !== reachable) {
-          current.reachable = reachable;
-        }
-      });
-    },
-
-    markDevDown: appId => {
-      try {
-        localStorage.removeItem(`apps-devurl:${appId}`);
-      } catch {
-        // Best effort.
-      }
-      set(s => {
-        const preview = s.previewByApp[appId];
-        // A launch in flight (building) is not "down": the snapshot that
-        // arrived mid-boot simply predates the server.
-        if (preview?.mode === "dev" && !preview.building) {
-          s.previewByApp[appId] = {
-            url: null,
-            building: false,
-            // PRESERVE a boot failure: the next 15s status poll used to
-            // land here and wipe the error — the red "last start failed"
-            // state lived for seconds, then vanished as if nothing
-            // happened. Down is down; the error explains WHY.
-            error: preview.error ?? null,
-          };
-        }
-      });
-    },
-
-    setCurrentUserId: userId => {
-      set(s => {
-        s.currentUserId = userId;
-      });
-    },
-
-    applyBoxState: (userId, state) => {
-      const { currentUserId, apps } = get();
-      // Diagnostics: `localStorage["apps-debug"] = "1"` records every
-      // pushed snapshot on window.__appsBoxEvents for inspection.
-      try {
-        if (localStorage.getItem("apps-debug")) {
-          const w = window as Window & {
-            __appsBoxEvents?: unknown[];
-          };
-          (w.__appsBoxEvents ??= []).push({
-            at: Date.now(),
-            userId,
-            currentUserId,
-            state,
-          });
-        }
-      } catch {
-        // Best effort.
-      }
-      // Unknown identity = drop, not accept: while /me is still resolving in
-      // a multi-user workspace, a TEAMMATE's box push must not paint this
-      // client's dots and previews.
-      if (!currentUserId || userId !== currentUserId) return;
-      // Reactive box identity/liveness for the sandbox panel and, crucially,
-      // preview coherence: a second browser learns the box's id and status the
-      // instant they change, not on a poll.
-      set(s => {
-        if (state.status) s.boxStatus = state.status;
-        if (state.sandboxId !== undefined) s.boxSandboxId = state.sandboxId;
-        if (state.terminals != null) s.boxTerminals = state.terminals;
-      });
-      if (state.status === "offline") {
-        // The box is gone — every dev-server URL now points at a dead sandbox.
-        // Drop them so open previews flip to the launch state immediately
-        // instead of showing E2B's "sandbox not found".
-        set(s => {
-          s.runningDevApps = [];
-          s.boxTerminals = [];
         });
-        for (const app of apps) get().markDevDown(app.id);
-        // markDevDown only clears keys for apps we KNOW about; if this push
-        // beat fetchApps, the loop above ran over nothing and stale URLs
-        // survive into the next session. Purge the namespace wholesale —
-        // every remembered dev URL died with the machine.
-        try {
-          for (let i = localStorage.length - 1; i >= 0; i--) {
-            const k = localStorage.key(i);
-            if (k?.startsWith("apps-devurl:")) localStorage.removeItem(k);
-          }
-        } catch {
-          // Best effort.
-        }
-        return;
-      }
-      if (state.devServers) {
-        const serving = new Map(state.devServers.map(d => [d.slug, d]));
-        set(s => {
-          s.runningDevApps = [...serving.keys()];
-        });
-        for (const app of apps) {
-          const entry = app.slug ? serving.get(app.slug) : undefined;
-          if (entry?.url) {
-            get().markDevServing(app.id, entry.url, entry.reachable);
-          } else get().markDevDown(app.id);
-        }
-      }
-      if (state.branch !== null || state.changes !== null) {
-        set(s => {
-          for (const app of apps) {
-            const prev = s.statusByApp[app.id];
-            const repoChanges = state.changes ?? prev?.repoChanges ?? [];
-            s.statusByApp[app.id] = {
-              branch: state.branch ?? prev?.branch ?? "main",
-              baseSha: state.head ?? prev?.baseSha ?? "",
-              branchHead: prev?.branchHead ?? null,
-              ahead: state.ahead ?? prev?.ahead ?? 0,
-              changes: repoChanges.filter(c =>
-                c.path.startsWith(`apps/${app.slug}/`),
-              ),
-              repoChanges,
-              offline: false,
-            };
-          }
-        });
-      }
-    },
-
-    fetchDevLog: async (workspaceId, appId, offset) => {
-      try {
-        const body = unwrapBody(
-          await api.GET(
-            "/api/workspaces/{workspaceId}/apps/{id}/dev-preview/log",
-            {
-              params: {
-                path: { workspaceId, id: appId },
-                query: { offset },
-              },
-            },
-          ),
-        ) as { size?: number; chunk?: string };
-        return { size: body.size ?? 0, chunk: body.chunk ?? "" };
-      } catch {
-        // Polling: one missed beat is fine; the next one catches up.
-        return { size: offset, chunk: "" };
-      }
-    },
-
-    startDevPreview: async (workspaceId, appId, opts) => {
-      // Optimistic reattach: if this app had a dev server last time, its URL
-      // is almost certainly still valid (the sandbox sleeps rather than
-      // dies), so show the iframe IMMEDIATELY and let the POST revalidate
-      // behind it. Cold starts still show the boot state — there is no
-      // remembered URL to be optimistic with. A stale URL costs a broken
-      // iframe for the seconds until the POST corrects it; the alternative
-      // cost 10+ seconds of "Starting..." on every reload, for a server
-      // that was already running.
-      let optimistic: string | null = null;
-      try {
-        optimistic = localStorage.getItem(`apps-devurl:${appId}`);
-      } catch {
-        // Storage unavailable — no optimism, same as before.
-      }
-      // The remembered URL embeds a sandbox id, and box truth can prove it
-      // dead: an offline box, or a live box with a DIFFERENT id, means the
-      // URL is a corpse — optimism would iframe E2B's error page for the
-      // whole post-recycle cold boot (clone + install + vite, not seconds).
-      const { boxStatus, boxSandboxId } = get();
-      if (
-        optimistic &&
-        (boxStatus === "offline" ||
-          (boxSandboxId && !optimistic.includes(boxSandboxId)))
-      ) {
-        optimistic = null;
-        try {
-          localStorage.removeItem(`apps-devurl:${appId}`);
-        } catch {
-          // Best effort.
-        }
-      }
-      set(s => {
-        s.previewByApp[appId] = optimistic
-          ? {
-              url: optimistic,
-              building: false,
-              error: null,
-              builtAt: Date.now(),
-              mode: "dev",
+        // Tail the sandbox build log while the publish runs, so the terminal
+        // shows npm install + vite build live instead of a silent spinner.
+        let stopTail = false;
+        const tail = (async () => {
+          let offset = 0;
+          while (!stopTail) {
+            try {
+              const res = await fetch(
+                `/api/workspaces/${workspaceId}/apps/${appId}/build/log?offset=${offset}`,
+                { credentials: "include" },
+              );
+              if (res.ok) {
+                const body = (await res.json()) as {
+                  size?: number;
+                  chunk?: string;
+                };
+                if (body.chunk) {
+                  set(s => {
+                    const p = s.previewByApp[appId];
+                    if (p) p.buildOutput = (p.buildOutput ?? "") + body.chunk;
+                  });
+                }
+                offset = body.size ?? offset;
+              }
+            } catch {
+              // A missed poll is fine; the next one resumes from `offset`.
             }
-          : {
-              ...(s.previewByApp[appId] ?? { url: null }),
-              building: true,
-              error: null,
+            await new Promise(r => setTimeout(r, 500));
+          }
+        })();
+        try {
+          const res = await api.POST(
+            "/api/workspaces/{workspaceId}/apps/{id}/publish",
+            {
+              params: { path: { workspaceId, id: appId } },
+              body: {},
+            },
+          );
+          const raw = (res.data ?? res.error) as
+            | {
+                success?: boolean;
+                sha?: string;
+                error?: string;
+                output?: string;
+              }
+            | undefined;
+          if (res.response.ok && raw?.sha) {
+            set(s => {
+              const app = s.apps.find(a => a.id === appId);
+              if (app) {
+                app.publishedSha = raw.sha;
+                app.publishedAt = new Date().toISOString();
+              }
+              const p = s.previewByApp[appId];
+              s.previewByApp[appId] = {
+                ...(p ?? { url: null }),
+                building: false,
+                publishing: false,
+                error: null,
+              };
+            });
+          } else {
+            // Surface the build output (tsc/vite errors) — without it a failed
+            // publish is just "Build failed" with nothing to act on. The full
+            // build log is already in `buildOutput` (tailed live above).
+            const detail = [raw?.error, raw?.output]
+              .filter(Boolean)
+              .join("\n\n");
+            set(s => {
+              const p = s.previewByApp[appId];
+              s.previewByApp[appId] = {
+                ...(p ?? { url: null }),
+                building: false,
+                publishing: false,
+                error: detail || "Publish failed",
+              };
+            });
+          }
+        } catch (e) {
+          set(s => {
+            const p = s.previewByApp[appId];
+            s.previewByApp[appId] = {
+              ...(p ?? { url: null }),
+              building: false,
+              publishing: false,
+              error: message(e, "Publish failed"),
             };
-        if (optimistic) s.viewMode[appId] = "preview";
-      });
-      try {
-        // One retry, for the takeover shape: when another app's dev server
-        // owns the port, the first request kills it, reinstalls and relaunches
-        // — which can outlive a transport deadline even though the server
-        // finishes the job. The second request finds the right server already
-        // listening and returns in milliseconds. Retrying anything else once
-        // is harmless; the second failure is the one reported.
-        const restartBody = opts?.restart ? { restart: true } : undefined;
-        let res = await api.POST(
-          "/api/workspaces/{workspaceId}/apps/{id}/dev-preview",
-          {
-            params: { path: { workspaceId, id: appId } },
-            body: restartBody,
-          },
-        );
-        if (!res.response.ok) {
-          // The retry must NOT restart again — the first call already did;
-          // a second reap would kill the server it just booted.
-          res = await api.POST(
-            "/api/workspaces/{workspaceId}/apps/{id}/dev-preview",
+          });
+        } finally {
+          stopTail = true;
+          void tail;
+        }
+      },
+
+      buildPreview: async (workspaceId, appId) => {
+        set(s => {
+          s.previewByApp[appId] = {
+            ...(s.previewByApp[appId] ?? { url: null }),
+            building: true,
+            error: null,
+          };
+        });
+        try {
+          const res = await api.POST(
+            "/api/workspaces/{workspaceId}/apps/{id}/preview",
             {
               params: { path: { workspaceId, id: appId } },
               body: undefined,
             },
           );
-        }
-        const raw = (res.data ?? res.error) as
-          | {
-              success?: boolean;
-              url?: string;
-              error?: string;
-              evicted?: string[];
-            }
-          | undefined;
-        if (res.response.ok && raw?.url) {
-          // The box enforces a running cap; if starting this one closed
-          // others, reflect that immediately instead of waiting for the next
-          // running-servers poll — clear their dots and preview state.
-          const evicted = raw.evicted ?? [];
-          if (evicted.length) {
-            const apps = get().apps;
+          const raw = (res.data ?? res.error) as
+            | {
+                success?: boolean;
+                url?: string;
+                buildOutput?: string;
+                error?: string;
+                stdout?: string;
+                stderr?: string;
+              }
+            | undefined;
+          if (res.response.ok && raw?.url) {
             set(s => {
-              s.runningDevApps = s.runningDevApps.filter(
-                sl => !evicted.includes(sl),
-              );
+              s.previewByApp[appId] = {
+                url: raw.url ?? null,
+                building: false,
+                error: null,
+                buildOutput: raw.buildOutput,
+                builtAt: Date.now(),
+                mode: "static",
+              };
+              s.viewMode[appId] = "preview";
             });
-            for (const sl of evicted) {
-              const a = apps.find(x => x.slug === sl);
-              if (a) get().markDevDown(a.id);
-            }
+          } else {
+            const detail = [raw?.error, raw?.stdout, raw?.stderr]
+              .filter(Boolean)
+              .join("\n");
+            set(s => {
+              s.previewByApp[appId] = {
+                ...(s.previewByApp[appId] ?? { url: null }),
+                building: false,
+                error: detail || "Build failed",
+              };
+            });
           }
-          try {
-            localStorage.setItem(`apps-devurl:${appId}`, raw.url);
-          } catch {
-            // Best effort.
-          }
-          set(s => {
-            s.previewByApp[appId] = {
-              url: raw.url ?? null,
-              building: false,
-              error: null,
-              builtAt: Date.now(),
-              mode: "dev",
-            };
-            s.viewMode[appId] = "preview";
-          });
-        } else {
+          void get().fetchStatus(workspaceId, appId);
+        } catch (e) {
           set(s => {
             s.previewByApp[appId] = {
               ...(s.previewByApp[appId] ?? { url: null }),
               building: false,
-              error: raw?.error ?? "Failed to start dev preview",
+              error: message(e, "Build failed"),
             };
           });
         }
-      } catch (e) {
+      },
+
+      fetchSandboxStats: async (workspaceId, appId) => {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/sandbox", {
+            params: { path: { workspaceId, id: appId } },
+          }),
+        );
+        return (body ?? null) as Record<string, unknown> | null;
+      },
+
+      recycleSandbox: async (workspaceId, appId) => {
+        await api.POST(
+          "/api/workspaces/{workspaceId}/apps/{id}/sandbox/recycle",
+          { params: { path: { workspaceId, id: appId } } },
+        );
+      },
+
+      stopDev: async (workspaceId, appId) => {
+        // Kill ALL sessions server-side, not just the dev one: leaving old
+        // shells alive meant re-entering dev mode reattached a museum of
+        // terminals with their history. Best effort — an unreachable API
+        // still flips the UI, and the box agent reconciles the dot.
+        try {
+          await api.DELETE(
+            "/api/workspaces/{workspaceId}/apps/{id}/terminal-sessions",
+            { params: { path: { workspaceId, id: appId } } },
+          );
+        } catch {
+          // Best effort.
+        }
+        try {
+          localStorage.removeItem(`apps-shells:${appId}`);
+          localStorage.removeItem(`apps-term-active:${appId}`);
+        } catch {
+          // Best effort.
+        }
+        get().markDevDown(appId);
+        get().setEditing(workspaceId, appId, false);
+      },
+
+      fetchAppBindings: async (workspaceId, appId) => {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/bindings", {
+            params: { path: { workspaceId, id: appId } },
+          }),
+        ) as { bindings?: Array<Record<string, unknown> & { name: string }> };
+        return body.bindings ?? [];
+      },
+
+      materializeAppBinding: async (workspaceId, appId, name) => {
+        return unwrapBody(
+          await api.POST(
+            "/api/workspaces/{workspaceId}/apps/{id}/bindings/{name}/materialize",
+            { params: { path: { workspaceId, id: appId, name } } },
+          ),
+        ) as Record<string, unknown>;
+      },
+
+      fetchRunningDevApps: async workspaceId => {
+        const appId = get().apps[0]?.id;
+        if (!appId) return;
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/dev-servers",
+              {
+                params: { path: { workspaceId, id: appId } },
+              },
+            ),
+          ) as { running?: string[] };
+          // A poll answered before a recycle must not overwrite the offline
+          // push that arrived while it was in flight (§13.11: pushes win).
+          if (get().boxStatus === "offline") return;
+          set(s => {
+            s.runningDevApps = body.running ?? [];
+          });
+        } catch {
+          // Advisory dots; a failed probe changes nothing.
+        }
+      },
+
+      killTerminalSession: async (workspaceId, appId, termId) => {
+        try {
+          await api.DELETE(
+            "/api/workspaces/{workspaceId}/apps/{id}/terminal-sessions/{termId}",
+            { params: { path: { workspaceId, id: appId, termId } } },
+          );
+        } catch {
+          // Best effort — an unreachable API still lets the tab close; the
+          // sandbox-side reaper collects orphans later.
+        }
+      },
+
+      checkDevStatus: async (workspaceId, appId) => {
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/dev-preview/status",
+              { params: { path: { workspaceId, id: appId } } },
+            ),
+          ) as { serving?: boolean; url?: string; reachable?: boolean };
+          // Stale probe vs offline push: the push wins (§13.11). A response
+          // computed before the box died must not repaint dead-sandbox URLs.
+          if (get().boxStatus === "offline") return;
+          const url = body.url;
+          if (body.serving && url) {
+            // Discovery: a dev server is ALREADY running for this app (started
+            // in another tab, another browser, or before a reload that lost
+            // client state). Show it — do not make the user "start" a thing
+            // that is running.
+            get().markDevServing(appId, url, body.reachable);
+            return;
+          }
+          if (body.serving === false) get().markDevDown(appId);
+        } catch {
+          // Advisory: an unreachable probe must not kill a working preview.
+        }
+      },
+
+      markDevServing: (appId, url, reachable) => {
+        try {
+          localStorage.setItem(`apps-devurl:${appId}`, url);
+        } catch {
+          // Best effort.
+        }
         set(s => {
-          s.previewByApp[appId] = {
-            ...(s.previewByApp[appId] ?? { url: null }),
-            building: false,
-            error: message(e, "Failed to start dev preview"),
-          };
+          const current = s.previewByApp[appId];
+          if (current?.building) return;
+          if (current?.url !== url) {
+            s.previewByApp[appId] = {
+              url,
+              building: false,
+              error: null,
+              builtAt: Date.now(),
+              mode: "dev",
+              reachable,
+            };
+            s.viewMode[appId] = "preview";
+          } else if (current && current.reachable !== reachable) {
+            current.reachable = reachable;
+          }
         });
-      }
-    },
+      },
 
-    setViewMode: (appId, mode) => {
-      set(s => {
-        s.viewMode[appId] = mode;
-      });
-    },
+      markDevDown: appId => {
+        try {
+          localStorage.removeItem(`apps-devurl:${appId}`);
+        } catch {
+          // Best effort.
+        }
+        set(s => {
+          const preview = s.previewByApp[appId];
+          // A launch in flight (building) is not "down": the snapshot that
+          // arrived mid-boot simply predates the server.
+          if (preview?.mode === "dev" && !preview.building) {
+            s.previewByApp[appId] = {
+              url: null,
+              building: false,
+              // PRESERVE a boot failure: the next 15s status poll used to
+              // land here and wipe the error — the red "last start failed"
+              // state lived for seconds, then vanished as if nothing
+              // happened. Down is down; the error explains WHY.
+              error: preview.error ?? null,
+            };
+          }
+        });
+      },
 
-    clearError: () => {
-      set(s => {
-        s.error = null;
-      });
+      setCurrentUserId: userId => {
+        set(s => {
+          s.currentUserId = userId;
+        });
+      },
+
+      applyBoxState: (userId, state) => {
+        const { currentUserId, apps } = get();
+        // Diagnostics: `localStorage["apps-debug"] = "1"` records every
+        // pushed snapshot on window.__appsBoxEvents for inspection.
+        try {
+          if (localStorage.getItem("apps-debug")) {
+            const w = window as Window & {
+              __appsBoxEvents?: unknown[];
+            };
+            (w.__appsBoxEvents ??= []).push({
+              at: Date.now(),
+              userId,
+              currentUserId,
+              state,
+            });
+          }
+        } catch {
+          // Best effort.
+        }
+        // Unknown identity = drop, not accept: while /me is still resolving in
+        // a multi-user workspace, a TEAMMATE's box push must not paint this
+        // client's dots and previews.
+        if (!currentUserId || userId !== currentUserId) return;
+        // Reactive box identity/liveness for the sandbox panel and, crucially,
+        // preview coherence: a second browser learns the box's id and status the
+        // instant they change, not on a poll.
+        set(s => {
+          if (state.status) s.boxStatus = state.status;
+          if (state.sandboxId !== undefined) s.boxSandboxId = state.sandboxId;
+          if (state.terminals != null) s.boxTerminals = state.terminals;
+        });
+        if (state.status === "offline") {
+          // The box is gone — every dev-server URL now points at a dead sandbox.
+          // Drop them so open previews flip to the launch state immediately
+          // instead of showing E2B's "sandbox not found".
+          set(s => {
+            s.runningDevApps = [];
+            s.boxTerminals = [];
+          });
+          for (const app of apps) get().markDevDown(app.id);
+          // markDevDown only clears keys for apps we KNOW about; if this push
+          // beat fetchApps, the loop above ran over nothing and stale URLs
+          // survive into the next session. Purge the namespace wholesale —
+          // every remembered dev URL died with the machine.
+          try {
+            for (let i = localStorage.length - 1; i >= 0; i--) {
+              const k = localStorage.key(i);
+              if (k?.startsWith("apps-devurl:")) localStorage.removeItem(k);
+            }
+          } catch {
+            // Best effort.
+          }
+          return;
+        }
+        if (state.devServers) {
+          const serving = new Map(state.devServers.map(d => [d.slug, d]));
+          set(s => {
+            s.runningDevApps = [...serving.keys()];
+          });
+          for (const app of apps) {
+            const entry = app.slug ? serving.get(app.slug) : undefined;
+            if (entry?.url) {
+              get().markDevServing(app.id, entry.url, entry.reachable);
+            } else get().markDevDown(app.id);
+          }
+        }
+        if (state.branch !== null || state.changes !== null) {
+          set(s => {
+            for (const app of apps) {
+              const prev = s.statusByApp[app.id];
+              const repoChanges = state.changes ?? prev?.repoChanges ?? [];
+              s.statusByApp[app.id] = {
+                branch: state.branch ?? prev?.branch ?? "main",
+                baseSha: state.head ?? prev?.baseSha ?? "",
+                branchHead: prev?.branchHead ?? null,
+                ahead: state.ahead ?? prev?.ahead ?? 0,
+                changes: repoChanges.filter(c =>
+                  c.path.startsWith(`apps/${app.slug}/`),
+                ),
+                repoChanges,
+                offline: false,
+              };
+            }
+          });
+        }
+      },
+
+      fetchDevLog: async (workspaceId, appId, offset) => {
+        try {
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/apps/{id}/dev-preview/log",
+              {
+                params: {
+                  path: { workspaceId, id: appId },
+                  query: { offset },
+                },
+              },
+            ),
+          ) as { size?: number; chunk?: string };
+          return { size: body.size ?? 0, chunk: body.chunk ?? "" };
+        } catch {
+          // Polling: one missed beat is fine; the next one catches up.
+          return { size: offset, chunk: "" };
+        }
+      },
+
+      startDevPreview: async (workspaceId, appId, opts) => {
+        // Optimistic reattach: if this app had a dev server last time, its URL
+        // is almost certainly still valid (the sandbox sleeps rather than
+        // dies), so show the iframe IMMEDIATELY and let the POST revalidate
+        // behind it. Cold starts still show the boot state — there is no
+        // remembered URL to be optimistic with. A stale URL costs a broken
+        // iframe for the seconds until the POST corrects it; the alternative
+        // cost 10+ seconds of "Starting..." on every reload, for a server
+        // that was already running.
+        let optimistic: string | null = null;
+        try {
+          optimistic = localStorage.getItem(`apps-devurl:${appId}`);
+        } catch {
+          // Storage unavailable — no optimism, same as before.
+        }
+        // The remembered URL embeds a sandbox id, and box truth can prove it
+        // dead: an offline box, or a live box with a DIFFERENT id, means the
+        // URL is a corpse — optimism would iframe E2B's error page for the
+        // whole post-recycle cold boot (clone + install + vite, not seconds).
+        const { boxStatus, boxSandboxId } = get();
+        if (
+          optimistic &&
+          (boxStatus === "offline" ||
+            (boxSandboxId && !optimistic.includes(boxSandboxId)))
+        ) {
+          optimistic = null;
+          try {
+            localStorage.removeItem(`apps-devurl:${appId}`);
+          } catch {
+            // Best effort.
+          }
+        }
+        set(s => {
+          s.previewByApp[appId] = optimistic
+            ? {
+                url: optimistic,
+                building: false,
+                error: null,
+                builtAt: Date.now(),
+                mode: "dev",
+              }
+            : {
+                ...(s.previewByApp[appId] ?? { url: null }),
+                building: true,
+                error: null,
+              };
+          if (optimistic) s.viewMode[appId] = "preview";
+        });
+        try {
+          // One retry, for the takeover shape: when another app's dev server
+          // owns the port, the first request kills it, reinstalls and relaunches
+          // — which can outlive a transport deadline even though the server
+          // finishes the job. The second request finds the right server already
+          // listening and returns in milliseconds. Retrying anything else once
+          // is harmless; the second failure is the one reported.
+          const restartBody = opts?.restart ? { restart: true } : undefined;
+          let res = await api.POST(
+            "/api/workspaces/{workspaceId}/apps/{id}/dev-preview",
+            {
+              params: { path: { workspaceId, id: appId } },
+              body: restartBody,
+            },
+          );
+          if (!res.response.ok) {
+            // The retry must NOT restart again — the first call already did;
+            // a second reap would kill the server it just booted.
+            res = await api.POST(
+              "/api/workspaces/{workspaceId}/apps/{id}/dev-preview",
+              {
+                params: { path: { workspaceId, id: appId } },
+                body: undefined,
+              },
+            );
+          }
+          const raw = (res.data ?? res.error) as
+            | {
+                success?: boolean;
+                url?: string;
+                error?: string;
+                evicted?: string[];
+              }
+            | undefined;
+          if (res.response.ok && raw?.url) {
+            // The box enforces a running cap; if starting this one closed
+            // others, reflect that immediately instead of waiting for the next
+            // running-servers poll — clear their dots and preview state.
+            const evicted = raw.evicted ?? [];
+            if (evicted.length) {
+              const apps = get().apps;
+              set(s => {
+                s.runningDevApps = s.runningDevApps.filter(
+                  sl => !evicted.includes(sl),
+                );
+              });
+              for (const sl of evicted) {
+                const a = apps.find(x => x.slug === sl);
+                if (a) get().markDevDown(a.id);
+              }
+            }
+            try {
+              localStorage.setItem(`apps-devurl:${appId}`, raw.url);
+            } catch {
+              // Best effort.
+            }
+            set(s => {
+              s.previewByApp[appId] = {
+                url: raw.url ?? null,
+                building: false,
+                error: null,
+                builtAt: Date.now(),
+                mode: "dev",
+              };
+              s.viewMode[appId] = "preview";
+            });
+          } else {
+            set(s => {
+              s.previewByApp[appId] = {
+                ...(s.previewByApp[appId] ?? { url: null }),
+                building: false,
+                error: raw?.error ?? "Failed to start dev preview",
+              };
+            });
+          }
+        } catch (e) {
+          set(s => {
+            s.previewByApp[appId] = {
+              ...(s.previewByApp[appId] ?? { url: null }),
+              building: false,
+              error: message(e, "Failed to start dev preview"),
+            };
+          });
+        }
+      },
+
+      setViewMode: (appId, mode) => {
+        set(s => {
+          s.viewMode[appId] = mode;
+        });
+      },
+
+      clearError: () => {
+        set(s => {
+          s.error = null;
+        });
+      },
+    })),
+    {
+      name: "apps-store",
+      version: 1,
+      // Only the list cache survives a reload; everything else is live
+      // state that must come from the box or the API.
+      partialize: s => ({ appsCacheByWorkspace: s.appsCacheByWorkspace }),
     },
-  })),
+  ),
 );


### PR DESCRIPTION
## Why

The Apps rail rendered an empty list and then everything at once, and the list request was slow.

## What

- **`ExplorerShell` owns the skeleton.** It only showed one if the explorer passed a `skeleton` node — 3 of 7 did (each hand-rolled); apps, consoles, notebooks and flows showed an empty rail. A default `ExplorerSkeleton` (tree rows at the tree's indentation) now renders whenever `loading` is set; `skeleton` remains an override.
- **Persisted list cache.** `appsStore` is wrapped in `persist` (partialized to `appsCacheByWorkspace`); `fetchApps` seeds `apps` from it before the request, so the rail paints instantly and refreshes in the background — same pattern as `databaseCatalogStore`.
- **Server: one git call per list.** `listAppFolders` ran `git ls-tree -r` over the *whole* monorepo + one `git show` per app on every request. Now memoized per (workspace, `main` sha) with a single `rev-parse` per request; on a miss it lists `apps/` non-recursively and reads manifests 8 at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
