### PR TITLE
refactor(tabs): one open-or-focus primitive — focusOrOpenTab — instead of twenty copies

### DIFF
--- a/app/src/apps-runtime/shell.ts
+++ b/app/src/apps-runtime/shell.ts
@@ -10,31 +10,16 @@ export function focusAppsTab(
   title: string,
   slug?: string,
 ): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: { kind?: string; metadata?: { appId?: string } }) =>
-      tab.kind === "app" && tab.metadata?.appId === appId,
-  );
-
-  if (existingTab) {
-    if (existingTab.title !== title && title) {
-      useConsoleStore.setState(state => {
-        const tab = state.tabs[existingTab.id];
-        if (tab) tab.title = title;
-      });
-    }
-    consoleStore.setActiveTab(existingTab.id);
-    return existingTab.id;
-  }
-
-  const tabId = consoleStore.openTab({
-    title: title || "App",
-    content: "",
-    kind: "app",
-    metadata: { appId: appId, appSlug: slug },
-  });
-  consoleStore.setActiveTab(tabId);
-  return tabId;
+  return useConsoleStore.getState().focusOrOpenTab(
+    { kind: "app", metadata: { appId } },
+    () => ({
+      title: title || "App",
+      content: "",
+      kind: "app",
+      metadata: { appId: appId, appSlug: slug },
+    }),
+    { title: title || undefined },
+  ) as string;
 }
 
 /** Open (or focus) a file of an Apps project in its own editor tab. */
@@ -43,32 +28,22 @@ export function focusAppsFileTab(
   path: string,
   slug?: string,
 ): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: { kind?: string; metadata?: { appId?: string; path?: string } }) =>
-      tab.kind === "app-file" &&
-      tab.metadata?.appId === appId &&
-      tab.metadata?.path === path,
-  );
-  if (existingTab) {
-    consoleStore.setActiveTab(existingTab.id);
-    return existingTab.id;
-  }
   const fileName = path.split("/").pop() || path;
-  const tabId = consoleStore.openTab({
-    title: fileName,
-    content: "",
-    kind: "app-file",
-    metadata: { appId: appId, appSlug: slug, path },
-  });
-  consoleStore.setActiveTab(tabId);
-  return tabId;
+  return useConsoleStore
+    .getState()
+    .focusOrOpenTab({ kind: "app-file", metadata: { appId, path } }, () => ({
+      title: fileName,
+      content: "",
+      kind: "app-file",
+      metadata: { appId: appId, appSlug: slug, path },
+    })) as string;
 }
 
 /**
  * Open (or focus) a diff of one repo-relative path, VS Code style: "Working
  * Tree" compares index → working copy (the Changes group), "Index" compares
- * HEAD → index (the Staged Changes group).
+ * HEAD → index (the Staged Changes group), "commit" shows what one commit
+ * did to the file (parent → sha).
  */
 export function focusAppsDiffTab(
   appId: string,
@@ -78,22 +53,6 @@ export function focusAppsDiffTab(
   /** "commit" mode: the commit whose change to `path` is shown. */
   sha?: string,
 ): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: {
-      kind?: string;
-      metadata?: { appId?: string; path?: string; mode?: string; sha?: string };
-    }) =>
-      tab.kind === "app-diff" &&
-      tab.metadata?.appId === appId &&
-      tab.metadata?.path === path &&
-      tab.metadata?.mode === mode &&
-      (mode !== "commit" || tab.metadata?.sha === sha),
-  );
-  if (existingTab) {
-    consoleStore.setActiveTab(existingTab.id);
-    return existingTab.id;
-  }
   const fileName = path.split("/").pop() || path;
   const label =
     mode === "commit"
@@ -101,14 +60,18 @@ export function focusAppsDiffTab(
       : mode === "index"
         ? "Index"
         : "Working Tree";
-  const tabId = consoleStore.openTab({
-    title: `${fileName} (${label})`,
-    content: "",
-    kind: "app-diff",
-    metadata: { appId: appId, appSlug: slug, path, mode, sha },
-  });
-  consoleStore.setActiveTab(tabId);
-  return tabId;
+  return useConsoleStore.getState().focusOrOpenTab(
+    {
+      kind: "app-diff",
+      metadata: { appId, path, mode, ...(mode === "commit" ? { sha } : {}) },
+    },
+    () => ({
+      title: `${fileName} (${label})`,
+      content: "",
+      kind: "app-diff",
+      metadata: { appId: appId, appSlug: slug, path, mode, sha },
+    }),
+  ) as string;
 }
 
 /**

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -25,6 +25,7 @@ import type {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useConsoleStore } from "../store/consoleStore";
+import { focusFlowTab, getFlowTitle } from "../flow-runtime/shell";
 import {
   useExplorerRevealStore,
   selectRevealFor,
@@ -42,15 +43,6 @@ interface FlowTreeNode extends ResourceTreeNode {
 
 const noopIsExpanded = () => false;
 const noopToggle = () => undefined;
-
-const getFlowTitle = (flow: any): string => {
-  if (flow.sourceType === "database") {
-    return `Query -> ${flow.tableDestination?.tableName || "Table"}`;
-  }
-  const sourceName = flow.dataSourceId?.name || "Source";
-  const destName = flow.destinationDatabaseId?.name || "Destination";
-  return `${sourceName} -> ${destName}`;
-};
 
 const classifyFlow = (flow: any): FlowTreeNode["flowKind"] => {
   if (flow.syncEngine === "cdc") return "cdc";
@@ -164,31 +156,7 @@ export function FlowsExplorer() {
     selectFlow(flowId);
     const flow = flows.find(item => item._id === flowId);
     if (!flow) return;
-
-    const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-      (tab: any) => tab.metadata?.flowId === flowId,
-    );
-
-    if (existingTab) {
-      setActiveTab(existingTab.id);
-      return;
-    }
-
-    const id = openTab({
-      title: getFlowTitle(flow),
-      content: "",
-      kind: "flow-editor",
-      metadata: {
-        flowId,
-        isNew: false,
-        flowType: flow.sourceType === "database" ? "db-scheduled" : flow.type,
-        enabled:
-          flow.type === "webhook"
-            ? flow.webhookConfig?.enabled
-            : flow.schedule?.enabled,
-      },
-    });
-    setActiveTab(id);
+    focusFlowTab(flow);
   };
 
   const sections = useMemo(() => {

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Snackbar } from "@mui/material";
 import { useUIStore } from "../store/uiStore";
-import {
-  selectTabBySettingsSection,
-  useConsoleStore,
-} from "../store/consoleStore";
+import { useConsoleStore } from "../store/consoleStore";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useAppsStore } from "../store/appsStore";
 import {
@@ -23,7 +20,11 @@ import {
 } from "../dbt-runtime/shell";
 import { useDbtStore } from "../store/dbtStore";
 import { useMcpStore } from "../store/mcpStore";
-import { focusDashboardDataSourceTab } from "../dashboard-runtime/shell";
+import {
+  focusDashboardDataSourceTab,
+  focusDashboardTab,
+} from "../dashboard-runtime/shell";
+import { focusFlowTabById } from "../flow-runtime/shell";
 import { focusNotebookTab } from "../notebook-runtime/shell";
 import {
   TAB_DEEP_LINK_PATTERNS,
@@ -51,8 +52,7 @@ export function UrlSync() {
   const { currentWorkspace } = useWorkspace();
   const { user } = useAuth();
   const loadConsole = useConsoleStore(state => state.loadConsole);
-  const openTab = useConsoleStore(state => state.openTab);
-  const setActiveTab = useConsoleStore(state => state.setActiveTab);
+  const focusOrOpenTab = useConsoleStore(state => state.focusOrOpenTab);
 
   // Derive the URL path for the currently active tab as a primitive string.
   // Returning a primitive means zustand's default Object.is comparison skips
@@ -143,44 +143,22 @@ export function UrlSync() {
       const connectorId = connectorMatch[1];
       setLeftPane("connectors");
 
-      // Check if we already have a tab for this connector
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t => t.kind === "connectors" && t.content === connectorId,
-      );
-
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        // Create a new tab for this connector
-        // We don't have the name yet, it will be fetched by ConnectorTab
-        const id = openTab({
-          title: "Connector", // Will be updated when entity loads
+      // A connector tab keeps its id in `content`; the name is fetched by
+      // ConnectorTab, so the title is a placeholder until it loads.
+      focusOrOpenTab(
+        { kind: "connectors", where: t => t.content === connectorId },
+        () => ({
+          title: "Connector",
           content: connectorId,
           kind: "connectors",
-        });
-        setActiveTab(id);
-      }
+        }),
+      );
     } else if (flowMatch) {
       // /f/:flowId
       const flowId = flowMatch[1];
       setLeftPane("flows");
 
-      // Check for existing tab
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t => t.kind === "flow-editor" && t.metadata?.flowId === flowId,
-      );
-
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        const id = openTab({
-          title: "Flow",
-          content: "",
-          kind: "flow-editor",
-          metadata: { flowId },
-        });
-        setActiveTab(id);
-      }
+      focusFlowTabById(flowId);
     } else if (dashboardDataSourceMatch) {
       // /d/:dashboardId/data/:dataSourceId
       const dashboardId = dashboardDataSourceMatch[1];
@@ -195,26 +173,15 @@ export function UrlSync() {
       const dashboardId = dashboardMatch[1];
       setLeftPane("dashboards");
 
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t => t.kind === "dashboard" && t.metadata?.dashboardId === dashboardId,
-      );
-
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        // Fetch dashboards to get the title, then open tab
+      // Focus if open; else resolve the title, then open (focusDashboardTab
+      // dedupes again in case a tab appeared while the list was loading).
+      if (!focusOrOpenTab({ kind: "dashboard", metadata: { dashboardId } })) {
         useDashboardStore
           .getState()
           .fetchDashboards(currentWorkspace.id)
           .then(dashboards => {
             const dashboard = dashboards.find(d => d._id === dashboardId);
-            const id = openTab({
-              title: dashboard?.title || "Dashboard",
-              content: "",
-              kind: "dashboard",
-              metadata: { dashboardId },
-            });
-            setActiveTab(id);
+            focusDashboardTab(dashboardId, dashboard?.title || "Dashboard");
           });
       }
     } else if (tableMatch) {
@@ -227,19 +194,15 @@ export function UrlSync() {
       const databaseId = params.get("dbid") || undefined;
       setLeftPane("databases");
 
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t =>
-          t.kind === "table-data" &&
-          t.connectionId === connectionId &&
-          t.metadata?.schema === schema &&
-          t.metadata?.table === table &&
-          (t.databaseName || undefined) === databaseName,
-      );
-
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        const id = openTab({
+      focusOrOpenTab(
+        {
+          kind: "table-data",
+          metadata: { schema, table },
+          where: t =>
+            t.connectionId === connectionId &&
+            (t.databaseName || undefined) === databaseName,
+        },
+        () => ({
           title: table,
           content: "",
           kind: "table-data",
@@ -247,9 +210,8 @@ export function UrlSync() {
           databaseId,
           databaseName,
           metadata: { schema, table },
-        });
-        setActiveTab(id);
-      }
+        }),
+      );
     } else if (appFileMatch) {
       // /a/:appId/file/:path — Apps file editor
       const appId = appFileMatch[1];
@@ -312,18 +274,11 @@ export function UrlSync() {
       const jobId = dbtJobMatch[2];
       setLeftPane("dbt");
 
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t =>
-          t.kind === "dbt-job" &&
-          t.metadata?.projectId === projectId &&
-          t.metadata?.jobId === jobId,
-      );
-
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        // Fetch jobs to resolve the title, then open the tab (placeholder
-        // title until then). focusDbtJobTab dedupes if a tab already exists.
+      // Focus if open; else resolve the title, then open (focusDbtJobTab
+      // dedupes again in case a tab appeared while jobs were loading).
+      if (
+        !focusOrOpenTab({ kind: "dbt-job", metadata: { projectId, jobId } })
+      ) {
         useDbtStore
           .getState()
           .fetchJobs(currentWorkspace.id, projectId)
@@ -355,32 +310,22 @@ export function UrlSync() {
       // /p/:chatId — plans only exist within a chat session, so we can only
       // focus a plan tab that is already present in this browser's state.
       const chatId = planMatch[1];
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        t => t.kind === "plan" && t.metadata?.chatId === chatId,
-      );
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      }
+      focusOrOpenTab({ kind: "plan", metadata: { chatId } });
     } else if (settingsSectionMatch) {
       // /settings/:section — open the explorer *and* focus the section's tab.
       const section = settingsSectionMatch[1];
       setLeftPane("settings");
 
       if (isSettingsSection(section)) {
-        const existingTab = selectTabBySettingsSection(section)(
-          useConsoleStore.getState(),
-        );
-        if (existingTab) {
-          setActiveTab(existingTab.id);
-        } else {
-          const id = openTab({
+        focusOrOpenTab(
+          { kind: "settings", where: t => t.settingsSection === section },
+          () => ({
             title: SECTION_LABELS[section],
             content: "",
             kind: "settings",
             settingsSection: section,
-          });
-          setActiveTab(id);
-        }
+          }),
+        );
       }
     } else if (settingsMatch) {
       // /settings — just show the explorer panel. No tab is forced open;

--- a/app/src/dashboard-runtime/shell.ts
+++ b/app/src/dashboard-runtime/shell.ts
@@ -6,22 +6,14 @@ export function getCurrentWorkspaceId(): string | null {
 }
 
 export function focusDashboardTab(dashboardId: string, title: string): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: any) =>
-      tab.kind === "dashboard" && tab.metadata?.dashboardId === dashboardId,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab({
+  const tabId = useConsoleStore
+    .getState()
+    .focusOrOpenTab({ kind: "dashboard", metadata: { dashboardId } }, () => ({
       title,
       content: "",
       kind: "dashboard",
       metadata: { dashboardId },
-    });
-
-  consoleStore.setActiveTab(tabId);
+    })) as string;
   useUIStore.getState().setLeftPane("dashboards");
   return tabId;
 }
@@ -35,24 +27,17 @@ export function focusDashboardDataSourceTab(
   dataSourceId: string,
   title: string,
 ): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: any) =>
-      tab.kind === "dashboard-data-source" &&
-      tab.metadata?.dashboardId === dashboardId &&
-      tab.metadata?.dataSourceId === dataSourceId,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab({
+  return useConsoleStore.getState().focusOrOpenTab(
+    {
+      kind: "dashboard-data-source",
+      metadata: { dashboardId, dataSourceId },
+    },
+    () => ({
       title,
       content: "",
       kind: "dashboard-data-source",
       isSaved: true,
       metadata: { dashboardId, dataSourceId },
-    });
-
-  consoleStore.setActiveTab(tabId);
-  return tabId;
+    }),
+  ) as string;
 }

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -1,10 +1,9 @@
 /**
- * dbt tab-open helpers — clones of app-runtime/shell.ts. Both the explorer
- * and the agent's client tools open tabs through these so dedupe behavior
- * is identical everywhere.
+ * dbt tab-open helpers. Both the explorer and the agent's client tools open
+ * tabs through these; dedupe is the store's focusOrOpenTab, like every kind.
  */
 
-import { useConsoleStore } from "../store/consoleStore";
+import { findTab, useConsoleStore } from "../store/consoleStore";
 import { useUIStore } from "../store/uiStore";
 import { useDbtStore } from "../store/dbtStore";
 
@@ -18,60 +17,36 @@ function basename(path: string): string {
 
 /** Open (or focus) a full-screen editor tab for a single dbt project file. */
 export function focusDbtFileTab(projectId: string, path: string): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: {
-      kind?: string;
-      metadata?: { projectId?: string; path?: string };
-    }) =>
-      tab.kind === "dbt-file" &&
-      tab.metadata?.projectId === projectId &&
-      tab.metadata?.path === path,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab(
-      {
-        title: basename(path),
-        content: "",
-        kind: "dbt-file",
-        metadata: { projectId, path },
-      },
-      // Each file opens its own tab instead of replacing a pristine one.
-      { replacePristine: false },
-    );
-
+  const tabId = useConsoleStore.getState().focusOrOpenTab(
+    { kind: "dbt-file", metadata: { projectId, path } },
+    () => ({
+      title: basename(path),
+      content: "",
+      kind: "dbt-file",
+      metadata: { projectId, path },
+    }),
+    // Each file opens its own tab instead of replacing a pristine one.
+    { replacePristine: false },
+  ) as string;
   useDbtStore.getState().setActiveProject(projectId);
-  consoleStore.setActiveTab(tabId);
   return tabId;
 }
 
 /** Open (or focus) the project Console tab (command bar + problems). */
 export function focusDbtConsoleTab(projectId: string, title: string): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: { kind?: string; metadata?: { projectId?: string } }) =>
-      tab.kind === "dbt-console" && tab.metadata?.projectId === projectId,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab(
-      {
-        title,
-        content: "",
-        kind: "dbt-console",
-        metadata: { projectId },
-      },
-      { replacePristine: false },
-    );
-  // A project's console is a durable document, not a preview: pin it at open
-  // (as notebooks do) so the next open cannot replace it.
-  consoleStore.updateDirty(tabId, true);
-
+  const tabId = useConsoleStore.getState().focusOrOpenTab(
+    { kind: "dbt-console", metadata: { projectId } },
+    () => ({
+      title,
+      content: "",
+      kind: "dbt-console",
+      metadata: { projectId },
+    }),
+    // A project's console is a durable document, not a preview: pinned at
+    // open (as notebooks are) so the next open cannot replace it.
+    { replacePristine: false, pin: true },
+  ) as string;
   useDbtStore.getState().setActiveProject(projectId);
-  consoleStore.setActiveTab(tabId);
   return tabId;
 }
 
@@ -86,32 +61,25 @@ export function focusDbtRunsTab(
   runId?: string,
 ): string {
   const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: { kind?: string; metadata?: { projectId?: string } }) =>
-      tab.kind === "dbt-runs" && tab.metadata?.projectId === projectId,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab(
-      {
-        title,
-        content: "",
-        kind: "dbt-runs",
-        metadata: { projectId, focusRunId: runId },
-      },
-      { replacePristine: false },
-    );
-
+  const match = { kind: "dbt-runs" as const, metadata: { projectId } };
+  const existed = Boolean(findTab(match)(consoleStore));
+  const tabId = consoleStore.focusOrOpenTab(
+    match,
+    () => ({
+      title,
+      content: "",
+      kind: "dbt-runs",
+      metadata: { projectId, focusRunId: runId },
+    }),
+    { replacePristine: false },
+  ) as string;
   // If re-focusing an existing tab with a new target run, update the metadata
   // so DbtRunsView can react and select it. updateMetadata replaces the whole
   // object, so pass the full set.
-  if (existingTab && runId) {
+  if (existed && runId) {
     consoleStore.updateMetadata(tabId, { projectId, focusRunId: runId });
   }
-
   useDbtStore.getState().setActiveProject(projectId);
-  consoleStore.setActiveTab(tabId);
   return tabId;
 }
 
@@ -126,30 +94,16 @@ export function focusDbtJobTab(
   title: string,
   autoEdit?: boolean,
 ): string {
-  const consoleStore = useConsoleStore.getState();
-  const existingTab = Object.values(consoleStore.tabs).find(
-    (tab: {
-      kind?: string;
-      metadata?: { projectId?: string; jobId?: string };
-    }) =>
-      tab.kind === "dbt-job" &&
-      tab.metadata?.projectId === projectId &&
-      tab.metadata?.jobId === jobId,
-  );
-
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab(
-      {
-        title,
-        content: "",
-        kind: "dbt-job",
-        metadata: { projectId, jobId, autoEdit },
-      },
-      { replacePristine: false },
-    );
-
+  const tabId = useConsoleStore.getState().focusOrOpenTab(
+    { kind: "dbt-job", metadata: { projectId, jobId } },
+    () => ({
+      title,
+      content: "",
+      kind: "dbt-job",
+      metadata: { projectId, jobId, autoEdit },
+    }),
+    { replacePristine: false },
+  ) as string;
   useDbtStore.getState().setActiveProject(projectId);
-  consoleStore.setActiveTab(tabId);
   return tabId;
 }

--- a/app/src/flow-runtime/shell.ts
+++ b/app/src/flow-runtime/shell.ts
@@ -1,0 +1,62 @@
+import { useConsoleStore } from "../store/consoleStore";
+import type { Flow } from "../store/flowStore";
+
+/** The title a flow row, tab and palette entry all show. Was three copies. */
+export function getFlowTitle(flow: Flow): string {
+  const f = flow as Flow & {
+    sourceType?: string;
+    tableDestination?: { tableName?: string };
+  };
+  if (f.sourceType === "database") {
+    return `Query -> ${f.tableDestination?.tableName || "Table"}`;
+  }
+  const sourceName =
+    (flow.dataSourceId as { name?: string } | undefined)?.name || "Source";
+  const destName =
+    (flow.destinationDatabaseId as { name?: string } | undefined)?.name ||
+    "Destination";
+  return `${sourceName} -> ${destName}`;
+}
+
+/**
+ * Open (or focus) the editor tab for a flow. The explorer, the command
+ * palette and deep links used to build this tab three different ways (three
+ * metadata sets); this is the one way.
+ */
+export function focusFlowTab(flow: Flow): string {
+  const f = flow as Flow & { sourceType?: string };
+  return useConsoleStore
+    .getState()
+    .focusOrOpenTab(
+      { kind: "flow-editor", metadata: { flowId: flow._id } },
+      () => ({
+        title: getFlowTitle(flow),
+        content: "",
+        kind: "flow-editor",
+        metadata: {
+          flowId: flow._id,
+          isNew: false,
+          flowType: f.sourceType === "database" ? "db-scheduled" : flow.type,
+          enabled:
+            flow.type === "webhook"
+              ? flow.webhookConfig?.enabled
+              : flow.schedule?.enabled,
+        },
+      }),
+    ) as string;
+}
+
+/**
+ * Deep link with only an id: focus the tab if open, else open a placeholder
+ * the FlowEditor fills in once the flow loads.
+ */
+export function focusFlowTabById(flowId: string): string {
+  return useConsoleStore
+    .getState()
+    .focusOrOpenTab({ kind: "flow-editor", metadata: { flowId } }, () => ({
+      title: "Flow",
+      content: "",
+      kind: "flow-editor",
+      metadata: { flowId },
+    })) as string;
+}

--- a/app/src/lib/command-palette/entity-search.ts
+++ b/app/src/lib/command-palette/entity-search.ts
@@ -9,6 +9,7 @@
 
 import { focusDashboardTab } from "../../dashboard-runtime/shell";
 import { focusDbtConsoleTab } from "../../dbt-runtime/shell";
+import { focusFlowTab, getFlowTitle } from "../../flow-runtime/shell";
 import type { ConsoleSearchResult } from "../../store/commandPaletteStore";
 import { useConsoleStore } from "../../store/consoleStore";
 import {
@@ -16,7 +17,7 @@ import {
   type DashboardEntry,
 } from "../../store/dashboardTreeStore";
 import { useDbtStore } from "../../store/dbtStore";
-import { useFlowStore, type Flow } from "../../store/flowStore";
+import { useFlowStore } from "../../store/flowStore";
 import { EXPLORER_ICONS, TAB_KIND_ICONS, tabKindIcon } from "../entity-icons";
 import { matchScore, type PaletteEntityItem } from "./types";
 
@@ -136,30 +137,13 @@ export function searchDbtProjects(query: string): PaletteEntityItem[] {
   return sorted(scored, 4);
 }
 
-/** Mirrors FlowsExplorer's title derivation for a flow row. */
-function flowTitle(flow: Flow): string {
-  const f = flow as Flow & {
-    sourceType?: string;
-    tableDestination?: { tableName?: string };
-  };
-  if (f.sourceType === "database") {
-    return `Query -> ${f.tableDestination?.tableName || "Table"}`;
-  }
-  const sourceName =
-    (flow.dataSourceId as { name?: string } | undefined)?.name || "Source";
-  const destName =
-    (flow.destinationDatabaseId as { name?: string } | undefined)?.name ||
-    "Destination";
-  return `${sourceName} -> ${destName}`;
-}
-
 export function searchFlows(
   workspaceId: string,
   query: string,
 ): PaletteEntityItem[] {
   const flows = useFlowStore.getState().flows[workspaceId] ?? [];
   const scored: Scored[] = flows.map(flow => {
-    const title = flowTitle(flow);
+    const title = getFlowTitle(flow);
     return {
       score: matchScore(query, title),
       item: {
@@ -168,32 +152,8 @@ export function searchFlows(
         section: "Flows",
         icon: EXPLORER_ICONS.flows,
         run: () => {
-          const consoleStore = useConsoleStore.getState();
           useFlowStore.getState().selectFlow(flow._id);
-          const existing = Object.values(consoleStore.tabs).find(
-            tab => tab.metadata?.flowId === flow._id,
-          );
-          if (existing) {
-            consoleStore.setActiveTab(existing.id);
-            return;
-          }
-          const f = flow as Flow & { sourceType?: string };
-          const id = consoleStore.openTab({
-            title,
-            content: "",
-            kind: "flow-editor",
-            metadata: {
-              flowId: flow._id,
-              isNew: false,
-              flowType:
-                f.sourceType === "database" ? "db-scheduled" : flow.type,
-              enabled:
-                flow.type === "webhook"
-                  ? flow.webhookConfig?.enabled
-                  : flow.schedule?.enabled,
-            },
-          });
-          consoleStore.setActiveTab(id);
+          focusFlowTab(flow);
         },
       },
     };

--- a/app/src/notebook-runtime/shell.ts
+++ b/app/src/notebook-runtime/shell.ts
@@ -1,36 +1,22 @@
 import { useConsoleStore } from "../store/consoleStore";
 
 /**
- * Open (or focus) the editor tab for a notebook. Mirrors `focusAppTab`
- * (app-runtime/shell.ts): the generic tab store (`consoleStore`) owns all tab
- * kinds, so a notebook tab is just `kind: "notebook"` with the id in metadata.
+ * Open (or focus) the editor tab for a notebook. The generic tab store owns
+ * all tab kinds, so a notebook tab is just `kind: "notebook"` with the id in
+ * metadata. Notebooks are durable documents, not previews: they open pinned
+ * and never evict a pristine tab, so several stay open at once.
  */
 export function focusNotebookTab(notebookId: string, title: string): string {
-  const consoleStore = useConsoleStore.getState();
-  const existing = Object.values(consoleStore.tabs).find(
-    (tab: { kind?: string; metadata?: { notebookId?: string } }) =>
-      tab.kind === "notebook" && tab.metadata?.notebookId === notebookId,
-  );
-  const tabId =
-    existing?.id ??
-    consoleStore.openTab(
-      {
-        title,
-        content: "",
-        kind: "notebook",
-        // Notebooks own their own persistence — never auto-save as a console.
-        isSaved: true,
-        metadata: { notebookId },
-      },
-      // Notebooks are durable documents, not "preview" tabs: opening one must
-      // not evict an existing pristine tab.
-      { replacePristine: false },
-    );
-  // Pin the tab (mark it non-pristine) so a later open — another notebook or a
-  // scratch console — doesn't replace it. This is what lets several notebooks
-  // stay open at once, like consoles and dashboards. Renders non-italic (a
-  // permanent tab), with no "unsaved" indicator.
-  consoleStore.updateDirty(tabId, true);
-  consoleStore.setActiveTab(tabId);
-  return tabId;
+  return useConsoleStore.getState().focusOrOpenTab(
+    { kind: "notebook", metadata: { notebookId } },
+    () => ({
+      title,
+      content: "",
+      kind: "notebook",
+      // Notebooks own their own persistence — never auto-save as a console.
+      isSaved: true,
+      metadata: { notebookId },
+    }),
+    { replacePristine: false, pin: true },
+  ) as string;
 }

--- a/app/src/store/consoleStore.test.ts
+++ b/app/src/store/consoleStore.test.ts
@@ -230,3 +230,110 @@ describe("consoleStore preview-tab invariant (kind-agnostic)", () => {
     expect(useConsoleStore.getState().tabOrder).toEqual(["a1"]);
   });
 });
+
+describe("consoleStore focusOrOpenTab — the one open-or-focus primitive", () => {
+  beforeEach(() => {
+    resetConsoleStore();
+  });
+
+  it("opens when nothing matches, focuses (without reopening) when it does", () => {
+    const store = useConsoleStore.getState();
+    const first = store.focusOrOpenTab(
+      { kind: "dashboard", metadata: { dashboardId: "d1" } },
+      () => ({
+        title: "Sales",
+        content: "",
+        kind: "dashboard",
+        metadata: { dashboardId: "d1" },
+      }),
+    );
+    expect(first).not.toBeNull();
+    const again = store.focusOrOpenTab(
+      { kind: "dashboard", metadata: { dashboardId: "d1" } },
+      () => ({
+        title: "Sales",
+        content: "",
+        kind: "dashboard",
+        metadata: { dashboardId: "d1" },
+      }),
+    );
+    expect(again).toBe(first);
+    expect(useConsoleStore.getState().tabOrder).toEqual([first]);
+    expect(useConsoleStore.getState().activeTabId).toBe(first);
+  });
+
+  it("matches on kind AND every listed metadata key", () => {
+    const store = useConsoleStore.getState();
+    const a = store.focusOrOpenTab(
+      { kind: "app-file", metadata: { appId: "a", path: "x.ts" } },
+      () => ({
+        title: "x.ts",
+        content: "",
+        kind: "app-file",
+        metadata: { appId: "a", path: "x.ts" },
+      }),
+    );
+    useConsoleStore.getState().updateDirty(a as string, true);
+    const b = store.focusOrOpenTab(
+      { kind: "app-file", metadata: { appId: "a", path: "y.ts" } },
+      () => ({
+        title: "y.ts",
+        content: "",
+        kind: "app-file",
+        metadata: { appId: "a", path: "y.ts" },
+      }),
+    );
+    expect(b).not.toBe(a);
+    // Same metadata, different kind: not the same entity.
+    const c = store.focusOrOpenTab(
+      { kind: "app-diff", metadata: { appId: "a", path: "x.ts" } },
+      () => ({
+        title: "x.ts (diff)",
+        content: "",
+        kind: "app-diff",
+        metadata: { appId: "a", path: "x.ts" },
+      }),
+    );
+    expect(c).not.toBe(a);
+  });
+
+  it("is 'focus if present' when create is omitted", () => {
+    const store = useConsoleStore.getState();
+    expect(
+      store.focusOrOpenTab({ kind: "plan", metadata: { chatId: "c" } }),
+    ).toBeNull();
+    expect(useConsoleStore.getState().tabOrder).toEqual([]);
+  });
+
+  it("refreshes the title of an existing tab and can pin it", () => {
+    const store = useConsoleStore.getState();
+    const id = store.focusOrOpenTab(
+      { kind: "app", metadata: { appId: "a" } },
+      () => ({
+        title: "Old",
+        content: "",
+        kind: "app",
+        metadata: { appId: "a" },
+      }),
+    ) as string;
+    store.focusOrOpenTab({ kind: "app", metadata: { appId: "a" } }, undefined, {
+      title: "New",
+      pin: true,
+    });
+    expect(useConsoleStore.getState().tabs[id].title).toBe("New");
+    expect(useConsoleStore.getState().tabs[id].isDirty).toBe(true);
+  });
+
+  it("supports a predicate for identity that is not in metadata", () => {
+    const store = useConsoleStore.getState();
+    const id = store.focusOrOpenTab(
+      { kind: "connectors", where: t => t.content === "cx1" },
+      () => ({ title: "Connector", content: "cx1", kind: "connectors" }),
+    );
+    const again = store.focusOrOpenTab(
+      { kind: "connectors", where: t => t.content === "cx1" },
+      () => ({ title: "Connector", content: "cx1", kind: "connectors" }),
+    );
+    expect(again).toBe(id);
+  });
+});

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -41,13 +41,45 @@ interface ConsoleState {
   error: Record<string, string | null>;
 }
 
+/** What `openTab` accepts — named so the open-or-focus primitive can share it. */
+export type OpenTabInput = Omit<ConsoleTab, "id" | "isSaved"> & {
+  id?: string;
+  isSaved?: boolean;
+};
+
+/**
+ * How an entity is recognised among open tabs: its kind, the metadata keys
+ * that identify it (every listed key must be equal — `undefined` included),
+ * and, for identity that does not live in metadata (a connection id, a
+ * connector held in `content`), a predicate.
+ */
+export interface TabMatch {
+  kind: TabKind;
+  metadata?: Record<string, unknown>;
+  where?: (tab: ConsoleTab) => boolean;
+}
+
+export function matchesTab(tab: ConsoleTab, match: TabMatch): boolean {
+  if ((tab.kind ?? "console") !== match.kind) return false;
+  if (match.metadata) {
+    const meta = (tab.metadata ?? {}) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(match.metadata)) {
+      if (meta[key] !== value) return false;
+    }
+  }
+  return match.where ? match.where(tab) : true;
+}
+
+/** The open tab showing this entity, if any. Pure — usable as a selector. */
+export const findTab =
+  (match: TabMatch) =>
+  (state: { tabs: Record<string, ConsoleTab> }): ConsoleTab | undefined =>
+    Object.values(state.tabs).find(tab => matchesTab(tab, match));
+
 interface ConsoleActions {
   // Tab management
   openTab: (
-    tab: Omit<ConsoleTab, "id" | "isSaved"> & {
-      id?: string;
-      isSaved?: boolean;
-    },
+    tab: OpenTabInput,
     options?: {
       /**
        * When false, never close the "first pristine tab" to make room (VS
@@ -63,6 +95,26 @@ interface ConsoleActions {
       preserveMissingSavedStateHash?: boolean;
     },
   ) => string;
+  /**
+   * THE way to open an entity tab: focus the tab that already shows this
+   * entity (by kind + metadata, plus an optional predicate), else open one
+   * from `create` and focus it. Returns the tab id; null when nothing
+   * matched and `create` declined (returned null) — "focus if present".
+   *
+   * `options.title` refreshes the title of an already-open tab (an entity
+   * renamed elsewhere); `options.pin` pins the tab (durable documents that
+   * must never be preview-replaced: notebooks, dbt consoles).
+   *
+   * Before this existed the same find-then-open was written out ~20 times
+   * across the runtimes' shell.ts files, explorers, UrlSync and the command
+   * palette — each with its own predicate shape, and three flow openers
+   * with three different metadata sets.
+   */
+  focusOrOpenTab: (
+    match: TabMatch,
+    create?: () => OpenTabInput | null,
+    options?: { replacePristine?: boolean; title?: string; pin?: boolean },
+  ) => string | null;
   closeTab: (id: string) => void;
   setActiveTab: (id: string | null) => void;
   clearAllConsoles: () => void;
@@ -639,6 +691,32 @@ export const useConsoleStore = create<ConsoleStore>()(
           state.activeTabId = id;
         });
 
+        return id;
+      },
+
+      focusOrOpenTab: (match, create, options) => {
+        const existing = findTab(match)(get());
+        if (existing) {
+          if (options?.title && options.title !== existing.title) {
+            set(state => {
+              const tab = state.tabs[existing.id];
+              if (tab) tab.title = options.title as string;
+            });
+          }
+          if (options?.pin) get().updateDirty(existing.id, true);
+          get().setActiveTab(existing.id);
+          return existing.id;
+        }
+        const input = create?.();
+        if (!input) return null;
+        const id = get().openTab(
+          input,
+          options?.replacePristine === undefined
+            ? undefined
+            : { replacePristine: options.replacePristine },
+        );
+        if (options?.pin) get().updateDirty(id, true);
+        get().setActiveTab(id);
         return id;
       },
 
@@ -2194,10 +2272,11 @@ export const selectConsoleById =
 export const selectTabByKind =
   (kind: TabKind) =>
   (state: ConsoleStore): ConsoleTab | undefined =>
-    Object.values(state.tabs).find(tab => tab.kind === kind);
+    findTab({ kind })(state);
 export const selectTabBySettingsSection =
   (section: SettingsSection) =>
   (state: ConsoleStore): ConsoleTab | undefined =>
-    Object.values(state.tabs).find(
-      tab => tab.kind === "settings" && tab.settingsSection === section,
-    );
+    findTab({
+      kind: "settings",
+      where: tab => tab.settingsSection === section,
+    })(state);


### PR DESCRIPTION
## Why

"Find the existing tab for this entity, else open it, then focus it" existed in **20 copies across 8 files**, each with its own predicate shape; the flow editor alone was opened three different ways with three metadata sets, and its title had two copies (one commented *"mirrors FlowsExplorer's"*).

## What

- `consoleStore.focusOrOpenTab(match, create?, options?)` — `match` = `{ kind, metadata?, where? }` (every listed metadata key must equal; `where` for identity not in metadata, e.g. connector id in `content`). Focuses the existing tab or opens `create()`; omit `create` for "focus if present". `options.title` refreshes a renamed entity's tab title; `options.pin` pins durable documents (notebooks, dbt console); `replacePristine` passes through.
- Pure `findTab(match)` selector; `selectTabByKind` / `selectTabBySettingsSection` now use it.
- Rewritten on it: `apps-runtime/shell.ts` (3), `dashboard-runtime/shell.ts` (2), `dbt-runtime/shell.ts` (4), `notebook-runtime/shell.ts`, `UrlSync` (7), `FlowsExplorer`, command palette. New `flow-runtime/shell.ts` with the one `focusFlowTab` / `getFlowTitle`.
- 5 new `consoleStore` tests; `grep "Object.values(.*tabs).find"` now hits only the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
