### PR TITLE
feat(apps): the Source Control graph renders the same CommitRow as History

### DIFF
--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -1473,13 +1473,17 @@ const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 export async function commitChanges(
   project: IAppProject,
   sha: string,
+  /** "repo": every file, repo-relative — the Source Control graph's view. */
+  scope: "app" | "repo" = "app",
 ): Promise<{ sha: string; parent: string | null; files: ChangedFile[] }> {
   const repoDir = await repoFor(project);
   const oid = await resolveCommit(repoDir, sha);
   if (!oid) throw new Error(`No such commit: ${sha}`);
   const parent = await resolveCommit(repoDir, `${oid}^`);
+  const all = await diffNameStatus(repoDir, parent ?? EMPTY_TREE, oid);
+  if (scope === "repo") return { sha: oid, parent, files: all };
   const root = appRootFor(project);
-  const files = (await diffNameStatus(repoDir, parent ?? EMPTY_TREE, oid))
+  const files = all
     .filter(f => f.path.startsWith(`${root}/`))
     .map(f => ({ ...f, path: f.path.slice(root.length + 1) }));
   return { sha: oid, parent, files };

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -1311,13 +1311,16 @@ appsRoutes.openapi(
     method: "get",
     path: "/{id}/git/commit",
     tags: ["Apps"],
-    summary: "What one commit changed in this app",
+    summary: "What one commit changed (in this app, or repo-wide)",
     description:
-      "The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.",
+      "The commit's parent and the files it added, modified, deleted or renamed — app-relative by default, repo-relative with scope=repo (the Source Control graph). Read from the repository — starts no sandbox.",
     security: AUTH_SECURITY,
     request: {
       params: ProjectParam,
-      query: z.object({ sha: z.string().regex(/^[0-9a-f]{7,40}$/) }),
+      query: z.object({
+        sha: z.string().regex(/^[0-9a-f]{7,40}$/),
+        scope: z.enum(["app", "repo"]).optional(),
+      }),
     },
     responses: OPEN_RESPONSES,
   }),
@@ -1325,8 +1328,8 @@ appsRoutes.openapi(
     try {
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
-      const { sha } = c.req.valid("query");
-      const commit = await commitChanges(loaded.project, sha);
+      const { sha, scope } = c.req.valid("query");
+      const commit = await commitChanges(loaded.project, sha, scope ?? "app");
       return c.json({ success: true as const, commit }, 200);
     } catch (error) {
       return handleError(c, error);

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3859,8 +3859,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * What one commit changed in this app
-         * @description The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.
+         * What one commit changed (in this app, or repo-wide)
+         * @description The commit's parent and the files it added, modified, deleted or renamed — app-relative by default, repo-relative with scope=repo (the Source Control graph). Read from the repository — starts no sandbox.
          */
         get: operations["get_api_workspaces_workspaceId_apps_id_git_commit"];
         put?: never;
@@ -18071,6 +18071,7 @@ export interface operations {
         parameters: {
             query: {
                 sha: string;
+                scope?: "app" | "repo";
             };
             header?: never;
             path: {

--- a/app/src/components/AppHistoryPopover.tsx
+++ b/app/src/components/AppHistoryPopover.tsx
@@ -15,39 +15,27 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Collapse,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  IconButton,
   ListItemIcon,
   ListItemText,
   Menu,
   MenuItem,
   Popover,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import {
-  ChevronDown as ExpandIcon,
-  ChevronRight as CollapsedIcon,
   Copy as CopyIcon,
   FileDiff as DiffIcon,
-  MoreHorizontal as MoreIcon,
   Rocket as LiveIcon,
   Undo2 as RestoreIcon,
 } from "lucide-react";
 import { useAppsStore, type AppCommit } from "../store/appsStore";
 import { focusAppsDiffTab } from "../apps-runtime/shell";
-
-const STATUS_LETTER: Record<string, string> = {
-  added: "A",
-  modified: "M",
-  deleted: "D",
-  renamed: "R",
-};
+import { CommitChip, CommitRow } from "./CommitRow";
 
 function errorMessage(e: unknown, fallback: string): string {
   return e instanceof Error && e.message ? e.message : fallback;
@@ -198,165 +186,32 @@ export default function AppHistoryPopover({
               No commits yet.
             </Typography>
           )}
-          {commits.map(c => {
-            const isLive = !!publishedSha && c.oid === publishedSha;
-            const isHead = c.oid === headOid;
-            const isOpen = expanded === c.oid;
-            const files = commitFiles?.[c.oid];
-            return (
-              <Box key={c.oid} sx={{ borderBottom: 1, borderColor: "divider" }}>
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "flex-start",
-                    gap: 0.5,
-                    px: 1,
-                    py: 1,
-                    cursor: "pointer",
-                    "&:hover": { bgcolor: "action.hover" },
-                  }}
-                  onClick={() => toggleFiles(c.oid)}
-                >
-                  <Box sx={{ pt: 0.25, color: "text.secondary" }}>
-                    {isOpen ? (
-                      <ExpandIcon size={16} />
-                    ) : (
-                      <CollapsedIcon size={16} />
-                    )}
-                  </Box>
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: "text.primary",
-                        overflowWrap: "anywhere",
-                        display: "-webkit-box",
-                        WebkitLineClamp: isOpen ? "unset" : 2,
-                        WebkitBoxOrient: "vertical",
-                        overflow: "hidden",
-                      }}
-                    >
-                      {c.subject}
-                    </Typography>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        mt: 0.25,
-                        flexWrap: "wrap",
-                      }}
-                    >
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        sx={{ fontFamily: "monospace" }}
-                      >
-                        {c.oid.slice(0, 7)}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {c.author} · {new Date(c.timestamp).toLocaleString()}
-                      </Typography>
-                      {isLive && (
-                        <Chip
-                          size="small"
-                          color="success"
-                          icon={<LiveIcon size={12} />}
-                          label="Live"
-                          sx={{ height: 18, fontSize: "0.65rem" }}
-                        />
-                      )}
-                      {isHead && (
-                        <Chip
-                          size="small"
-                          variant="outlined"
-                          label="Latest"
-                          sx={{ height: 18, fontSize: "0.65rem" }}
-                        />
-                      )}
-                    </Box>
-                  </Box>
-                  <Tooltip title="Actions">
-                    <IconButton
-                      size="small"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setMenu({ anchor: e.currentTarget, commit: c });
-                      }}
-                    >
-                      <MoreIcon size={16} />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-                <Collapse in={isOpen} unmountOnExit>
-                  <Box sx={{ pl: 4, pr: 1, pb: 1 }}>
-                    {!files ? (
-                      <CircularProgress size={14} sx={{ ml: 1, my: 0.5 }} />
-                    ) : files.length === 0 ? (
-                      <Typography variant="caption" color="text.secondary">
-                        No files of this app changed in this commit.
-                      </Typography>
-                    ) : (
-                      files.map(f => (
-                        <Box
-                          key={f.path}
-                          onClick={e => {
-                            e.stopPropagation();
-                            focusAppsDiffTab(
-                              appId,
-                              f.path,
-                              "commit",
-                              slug,
-                              c.oid,
-                            );
-                            onClose();
-                          }}
-                          sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 1,
-                            px: 1,
-                            py: 0.25,
-                            borderRadius: 1,
-                            cursor: "pointer",
-                            "&:hover": { bgcolor: "action.hover" },
-                          }}
-                        >
-                          <Typography
-                            variant="caption"
-                            sx={{
-                              fontFamily: "monospace",
-                              width: 12,
-                              color:
-                                f.status === "deleted"
-                                  ? "error.main"
-                                  : f.status === "added"
-                                    ? "success.main"
-                                    : "text.secondary",
-                            }}
-                          >
-                            {STATUS_LETTER[f.status] ?? "M"}
-                          </Typography>
-                          <Typography
-                            variant="caption"
-                            sx={{
-                              fontFamily: "monospace",
-                              color: "text.primary",
-                              overflowWrap: "anywhere",
-                            }}
-                          >
-                            {f.path}
-                          </Typography>
-                          <Box sx={{ flex: 1 }} />
-                          <DiffIcon size={13} style={{ opacity: 0.6 }} />
-                        </Box>
-                      ))
-                    )}
-                  </Box>
-                </Collapse>
-              </Box>
-            );
-          })}
+          {commits.map(c => (
+            <CommitRow
+              key={c.oid}
+              commit={c}
+              expanded={expanded === c.oid}
+              onToggle={() => toggleFiles(c.oid)}
+              files={commitFiles?.[c.oid]}
+              onFileClick={f => {
+                focusAppsDiffTab(appId, f.path, "commit", slug, c.oid);
+                onClose();
+              }}
+              onMenu={anchor => setMenu({ anchor, commit: c })}
+              chips={
+                <>
+                  {!!publishedSha && c.oid === publishedSha && (
+                    <CommitChip
+                      label="Live"
+                      color="success"
+                      icon={<LiveIcon size={12} />}
+                    />
+                  )}
+                  {c.oid === headOid && <CommitChip label="Latest" outlined />}
+                </>
+              }
+            />
+          ))}
         </Box>
       </Popover>
 
@@ -431,7 +286,7 @@ export default function AppHistoryPopover({
           <DialogContentText>
             {confirm?.kind === "restore" ? (
               <>
-                The app's files go back to what they were in{" "}
+                The app&apos;s files go back to what they were in{" "}
                 <b>{confirm.commit.subject}</b> (
                 <code>{confirm.commit.oid.slice(0, 7)}</code>), as a new commit
                 on <b>{branch}</b>. Everything after it stays in the history, so

--- a/app/src/components/CommitRow.tsx
+++ b/app/src/components/CommitRow.tsx
@@ -1,0 +1,252 @@
+/**
+ * ONE commit, wherever commits are listed — the app History popover and the
+ * Source Control graph render this same row, so they read the same and act
+ * the same: subject, `sha · author · when` (relative or absolute, the other
+ * on hover), chips, a ⋯ menu, and an expandable list of the files the commit
+ * touched, each opening its diff.
+ */
+import { formatDistanceToNowStrict } from "date-fns";
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ChevronDown as ExpandIcon,
+  ChevronRight as CollapsedIcon,
+  FileDiff as DiffIcon,
+  MoreHorizontal as MoreIcon,
+} from "lucide-react";
+import type { AppCommit, AppCommitFile } from "../store/appsStore";
+
+const STATUS_LETTER: Record<string, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+export function CommitRow({
+  commit,
+  dense = false,
+  timeFormat = "absolute",
+  chips,
+  expanded,
+  onToggle,
+  files,
+  onFileClick,
+  onMenu,
+  leading,
+}: {
+  commit: AppCommit;
+  /** Sidebar rail: one line, ellipsis; the popover shows two wrapped lines. */
+  dense?: boolean;
+  timeFormat?: "absolute" | "relative";
+  chips?: React.ReactNode;
+  expanded: boolean;
+  onToggle: () => void;
+  /** undefined = loading; [] = nothing in scope. */
+  files?: AppCommitFile[];
+  /** Absent → the file is listed but not openable (outside any app). */
+  onFileClick?: (file: AppCommitFile) => void;
+  onMenu?: (anchor: HTMLElement) => void;
+  /** Replaces the chevron (the graph's rail dot). */
+  leading?: React.ReactNode;
+}) {
+  const when = new Date(commit.timestamp);
+  const absolute = when.toLocaleString();
+  const relative = formatDistanceToNowStrict(when, { addSuffix: true });
+  return (
+    <Box sx={{ borderBottom: dense ? 0 : 1, borderColor: "divider" }}>
+      <Box
+        onClick={onToggle}
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 0.5,
+          px: dense ? 1.5 : 1,
+          py: dense ? 0.5 : 1,
+          cursor: "pointer",
+          "&:hover": { bgcolor: "action.hover" },
+          "&:hover .commit-row-menu": { opacity: 1 },
+        }}
+      >
+        <Box sx={{ pt: dense ? 0.4 : 0.25, color: "text.secondary" }}>
+          {leading ??
+            (expanded ? <ExpandIcon size={16} /> : <CollapsedIcon size={16} />)}
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.primary",
+              fontSize: dense ? 13 : undefined,
+              ...(dense && !expanded
+                ? {
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }
+                : {
+                    overflowWrap: "anywhere",
+                    display: "-webkit-box",
+                    WebkitLineClamp: expanded ? "unset" : 2,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }),
+            }}
+          >
+            {commit.subject}
+          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              mt: 0.25,
+              flexWrap: dense ? "nowrap" : "wrap",
+              minWidth: 0,
+            }}
+          >
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ fontFamily: "monospace", flexShrink: 0 }}
+            >
+              {commit.oid.slice(0, 7)}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {commit.author}
+            </Typography>
+            <Tooltip title={timeFormat === "relative" ? absolute : relative}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ flexShrink: 0, whiteSpace: "nowrap" }}
+              >
+                · {timeFormat === "relative" ? relative : absolute}
+              </Typography>
+            </Tooltip>
+            {chips}
+          </Box>
+        </Box>
+        {onMenu && (
+          <Tooltip title="Actions">
+            <IconButton
+              className="commit-row-menu"
+              size="small"
+              sx={{ opacity: dense ? 0 : 1, transition: "opacity 120ms" }}
+              onClick={e => {
+                e.stopPropagation();
+                onMenu(e.currentTarget);
+              }}
+            >
+              <MoreIcon size={16} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+      <Collapse in={expanded} unmountOnExit>
+        <Box sx={{ pl: dense ? 4.5 : 4, pr: 1, pb: 1 }}>
+          {!files ? (
+            <CircularProgress size={14} sx={{ ml: 1, my: 0.5 }} />
+          ) : files.length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              No files changed.
+            </Typography>
+          ) : (
+            files.map(f => {
+              const openable = Boolean(onFileClick);
+              return (
+                <Box
+                  key={f.path}
+                  onClick={e => {
+                    e.stopPropagation();
+                    onFileClick?.(f);
+                  }}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    px: 1,
+                    py: 0.25,
+                    borderRadius: 1,
+                    cursor: openable ? "pointer" : "default",
+                    "&:hover": openable ? { bgcolor: "action.hover" } : {},
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      fontFamily: "monospace",
+                      width: 12,
+                      flexShrink: 0,
+                      color:
+                        f.status === "deleted"
+                          ? "error.main"
+                          : f.status === "added"
+                            ? "success.main"
+                            : "text.secondary",
+                    }}
+                  >
+                    {STATUS_LETTER[f.status] ?? "M"}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      fontFamily: "monospace",
+                      color: "text.primary",
+                      overflowWrap: "anywhere",
+                      minWidth: 0,
+                    }}
+                  >
+                    {f.path}
+                  </Typography>
+                  <Box sx={{ flex: 1 }} />
+                  {openable && <DiffIcon size={13} style={{ opacity: 0.6 }} />}
+                </Box>
+              );
+            })
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+/** Small status chip shared by both commit lists. */
+export function CommitChip({
+  label,
+  color,
+  icon,
+  outlined,
+}: {
+  label: string;
+  color?: "success" | "primary" | "default";
+  icon?: React.ReactElement;
+  outlined?: boolean;
+}) {
+  return (
+    <Chip
+      size="small"
+      color={color}
+      variant={outlined ? "outlined" : "filled"}
+      icon={icon}
+      label={label}
+      sx={{ height: 18, fontSize: "0.65rem" }}
+    />
+  );
+}

--- a/app/src/components/SourceControlExplorer.tsx
+++ b/app/src/components/SourceControlExplorer.tsx
@@ -49,9 +49,17 @@ import {
   RefreshCw as RefreshIcon,
   RotateCcw as DiscardIcon,
   SquareArrowOutUpRight as OpenFileIcon,
+  Copy as CopyIcon,
+  FileDiff as DiffIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
-import { useAppsStore, type AppChange } from "../store/appsStore";
+import {
+  useAppsStore,
+  type AppChange,
+  type AppCommit,
+  type AppCommitFile,
+} from "../store/appsStore";
+import { CommitRow } from "./CommitRow";
 import {
   useConsoleStore,
   selectTabBySettingsSection,
@@ -432,6 +440,46 @@ export default function SourceControlExplorer() {
   );
 
   const commits = useMemo(() => history ?? [], [history]);
+
+  // Graph rows are the SAME CommitRow the app History popover uses — with
+  // repo-wide changed files, since the graph is the whole repository.
+  const fetchCommitFiles = useAppsStore(s => s.fetchCommitFiles);
+  const commitFilesByApp = useAppsStore(s => s.commitFilesByApp);
+  const graphFiles = useMemo(() => {
+    const byKey = appId ? (commitFilesByApp[appId] ?? {}) : {};
+    const out: Record<string, AppCommitFile[]> = {};
+    for (const [key, files] of Object.entries(byKey)) {
+      if (key.startsWith("repo:")) out[key.slice(5)] = files;
+    }
+    return out;
+  }, [commitFilesByApp, appId]);
+  const [graphExpanded, setGraphExpanded] = useState<string | null>(null);
+  const [graphMenu, setGraphMenu] = useState<{
+    anchor: HTMLElement;
+    commit: AppCommit;
+  } | null>(null);
+  const toggleGraphCommit = useCallback(
+    (oid: string) => {
+      const next = graphExpanded === oid ? null : oid;
+      setGraphExpanded(next);
+      if (next && workspaceId && appId) {
+        void fetchCommitFiles(workspaceId, appId, next, "repo");
+      }
+    },
+    [graphExpanded, fetchCommitFiles, workspaceId, appId],
+  );
+  // A repo path opens as the owning app's commit diff; files outside any
+  // app (a root README) are listed but not openable.
+  const openRepoFileDiff = useCallback(
+    (oid: string) => (file: AppCommitFile) => {
+      const m = file.path.match(/^apps\/([^/]+)\/(.+)$/);
+      if (!m) return;
+      const app = apps.find(a => a.slug === m[1]);
+      if (!app) return;
+      focusAppsDiffTab(app.id, m[2], "commit", app.slug, oid);
+    },
+    [apps],
+  );
 
   if (!workspaceId) return null;
 
@@ -889,80 +937,80 @@ export default function SourceControlExplorer() {
                   </Typography>
                 )}
                 {commits.map((entry, index) => (
-                  <Box
+                  <CommitRow
                     key={entry.oid}
-                    title={`${entry.oid.slice(0, 8)} — ${entry.author}`}
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 1,
-                      px: 1.5,
-                      py: 0.4,
-                      minWidth: 0,
-                      overflow: "hidden",
-                      "&:hover": { bgcolor: "action.hover" },
-                    }}
-                  >
-                    {/* The rail dot; VS Code rings the newest commit. */}
-                    <Box
-                      sx={{
-                        width: 9,
-                        height: 9,
-                        borderRadius: "50%",
-                        flexShrink: 0,
-                        bgcolor: index === 0 ? "transparent" : "primary.main",
-                        border: index === 0 ? 2 : 0,
-                        borderColor: "primary.main",
-                      }}
-                    />
-                    {/* Subject owns the row; the author yields. VS Code does
-                      the same — with both fighting for the same pixels the
-                      subject collapsed to two letters in a narrow rail while
-                      an email address took the line. */}
-                    <Box
-                      component="span"
-                      sx={{
-                        flex: 1,
-                        minWidth: 40,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        fontSize: 13,
-                      }}
-                    >
-                      {entry.subject}
-                    </Box>
-                    <Box
-                      component="span"
-                      sx={{
-                        color: "text.disabled",
-                        fontSize: 11.5,
-                        flexShrink: 1,
-                        minWidth: 0,
-                        maxWidth: "35%",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {entry.author}
-                    </Box>
-                    {index === 0 && (
-                      <Chip
-                        icon={<BranchIcon size={11} />}
-                        label={branch}
-                        size="small"
-                        color="primary"
+                    commit={entry}
+                    dense
+                    timeFormat="relative"
+                    expanded={graphExpanded === entry.oid}
+                    onToggle={() => toggleGraphCommit(entry.oid)}
+                    files={graphFiles[entry.oid]}
+                    onFileClick={openRepoFileDiff(entry.oid)}
+                    onMenu={anchor => setGraphMenu({ anchor, commit: entry })}
+                    leading={
+                      // The rail dot; VS Code rings the newest commit.
+                      <Box
                         sx={{
-                          ml: "auto",
-                          height: 18,
-                          fontSize: "0.66rem",
+                          width: 9,
+                          height: 9,
+                          mt: 0.6,
+                          borderRadius: "50%",
                           flexShrink: 0,
+                          bgcolor: index === 0 ? "transparent" : "primary.main",
+                          border: index === 0 ? 2 : 0,
+                          borderColor: "primary.main",
                         }}
                       />
-                    )}
-                  </Box>
+                    }
+                    chips={
+                      index === 0 ? (
+                        <Chip
+                          icon={<BranchIcon size={11} />}
+                          label={branch}
+                          size="small"
+                          color="primary"
+                          sx={{
+                            height: 18,
+                            fontSize: "0.66rem",
+                            flexShrink: 0,
+                          }}
+                        />
+                      ) : undefined
+                    }
+                  />
                 ))}
+                <Menu
+                  anchorEl={graphMenu?.anchor ?? null}
+                  open={Boolean(graphMenu)}
+                  onClose={() => setGraphMenu(null)}
+                >
+                  <MenuItem
+                    onClick={() => {
+                      if (graphMenu) toggleGraphCommit(graphMenu.commit.oid);
+                      setGraphMenu(null);
+                    }}
+                  >
+                    <ListItemIcon>
+                      <DiffIcon size={16} />
+                    </ListItemIcon>
+                    <ListItemText>View changes</ListItemText>
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      if (graphMenu) {
+                        void navigator.clipboard?.writeText(
+                          graphMenu.commit.oid,
+                        );
+                      }
+                      setGraphMenu(null);
+                    }}
+                  >
+                    <ListItemIcon>
+                      <CopyIcon size={16} />
+                    </ListItemIcon>
+                    <ListItemText>Copy commit SHA</ListItemText>
+                  </MenuItem>
+                </Menu>
               </Box>
             </Section>
           </>

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -364,11 +364,15 @@ interface AppsStore {
     action: "stage" | "unstage" | "discard",
     paths: string[],
   ) => Promise<{ ok: boolean; error?: string }>;
-  /** What one commit changed in this app. Cached per (app, sha). */
+  /**
+   * What one commit changed — in this app (app-relative paths) or, with
+   * scope "repo", across the repository (repo-relative). Cached per key.
+   */
   fetchCommitFiles: (
     workspaceId: string,
     appId: string,
     sha: string,
+    scope?: "app" | "repo",
   ) => Promise<AppCommitFile[] | null>;
   fetchCommitFileVersions: (
     workspaceId: string,
@@ -1165,21 +1169,25 @@ export const useAppsStore = create<AppsStore>()(
         }
       },
 
-      fetchCommitFiles: async (workspaceId, appId, sha) => {
-        const cached = get().commitFilesByApp[appId]?.[sha];
+      fetchCommitFiles: async (workspaceId, appId, sha, scope = "app") => {
+        const key = scope === "repo" ? `repo:${sha}` : sha;
+        const cached = get().commitFilesByApp[appId]?.[key];
         if (cached) return cached;
         try {
           const body = unwrapBody(
             await api.GET(
               "/api/workspaces/{workspaceId}/apps/{id}/git/commit",
               {
-                params: { path: { workspaceId, id: appId }, query: { sha } },
+                params: {
+                  path: { workspaceId, id: appId },
+                  query: { sha, scope },
+                },
               },
             ),
           ) as { commit?: { files?: AppCommitFile[] } };
           const files = body.commit?.files ?? [];
           set(s => {
-            (s.commitFilesByApp[appId] ??= {})[sha] = files;
+            (s.commitFilesByApp[appId] ??= {})[key] = files;
           });
           return files;
         } catch (e) {

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -24235,8 +24235,8 @@
         "tags": [
           "Apps"
         ],
-        "summary": "What one commit changed in this app",
-        "description": "The commit's parent and the app-relative files it added, modified, deleted or renamed. Read from the repository — starts no sandbox.",
+        "summary": "What one commit changed (in this app, or repo-wide)",
+        "description": "The commit's parent and the files it added, modified, deleted or renamed — app-relative by default, repo-relative with scope=repo (the Source Control graph). Read from the repository — starts no sandbox.",
         "security": [
           {
             "cookieAuth": []
@@ -24269,6 +24269,18 @@
             },
             "required": true,
             "name": "sha",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "app",
+                "repo"
+              ]
+            },
+            "required": false,
+            "name": "scope",
             "in": "query"
           }
         ],


### PR DESCRIPTION
## Why

The graph rows had a subject, an author and a sha tooltip — no time, nothing actionable — next to the new History panel that has all of it. Two renderings of the same thing.

## What

- **`CommitRow`** — one component for a commit anywhere: subject, `sha · author · when` (relative + absolute on hover, or the reverse), chips, ⋯ menu, expandable changed files opening their diffs.
- **History popover** rewritten on it (same UX, ~120 fewer lines).
- **Graph**: relative time (absolute on hover), expand → repo-wide changed files (`GET /git/commit?scope=repo`), file click → the owning app's commit diff (files outside `apps/` listed, not openable), menu with View changes / Copy SHA. Restore / go-live stay in the app-scoped History panel.
- Spec + client types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
