### PR TITLE
fix(apps): the binding due-check read the OLDEST attempt — every scheduled binding re-ran every tick

### DIFF
--- a/api/src/inngest/functions/apps-binding-refresh.test.ts
+++ b/api/src/inngest/functions/apps-binding-refresh.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isBindingDueAt } from "./apps-binding-refresh";
+
+const daily = { schedule: "0 3 * * *", timezone: "UTC" };
+const at = (iso: string) => new Date(iso);
+
+describe("isBindingDueAt (binding history is newest-first)", () => {
+  it("is due when it has never been attempted", () => {
+    expect(isBindingDueAt(daily, null, at("2026-08-31T10:00:00Z"))).toBe(true);
+  });
+
+  it("reads the NEWEST attempt, not the oldest — a binding built this morning is not due again", () => {
+    const state = {
+      lastMaterializedAt: at("2026-08-31T09:11:00Z"),
+      history: [
+        { at: at("2026-08-31T09:11:00Z"), status: "ready" as const },
+        { at: at("2026-08-30T01:30:00Z"), status: "ready" as const },
+      ],
+    };
+    expect(isBindingDueAt(daily, state, at("2026-08-31T10:00:00Z"))).toBe(
+      false,
+    );
+    expect(isBindingDueAt(daily, state, at("2026-09-01T03:01:00Z"))).toBe(true);
+  });
+
+  it("backs off from a failed attempt instead of retrying every tick", () => {
+    const state = {
+      lastMaterializedAt: at("2026-08-30T03:00:00Z"),
+      history: [
+        {
+          at: at("2026-08-31T09:11:00Z"),
+          status: "error" as const,
+          error: "boom",
+        },
+        { at: at("2026-08-30T03:00:00Z"), status: "ready" as const },
+      ],
+    };
+    expect(isBindingDueAt(daily, state, at("2026-08-31T09:30:00Z"))).toBe(
+      false,
+    );
+  });
+
+  it("a 15-minute binding is due again 15 minutes after its last attempt", () => {
+    const state = {
+      history: [{ at: at("2026-08-31T09:11:00Z"), status: "ready" as const }],
+    };
+    const q = { schedule: "*/15 * * * *", timezone: "UTC" };
+    expect(isBindingDueAt(q, state, at("2026-08-31T09:14:00Z"))).toBe(false);
+    expect(isBindingDueAt(q, state, at("2026-08-31T09:16:00Z"))).toBe(true);
+  });
+
+  it("is never due without a schedule", () => {
+    expect(isBindingDueAt({ schedule: undefined }, null)).toBe(false);
+  });
+});

--- a/api/src/inngest/functions/apps-binding-refresh.ts
+++ b/api/src/inngest/functions/apps-binding-refresh.ts
@@ -27,6 +27,7 @@ import {
   materializeAppBinding,
   readBindings,
   type AppBinding,
+  type AppBindingStateDoc,
 } from "../../apps/bindings.service";
 import { isDashboardMaterializationDue } from "../../services/dashboard-materialization-schedule.service";
 
@@ -46,14 +47,19 @@ interface MaterializeEventData {
  * Due = the binding's cron has a run after its last ATTEMPT (not its last
  * success): a binding whose query is broken would otherwise be due on every
  * tick and re-run its failing warehouse query every 15 minutes forever.
+ *
+ * `history` is NEWEST FIRST (recordBindingRun pushes at position 0), so the
+ * last attempt is `history[0]`. Reading `history.at(-1)` here — the OLDEST
+ * run — made every binding look overdue on every tick: all 173 scheduled
+ * bindings re-ran their warehouse queries every 15 minutes.
  */
-async function isBindingDue(
-  projectId: string,
-  binding: AppBinding,
-): Promise<boolean> {
+export function isBindingDueAt(
+  binding: Pick<AppBinding, "schedule" | "timezone">,
+  state: AppBindingStateDoc | null,
+  now = new Date(),
+): boolean {
   if (!binding.schedule) return false;
-  const state = await getBindingState(projectId, binding.name);
-  const lastAttempt = state?.history?.at(-1)?.at ?? null;
+  const lastAttempt = state?.history?.[0]?.at ?? null;
   return isDashboardMaterializationDue({
     schedule: {
       enabled: true,
@@ -61,7 +67,19 @@ async function isBindingDue(
       timezone: binding.timezone,
     },
     lastRefreshedAt: lastAttempt ?? state?.lastMaterializedAt ?? null,
+    now,
   });
+}
+
+async function isBindingDue(
+  projectId: string,
+  binding: AppBinding,
+): Promise<boolean> {
+  if (!binding.schedule) return false;
+  return isBindingDueAt(
+    binding,
+    await getBindingState(projectId, binding.name),
+  );
 }
 
 export const appsBindingSchedulerFunction = inngest.createFunction(

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "src/apps/migrate-v1-apps.test.ts",
       "src/apps/box-state.service.test.ts",
       "src/apps/preview.service.test.ts",
+      "src/inngest/functions/apps-binding-refresh.test.ts",
     ],
     exclude: ["**/node_modules/**"],
     // Real git, real sandbox: slower than a unit test by design.


### PR DESCRIPTION
## Why

`recordBindingRun` keeps `history` **newest-first** (`$push … $position: 0`). The due-check from #833 read `history.at(-1)` — the oldest run — so every scheduled binding looked overdue on every tick. Once the scheduler could actually keep up (#837), prod re-ran all 173 scheduled bindings every 15 minutes (`triggered 173` on every tick; 167 state docs updated in 30 min; `untreated_v1`, a daily binding, built 10× this morning).

## What

- Read `history[0]`.
- The check is extracted as a pure `isBindingDueAt(binding, state, now)` with 5 tests (never attempted → due; built this morning → not due until the next cron; failed attempt backs off; `*/15` due again after 15 min; no schedule → never).

After deploy the tick summary should drop from `triggered 173` to roughly the 28 `*/15` bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
