### PR TITLE
refactor(api): one sh(), one content-type map, one EMPTY_TREE, one eyes key

### DIFF
--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -55,7 +55,7 @@ import {
   ensureDevServer,
 } from "../../apps/dev-server.service";
 import { getDashboardArtifactStore } from "../../services/dashboard-artifact-store.service";
-import { browseApp } from "../../apps/eyes.service";
+import { browseApp, eyesShotKey } from "../../apps/eyes.service";
 import { publishRealtimeEvent } from "../../services/realtime.service";
 import { loggers } from "../../logging";
 
@@ -616,7 +616,10 @@ export function createAppsTools({
           if (result.screenshotBase64) {
             try {
               const shotId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
-              const key = `apps/eyes/${loaded.project._id.toString()}/${shotId}.jpg`;
+              const key = eyesShotKey(
+                loaded.project._id.toString(),
+                `${shotId}.jpg`,
+              );
               await getDashboardArtifactStore().putBuffer(
                 Buffer.from(result.screenshotBase64, "base64"),
                 key,

--- a/api/src/apps/dev-server.service.ts
+++ b/api/src/apps/dev-server.service.ts
@@ -36,7 +36,7 @@ import {
   sessionKeyFor,
 } from "./worktree.service";
 import { loggers } from "../logging";
-import { boxEnvPath } from "./box";
+import { boxEnvPath, sh } from "./box";
 import { ensureBoxAgent } from "./box-agent";
 import { getBoxState, probeReachable } from "./box-state.service";
 import { readBindings, bindingArtifactKey } from "./bindings.service";
@@ -164,7 +164,7 @@ async function devPort(
         `console.log(m[app]??"");`);
   const result = await provider.exec(
     ctx,
-    `node -e '${script.replace(/'/g, String.raw`'\''`)}' ${JSON.stringify(handle.appRoot)}`,
+    `node -e ${sh(script)} ${JSON.stringify(handle.appRoot)}`,
     { timeoutMs: 30_000 },
   );
   const port = Number(result.stdout.trim());
@@ -694,11 +694,9 @@ export async function discoverDevServers(
     `if(--left===0)console.log(JSON.stringify(out))};` +
     `s.setTimeout(800);s.once("connect",()=>done(true));` +
     `s.once("error",()=>done(false));s.once("timeout",()=>done(false));});`;
-  const result = await provider.exec(
-    ctx,
-    `node -e '${script.replace(/'/g, String.raw`'\''`)}'`,
-    { timeoutMs: 15_000 },
-  );
+  const result = await provider.exec(ctx, `node -e ${sh(script)}`, {
+    timeoutMs: 15_000,
+  });
   try {
     const parsed = JSON.parse(result.stdout.trim() || "[]") as Array<{
       slug: string;

--- a/api/src/apps/eyes.service.ts
+++ b/api/src/apps/eyes.service.ts
@@ -12,6 +12,7 @@
  * capture, quit — nothing resident to fight the 2 GiB box for memory.
  */
 import { loggers } from "../logging";
+import { sh } from "./box";
 import { getSandboxProvider } from "./sandbox/provider";
 import { boxCtx, ensureBox, type WorktreeHandle } from "./worktree.service";
 import { currentDevPort } from "./dev-server.service";
@@ -235,6 +236,11 @@ async function ensureEyesRuntime(ctx: {
  * + console. Requires a RUNNING dev server — this never starts one (§13.9;
  * app_open_app is the start affordance).
  */
+/** Where an app_browse screenshot lives in the artifact store (§13.26). */
+export function eyesShotKey(projectId: string, shot: string): string {
+  return `apps/eyes/${projectId}/${shot}`;
+}
+
 export async function browseApp(
   handle: WorktreeHandle,
   opts: {
@@ -305,7 +311,7 @@ export async function browseApp(
     `for pid in $(pgrep -f chrome-headless-shell 2>/dev/null); do ` +
       `t=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' '); ` +
       `[ -n "$t" ] && [ "$t" -gt 180 ] && kill -9 "$pid" 2>/dev/null; done; ` +
-      `node ${RUNNER_PATH} '${args.replace(/'/g, String.raw`'\''`)}'`,
+      `node ${RUNNER_PATH} ${sh(args)}`,
     { timeoutMs: 90_000 },
   );
   const line = result.stdout

--- a/api/src/apps/git.ts
+++ b/api/src/apps/git.ts
@@ -46,6 +46,8 @@ const BASE_ENV: Record<string, string> = {
 };
 
 export const ZERO_OID = "0".repeat(40);
+/** The empty tree: what a root commit's "parent" diffs against. */
+export const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 /**
  * The subcommand, for error messages — `args[0]` is usually `-C`, so naming it

--- a/api/src/apps/preview.service.ts
+++ b/api/src/apps/preview.service.ts
@@ -25,6 +25,7 @@
  *   is all any instance needs to trust the token.
  */
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { contentTypeFor } from "./deployment.service";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -216,27 +217,6 @@ export function resolvePreviewGrant(token: string): PreviewGrant | null {
   return grants.get(token) ?? null;
 }
 
-const CONTENT_TYPES: Record<string, string> = {
-  ".html": "text/html; charset=utf-8",
-  ".js": "text/javascript; charset=utf-8",
-  ".mjs": "text/javascript; charset=utf-8",
-  ".css": "text/css; charset=utf-8",
-  ".json": "application/json; charset=utf-8",
-  ".map": "application/json; charset=utf-8",
-  ".svg": "image/svg+xml",
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-  ".ico": "image/x-icon",
-  ".txt": "text/plain; charset=utf-8",
-  ".woff": "font/woff",
-  ".woff2": "font/woff2",
-  ".ttf": "font/ttf",
-  ".wasm": "application/wasm",
-};
-
 export interface PreviewAsset {
   contents: Buffer;
   contentType: string;
@@ -262,11 +242,7 @@ export async function readPreviewAsset(
       const stat = await fs.stat(abs);
       if (!stat.isFile()) return null;
       const contents = await fs.readFile(abs);
-      const ext = path.extname(abs).toLowerCase();
-      return {
-        contents,
-        contentType: CONTENT_TYPES[ext] ?? "application/octet-stream",
-      };
+      return { contents, contentType: contentTypeFor(abs) };
     } catch {
       return null;
     }

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -74,7 +74,7 @@ import {
   appsGitOriginBase,
   appsSessionsRoot,
 } from "./config";
-import { assertSafeRelPath, runGit, ZERO_OID } from "./git";
+import { assertSafeRelPath, EMPTY_TREE, runGit, ZERO_OID } from "./git";
 import {
   DEFAULT_BRANCH,
   commitTree,
@@ -1462,9 +1462,6 @@ export async function gitPathsAction(
 }
 
 /** HEAD / index / working-tree contents of one repo-relative path, for diffs. */
-/** The empty tree: what a root commit's "parent" diffs against. */
-const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-
 /**
  * What one commit changed INSIDE this app (paths app-relative), and its
  * parent — the unit the History panel's "View changes" works in. Read from

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -10,6 +10,7 @@
  * feature flag).
  */
 import { createRoute, z } from "@hono/zod-openapi";
+import { eyesShotKey } from "../apps/eyes.service";
 import { Types } from "mongoose";
 import {
   AppProject,
@@ -2381,7 +2382,7 @@ appsRoutes.openapi(
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
       const { shot } = c.req.valid("param");
-      const key = `apps/eyes/${loaded.project._id.toString()}/${shot}`;
+      const key = eyesShotKey(loaded.project._id.toString(), shot);
       const store = getDashboardArtifactStore();
       const stream = await store.openReadStream(key);
       if (!stream) {


### PR DESCRIPTION
## What

- `sh()` — three inline re-spellings (dev-server ×2, eyes) → `box.ts`'s exported helper.
- `CONTENT_TYPES` — `preview.service` used its own map (already drifted: no `.avif`) → `deployment.service.contentTypeFor`.
- `EMPTY_TREE` → exported from `git.ts` next to `ZERO_OID`.
- `apps/eyes/<project>/<shot>` — same template literal in `routes/apps.ts` and the agent tool → `eyesShotKey()` in `eyes.service`.

## Deliberately not done

Artifact key *values* are unchanged. The audit's real finding there is that only dashboard keys honour `DASHBOARD_ARTIFACT_PREFIX`, so app deployments / dbt artifacts collide between PR previews and dev (same bucket). Fixing that moves prod objects — a copy-then-switch migration (see this morning's `apps-v2 → apps` incident), not a cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
