### PR TITLE
refactor(app): one Monaco theme rule and four option presets instead of 21 hand-written blocks

### DIFF
--- a/app/src/components/AppDiffTab.tsx
+++ b/app/src/components/AppDiffTab.tsx
@@ -5,15 +5,9 @@
  * Re-reads when the box reports the file's state changed.
  */
 import { useEffect, useMemo, useState } from "react";
-import {
-  Box,
-  Button,
-  Chip,
-  CircularProgress,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import { Box, Button, Chip, CircularProgress, Typography } from "@mui/material";
 import { DiffEditor } from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { SquareArrowOutUpRight as OpenIcon } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppsStore, type AppFileVersions } from "../store/appsStore";
@@ -45,7 +39,7 @@ export default function AppDiffTab({
       ? `${change.status}:${change.staged}:${change.unstaged}`
       : "clean";
   });
-  const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+  const monacoTheme = useMonacoTheme();
 
   const [versions, setVersions] = useState<AppFileVersions | null>(null);
   const [loading, setLoading] = useState(true);
@@ -181,16 +175,7 @@ export default function AppDiffTab({
             theme={monacoTheme}
             original={original ?? ""}
             modified={modified ?? ""}
-            options={{
-              readOnly: true,
-              originalEditable: false,
-              renderSideBySide: true,
-              minimap: { enabled: false },
-              fontSize: 13,
-              scrollBeyondLastLine: false,
-              automaticLayout: true,
-              renderOverviewRuler: false,
-            }}
+            options={{ ...EDITOR_OPTIONS.diff, renderOverviewRuler: false }}
           />
         )}
       </Box>

--- a/app/src/components/AppFileEditor.tsx
+++ b/app/src/components/AppFileEditor.tsx
@@ -6,9 +6,10 @@
  * WIP ref so nothing is lost if the tab or the sandbox dies.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Alert, Box, Button, Chip, Typography, useTheme } from "@mui/material";
+import { Alert, Box, Button, Chip, Typography } from "@mui/material";
 import { Database as DatabaseIcon, Play as PlayIcon } from "lucide-react";
 import MonacoEditor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppsStore } from "../store/appsStore";
 import { useConsoleStore } from "../store/consoleStore";
@@ -44,7 +45,7 @@ export default function AppFileEditor({
 }) {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
-  const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+  const monacoTheme = useMonacoTheme();
 
   const fileEntry = useAppsStore(s => s.fileContents[`${appId}\u0000${path}`]);
   const apps = useAppsStore(s => s.apps);
@@ -175,12 +176,7 @@ export default function AppFileEditor({
             theme={monacoTheme}
             beforeMount={configureMonacoForJsx}
             onChange={handleChange}
-            options={{
-              minimap: { enabled: false },
-              fontSize: 13,
-              automaticLayout: true,
-              scrollBeyondLastLine: false,
-            }}
+            options={EDITOR_OPTIONS.code}
           />
         ) : (
           <Box sx={{ p: 2 }}>

--- a/app/src/components/CollectionEditor.tsx
+++ b/app/src/components/CollectionEditor.tsx
@@ -29,7 +29,7 @@ import {
   ExpandMore as ExpandMoreIcon,
 } from "@mui/icons-material";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore } from "../store/schemaStore";
 
@@ -76,7 +76,7 @@ const CollectionEditorComponent = (
 ) => {
   const editorRef = useRef<any>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
   const { currentWorkspace } = useWorkspace();
   const fetchDatabaseCollectionInfo = useSchemaStore(
     s => s.fetchCollectionInfo,
@@ -409,16 +409,13 @@ db.createCollection("new_collection_name", {
             defaultLanguage="javascript"
             value={currentQuery}
             height="100%"
-            theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+            theme={monacoTheme}
             onMount={handleEditorDidMount}
             onChange={handleEditorChange}
             options={{
-              automaticLayout: true,
-              readOnly: false,
-              minimap: { enabled: false },
+              ...EDITOR_OPTIONS.code,
               fontSize: 12,
               wordWrap: "on",
-              scrollBeyondLastLine: false,
               formatOnPaste: true,
               formatOnType: true,
             }}

--- a/app/src/components/ConflictResolutionDialog.tsx
+++ b/app/src/components/ConflictResolutionDialog.tsx
@@ -16,7 +16,7 @@ import {
   Warning as WarningIcon,
 } from "@mui/icons-material";
 import { DiffEditor } from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 
 export interface ConflictData {
   existingId: string;
@@ -45,7 +45,7 @@ const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> = ({
   onSaveAsNew,
   isProcessing = false,
 }) => {
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
 
   if (!conflict) return null;
 
@@ -134,7 +134,7 @@ const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> = ({
         >
           <DiffEditor
             height="100%"
-            theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+            theme={monacoTheme}
             language={
               conflict.existingLanguage === "mongodb"
                 ? "javascript"
@@ -143,16 +143,9 @@ const ConflictResolutionDialog: React.FC<ConflictResolutionDialogProps> = ({
             original={conflict.existingContent}
             modified={newContent}
             options={{
-              automaticLayout: true,
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 13,
+              ...EDITOR_OPTIONS.diff,
               wordWrap: "on",
-              scrollBeyondLastLine: false,
-              renderSideBySide: true,
-              enableSplitViewResizing: true,
               diffWordWrap: "on",
-              originalEditable: false,
             }}
           />
         </Box>

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -42,6 +42,7 @@ import {
   Share2 as Share2Icon,
 } from "lucide-react";
 import Editor, { DiffEditor } from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useTheme } from "../contexts/ThemeContext";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore, TreeNode } from "../store/schemaStore";
@@ -209,6 +210,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
   const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
   const { currentWorkspace } = useWorkspace();
   const autoSaveConsole = useConsoleStore(state => state.autoSaveConsole);
   const resolveAgentReview = useConsoleStore(state => state.resolveAgentReview);
@@ -1641,36 +1643,31 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
               language={editorLanguage || "javascript"}
               defaultValue={lastInitialContentRef.current || initialContent}
               height="100%"
-              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              theme={monacoTheme}
               onMount={handleEditorDidMount}
               onChange={handleEditorChange}
               options={{
-                automaticLayout: true,
+                ...EDITOR_OPTIONS.code,
                 readOnly: isReadOnly,
-                minimap: { enabled: false },
                 fontSize: 12,
                 wordWrap: "on",
-                scrollBeyondLastLine: false,
               }}
             />
           ) : (
             <DiffEditor
               height="100%"
-              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              theme={monacoTheme}
               language={editorLanguage || "javascript"}
               original={originalContent}
               modified={modifiedContent}
               onMount={handleDiffEditorDidMount}
               options={{
-                automaticLayout: true,
-                readOnly: true,
-                minimap: { enabled: false },
+                ...EDITOR_OPTIONS.diff,
                 fontSize: 12,
                 wordWrap: "on",
-                scrollBeyondLastLine: false,
+                diffWordWrap: "on",
                 renderSideBySide: false,
                 enableSplitViewResizing: false,
-                diffWordWrap: "on",
               }}
             />
           )}

--- a/app/src/components/CreateViewDialog.tsx
+++ b/app/src/components/CreateViewDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mui/material";
 import { Close as CloseIcon } from "@mui/icons-material";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore } from "../store/schemaStore";
 
@@ -38,7 +38,7 @@ const CreateViewDialog: React.FC<CreateViewDialogProps> = ({
   databaseId,
   workspaceId,
 }) => {
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
   const { currentWorkspace } = useWorkspace();
   const fetchDatabaseCollections = useSchemaStore(s => s.fetchCollections);
   const effectiveWorkspaceId = workspaceId || currentWorkspace?.id;
@@ -209,15 +209,13 @@ const CreateViewDialog: React.FC<CreateViewDialogProps> = ({
               defaultLanguage="json"
               value={pipeline}
               height="100%"
-              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              theme={monacoTheme}
               onChange={value => setPipeline(value || "")}
               options={{
-                automaticLayout: true,
+                ...EDITOR_OPTIONS.code,
                 readOnly: isCreating,
-                minimap: { enabled: false },
                 fontSize: 12,
                 wordWrap: "on",
-                scrollBeyondLastLine: false,
                 formatOnPaste: true,
                 formatOnType: true,
               }}

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -35,7 +35,6 @@ import {
   type DashboardWidget,
 } from "../store/dashboardStore";
 import { useConsoleStore } from "../store/consoleStore";
-import { useTheme } from "../contexts/ThemeContext";
 import { useAuth } from "../contexts/auth-context";
 import {
   applyFreshMaterializationCommand,
@@ -84,7 +83,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   onCreated,
 }) => {
   const { user } = useAuth();
-  const { effectiveMode } = useTheme();
 
   const {
     dashboard,
@@ -553,7 +551,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
             <DashboardCodeEditor
               dashboard={dashboard}
               dashboardId={dashboardId}
-              effectiveMode={effectiveMode}
               onCodeError={setHasCodeError}
             />
           )}

--- a/app/src/components/DbFlowForm.tsx
+++ b/app/src/components/DbFlowForm.tsx
@@ -31,7 +31,6 @@ import {
   AccordionSummary,
   AccordionDetails,
 } from "@mui/material";
-import { useTheme as useMuiTheme } from "@mui/material/styles";
 import {
   Save as SaveIcon,
   Schedule as ScheduleIcon,
@@ -45,6 +44,7 @@ import {
   ExpandMore as ExpandMoreIcon,
 } from "@mui/icons-material";
 import Editor, { Monaco, OnMount } from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useSchemaStore, TreeNode } from "../store/schemaStore";
@@ -279,8 +279,7 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
     );
 
     // Theme for Monaco
-    const muiTheme = useMuiTheme();
-    const effectiveMode = muiTheme.palette.mode;
+    const monacoTheme = useMonacoTheme();
 
     // Register template placeholder completions
     const registerTemplateCompletions = useCallback((monaco: Monaco) => {
@@ -1283,27 +1282,15 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
                                     <Editor
                                       language="sql"
                                       value={field.value}
-                                      theme={
-                                        effectiveMode === "dark"
-                                          ? "vs-dark"
-                                          : "vs"
-                                      }
+                                      theme={monacoTheme}
                                       onChange={value =>
                                         field.onChange(value || "")
                                       }
                                       options={{
-                                        minimap: { enabled: false },
-                                        fontSize: 13,
+                                        ...EDITOR_OPTIONS.code,
                                         wordWrap: "on",
-                                        lineNumbers: "on",
-                                        scrollBeyondLastLine: false,
-                                        automaticLayout: true,
                                         tabSize: 2,
                                         padding: { top: 8, bottom: 8 },
-                                        scrollbar: {
-                                          vertical: "auto",
-                                          horizontal: "auto",
-                                        },
                                       }}
                                       onMount={(editor, monaco) => {
                                         editorRef.current = editor;

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -37,6 +37,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { DiffEditor } from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import {
   Plus as AddIcon,
   RefreshCw as RefreshIcon,
@@ -300,7 +301,7 @@ export function DbtExplorer() {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
   const theme = useTheme();
-  const monacoTheme = theme.palette.mode === "dark" ? "vs-dark" : "vs";
+  const monacoTheme = useMonacoTheme();
 
   const projects = useDbtStore(s => s.projects);
   const projectsLoaded = useDbtStore(s => s.projectsLoaded);
@@ -2394,13 +2395,7 @@ export function DbtExplorer() {
               modified={diffData.working}
               language={dbtDiffLanguage(diffData.path)}
               beforeMount={registerDbtJinjaLanguage}
-              options={{
-                readOnly: true,
-                renderSideBySide: true,
-                minimap: { enabled: false },
-                fontSize: 12,
-                scrollBeyondLastLine: false,
-              }}
+              options={{ ...EDITOR_OPTIONS.diff, fontSize: 12 }}
             />
           ) : null}
         </DialogContent>

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -38,7 +38,6 @@ import {
   Tabs,
   Tooltip,
   Typography,
-  useTheme,
 } from "@mui/material";
 import {
   AlertTriangle as WarnIcon,
@@ -54,6 +53,7 @@ import {
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import MonacoEditor, { type Monaco } from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import {
@@ -237,7 +237,7 @@ export default function DbtFileEditor({
   const { currentWorkspace } = useWorkspace();
   const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
-  const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+  const monacoTheme = useMonacoTheme();
 
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
   const file = useDbtStore(s => s.filesByProject[projectId]?.[path]);
@@ -800,10 +800,8 @@ export default function DbtFileEditor({
         beforeMount={handleBeforeMount}
         onMount={handleEditorMount as never}
         options={{
+          ...EDITOR_OPTIONS.code,
           minimap: { enabled: true },
-          fontSize: 13,
-          automaticLayout: true,
-          scrollBeyondLastLine: false,
           wordWrap: isMarkdown ? "on" : "off",
         }}
       />
@@ -1002,12 +1000,7 @@ export default function DbtFileEditor({
             language="sql"
             value={compileResult.compiledSql}
             theme={monacoTheme}
-            options={{
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              scrollBeyondLastLine: false,
-            }}
+            options={{ ...EDITOR_OPTIONS.readOnly, wordWrap: "off" }}
           />
         ) : (
           <Box sx={{ p: 2 }}>

--- a/app/src/components/NotebookCell.tsx
+++ b/app/src/components/NotebookCell.tsx
@@ -11,9 +11,9 @@ import {
   Select,
   TextField,
   Tooltip,
-  useTheme,
 } from "@mui/material";
 import Editor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { ChevronDown, ChevronUp, Play, Trash2 } from "lucide-react";
 
 import type { NotebookBlock, NotebookBlockType } from "../store/notebookStore";
@@ -84,7 +84,7 @@ export default function NotebookCell({
   onDelete,
   onMove,
 }: NotebookCellProps) {
-  const theme = useTheme();
+  const monacoTheme = useMonacoTheme();
   const monacoLanguage = MONACO_LANGUAGE[block.type];
 
   const [localRunning, setLocalRunning] = useState(false);
@@ -365,16 +365,12 @@ export default function NotebookCell({
           language={monacoLanguage}
           value={block.source}
           onChange={value => onChange({ source: value ?? "" })}
-          theme={theme.palette.mode === "dark" ? "vs-dark" : "light"}
+          theme={monacoTheme}
           height={editorHeight(block.source)}
           options={{
-            minimap: { enabled: false },
-            lineNumbers: "on",
-            scrollBeyondLastLine: false,
-            fontSize: 13,
+            ...EDITOR_OPTIONS.code,
             folding: false,
             wordWrap: "on",
-            automaticLayout: true,
             scrollbar: { alwaysConsumeMouseWheel: false },
             padding: { top: 8, bottom: 8 },
           }}

--- a/app/src/components/PlanDocumentTab.tsx
+++ b/app/src/components/PlanDocumentTab.tsx
@@ -10,9 +10,9 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Typography,
-  useTheme,
 } from "@mui/material";
 import MonacoEditor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import {
   Circle,
   CircleCheck,
@@ -56,8 +56,7 @@ export default function PlanDocumentTab({
 }: {
   toolCallId: string;
 }) {
-  const theme = useTheme();
-  const monacoTheme = theme.palette.mode === "dark" ? "vs-dark" : "vs";
+  const monacoTheme = useMonacoTheme();
 
   const plan = usePlanStore(s => s.plans[toolCallId]);
   const setDraftTitle = usePlanStore(s => s.setDraftTitle);
@@ -172,13 +171,7 @@ export default function PlanDocumentTab({
             value={plan.draft.planMarkdown}
             theme={monacoTheme}
             onChange={value => setDraftMarkdown(toolCallId, value ?? "")}
-            options={{
-              minimap: { enabled: false },
-              fontSize: 13,
-              automaticLayout: true,
-              scrollBeyondLastLine: false,
-              wordWrap: "on",
-            }}
+            options={{ ...EDITOR_OPTIONS.code, wordWrap: "on" }}
           />
         ) : (
           <Box sx={{ maxWidth: 760, mx: "auto", px: 3, py: 3 }}>

--- a/app/src/components/ResultsTable.tsx
+++ b/app/src/components/ResultsTable.tsx
@@ -28,7 +28,7 @@ import {
   FileCode2 as StructureIcon,
 } from "lucide-react";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useIsMobile } from "../hooks/useIsMobile";
 import type { MakoChartSpec } from "../lib/chart-spec";
 import ResultsChart from "./ResultsChart";
@@ -160,7 +160,7 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   );
   const [downloadAnchorEl, setDownloadAnchorEl] =
     React.useState<HTMLElement | null>(null);
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
 
   const requestedViewMode: ResultsViewMode =
     localOverride ?? controlledViewMode ?? internalViewMode;
@@ -1057,15 +1057,8 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
               height="100%"
               defaultLanguage="json"
               value={jsonContent}
-              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
-              options={{
-                readOnly: true,
-                minimap: { enabled: false },
-                scrollBeyondLastLine: false,
-                fontSize: 14,
-                wordWrap: "on",
-                automaticLayout: true,
-              }}
+              theme={monacoTheme}
+              options={{ ...EDITOR_OPTIONS.readOnly, fontSize: 14 }}
             />
           </Box>
         )}

--- a/app/src/components/TableStructureView.tsx
+++ b/app/src/components/TableStructureView.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, Alert, Button, CircularProgress } from "@mui/material";
 import Editor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useSchemaStore } from "../store/schemaStore";
 import { useWorkspace } from "../contexts/workspace-context";
-import { useTheme } from "../contexts/ThemeContext";
 
 interface TableStructureViewProps {
   connectionId: string;
@@ -25,7 +25,7 @@ function TableStructureView({
 }: TableStructureViewProps) {
   const fetchTableDefinition = useSchemaStore(s => s.fetchTableDefinition);
   const { currentWorkspace } = useWorkspace();
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
 
   const [definition, setDefinition] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -98,15 +98,8 @@ function TableStructureView({
         height="100%"
         defaultLanguage="sql"
         value={definition}
-        theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
-        options={{
-          readOnly: true,
-          minimap: { enabled: false },
-          scrollBeyondLastLine: false,
-          fontSize: 14,
-          wordWrap: "on",
-          automaticLayout: true,
-        }}
+        theme={monacoTheme}
+        options={{ ...EDITOR_OPTIONS.readOnly, fontSize: 14 }}
       />
     </Box>
   );

--- a/app/src/components/VersionConflictDialog.tsx
+++ b/app/src/components/VersionConflictDialog.tsx
@@ -16,7 +16,7 @@ import {
   Warning as WarningIcon,
 } from "@mui/icons-material";
 import { DiffEditor } from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import type { ConsoleVersionConflict } from "../lib/api-types";
 
 interface VersionConflictDialogProps {
@@ -49,7 +49,7 @@ const VersionConflictDialog: React.FC<VersionConflictDialogProps> = ({
   onLoadLatest,
   isProcessing = false,
 }) => {
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
 
   if (!conflict) return null;
 
@@ -144,21 +144,14 @@ const VersionConflictDialog: React.FC<VersionConflictDialogProps> = ({
         >
           <DiffEditor
             height="100%"
-            theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+            theme={monacoTheme}
             language={language === "mongodb" ? "javascript" : language || "sql"}
             original={conflict.content}
             modified={newContent}
             options={{
-              automaticLayout: true,
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 13,
+              ...EDITOR_OPTIONS.diff,
               wordWrap: "on",
-              scrollBeyondLastLine: false,
-              renderSideBySide: true,
-              enableSplitViewResizing: true,
               diffWordWrap: "on",
-              originalEditable: false,
             }}
           />
         </Box>

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "@mui/material";
 import { X, RotateCcw } from "lucide-react";
 import Editor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import {
   useVersionStore,
   type VersionListItem,
@@ -28,7 +29,6 @@ import {
   type VersionEntityType,
 } from "../store/versionStore";
 import { useWorkspace } from "../contexts/workspace-context";
-import { useTheme } from "../contexts/ThemeContext";
 
 interface VersionHistoryPanelProps {
   open: boolean;
@@ -76,7 +76,7 @@ export function VersionHistoryPanel({
   entityId,
   onRestore,
 }: VersionHistoryPanelProps) {
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
 
@@ -168,8 +168,6 @@ export function VersionHistoryPanel({
       onRestore?.();
     }
   };
-
-  const monacoTheme = effectiveMode === "dark" ? "vs-dark" : "light";
 
   let snapshotValue = "";
   let previewLanguage = "json";
@@ -286,11 +284,7 @@ export function VersionHistoryPanel({
                   theme={monacoTheme}
                   value={snapshotValue}
                   options={{
-                    readOnly: true,
-                    minimap: { enabled: false },
-                    scrollBeyondLastLine: false,
-                    fontSize: 12,
-                    wordWrap: "on",
+                    ...EDITOR_OPTIONS.readOnly,
                     renderLineHighlight: "none",
                   }}
                 />

--- a/app/src/components/ViewEditor.tsx
+++ b/app/src/components/ViewEditor.tsx
@@ -22,7 +22,7 @@ import {
   Delete as DeleteIcon,
 } from "@mui/icons-material";
 import Editor from "@monaco-editor/react";
-import { useTheme } from "../contexts/ThemeContext";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore } from "../store/schemaStore";
 
@@ -73,7 +73,7 @@ const ViewEditor = forwardRef<ViewEditorRef, ViewEditorProps>(
   ) {
     const editorRef = useRef<any>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    const { effectiveMode } = useTheme();
+    const monacoTheme = useMonacoTheme();
     const { currentWorkspace } = useWorkspace();
     const fetchDatabaseCollections = useSchemaStore(s => s.fetchCollections);
     const effectiveWorkspaceId = workspaceId || currentWorkspace?.id;
@@ -318,16 +318,13 @@ const ViewEditor = forwardRef<ViewEditorRef, ViewEditorProps>(
               defaultLanguage="json"
               value={currentContent}
               height="100%"
-              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              theme={monacoTheme}
               onMount={handleEditorDidMount}
               onChange={handleEditorChange}
               options={{
-                automaticLayout: true,
-                readOnly: false,
-                minimap: { enabled: false },
+                ...EDITOR_OPTIONS.code,
                 fontSize: 12,
                 wordWrap: "on",
-                scrollBeyondLastLine: false,
                 formatOnPaste: true,
                 formatOnType: true,
               }}

--- a/app/src/components/dashboard/DashboardCodeEditor.tsx
+++ b/app/src/components/dashboard/DashboardCodeEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import Editor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../../lib/monaco-presets";
 import { useDashboardStore } from "../../store/dashboardStore";
 import {
   serializeDashboardDefinition,
@@ -21,16 +22,15 @@ function formatZodErrors(error: {
 interface DashboardCodeEditorProps {
   dashboard: Dashboard;
   dashboardId?: string;
-  effectiveMode: "light" | "dark";
   onCodeError?: (hasError: boolean) => void;
 }
 
 const DashboardCodeEditor: React.FC<DashboardCodeEditorProps> = ({
   dashboard,
   dashboardId,
-  effectiveMode,
   onCodeError,
 }) => {
+  const monacoTheme = useMonacoTheme();
   const [codeValue, setCodeValue] = useState("");
   const [codeError, setCodeError] = useState<string | null>(null);
   const isEditorFocusedRef = useRef(false);
@@ -128,11 +128,10 @@ const DashboardCodeEditor: React.FC<DashboardCodeEditorProps> = ({
           language="json"
           value={codeValue}
           onChange={handleCodeChange}
-          theme={effectiveMode === "dark" ? "vs-dark" : "light"}
+          theme={monacoTheme}
           options={{
-            minimap: { enabled: false },
+            ...EDITOR_OPTIONS.code,
             fontSize: 12,
-            scrollBeyondLastLine: false,
             wordWrap: "on",
             formatOnPaste: true,
             tabSize: 2,

--- a/app/src/components/dashboard/WidgetInspector.tsx
+++ b/app/src/components/dashboard/WidgetInspector.tsx
@@ -14,11 +14,11 @@ import {
 } from "@mui/material";
 import { X, Copy } from "lucide-react";
 import Editor from "@monaco-editor/react";
+import { EDITOR_OPTIONS, useMonacoTheme } from "../../lib/monaco-presets";
 import {
   useDashboardStore,
   type DashboardWidget,
 } from "../../store/dashboardStore";
-import { useTheme } from "../../contexts/ThemeContext";
 import { useDashboardRuntimeStore } from "../../dashboard-runtime/store";
 import { previewDashboardQuery } from "../../dashboard-runtime/commands";
 
@@ -49,7 +49,7 @@ const WidgetInspector: React.FC<WidgetInspectorProps> = ({
   dashboardId,
 }) => {
   const { modifyWidget, addWidget } = useDashboardStore();
-  const { effectiveMode } = useTheme();
+  const monacoTheme = useMonacoTheme();
   const runtimeSession = useDashboardRuntimeStore(state =>
     dashboardId ? state.sessions[dashboardId] || null : null,
   );
@@ -263,14 +263,8 @@ const WidgetInspector: React.FC<WidgetInspectorProps> = ({
             language="sql"
             value={localSql}
             onChange={val => setLocalSql(val || "")}
-            theme={effectiveMode === "dark" ? "vs-dark" : "light"}
-            options={{
-              minimap: { enabled: false },
-              lineNumbers: "off",
-              fontSize: 12,
-              scrollBeyondLastLine: false,
-              wordWrap: "on",
-            }}
+            theme={monacoTheme}
+            options={EDITOR_OPTIONS.inline}
           />
         </Box>
         <Button
@@ -332,14 +326,8 @@ const WidgetInspector: React.FC<WidgetInspectorProps> = ({
                 language="json"
                 value={specJson}
                 onChange={val => setSpecJson(val || "")}
-                theme={effectiveMode === "dark" ? "vs-dark" : "light"}
-                options={{
-                  minimap: { enabled: false },
-                  lineNumbers: "off",
-                  fontSize: 12,
-                  scrollBeyondLastLine: false,
-                  wordWrap: "on",
-                }}
+                theme={monacoTheme}
+                options={EDITOR_OPTIONS.inline}
               />
             </Box>
           </>

--- a/app/src/lib/monaco-presets.ts
+++ b/app/src/lib/monaco-presets.ts
@@ -1,0 +1,60 @@
+/**
+ * One place for how Mako configures Monaco.
+ *
+ * Every `<Editor>` / `<DiffEditor>` used to hand-write its own `options`
+ * block and derive its theme its own way — and the light theme disagreed:
+ * "vs" in some files, "light" in others. Monaco registers only `vs`,
+ * `vs-dark`, `hc-black` and `hc-light`; an unknown name such as "light"
+ * silently falls back to `vs`, so both rendered the same — by accident.
+ * `useMonacoTheme` is the one rule, and it names the theme Monaco actually
+ * has.
+ *
+ * The presets are the common denominators of the blocks they replaced; a
+ * site keeps its own deviations as a spread:
+ * `options={{ ...EDITOR_OPTIONS.code, wordWrap: "on" }}`.
+ *
+ * `automaticLayout` is listed explicitly even though @monaco-editor/react
+ * already creates every editor with `{ automaticLayout: true, ...options }`,
+ * so a preset means the same thing whether or not it goes through the
+ * wrapper.
+ */
+import { useTheme } from "@mui/material/styles";
+import type { DiffEditorProps, EditorProps } from "@monaco-editor/react";
+
+export type MonacoTheme = "vs" | "vs-dark";
+
+/** Monaco theme matching the current MUI palette mode. */
+export function useMonacoTheme(): MonacoTheme {
+  return useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+}
+
+type EditorOptions = NonNullable<EditorProps["options"]>;
+type DiffEditorOptions = NonNullable<DiffEditorProps["options"]>;
+
+const base = {
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  automaticLayout: true,
+} satisfies EditorOptions;
+
+export const EDITOR_OPTIONS = {
+  /** Full-height source editor: file editors, plan documents, consoles. */
+  code: { ...base, fontSize: 13 },
+  /** Read-only viewer: compiled SQL, JSON results, version snapshots. */
+  readOnly: { ...base, readOnly: true, fontSize: 12, wordWrap: "on" },
+  /** Compact editor embedded in a form or inspector: no line numbers. */
+  inline: { ...base, lineNumbers: "off", fontSize: 12, wordWrap: "on" },
+  /** Read-only side-by-side diff. */
+  diff: {
+    ...base,
+    readOnly: true,
+    originalEditable: false,
+    renderSideBySide: true,
+    fontSize: 13,
+  },
+} satisfies {
+  code: EditorOptions;
+  readOnly: EditorOptions;
+  inline: EditorOptions;
+  diff: DiffEditorOptions;
+};


### PR DESCRIPTION
## Why

Every `<Editor>`/`<DiffEditor>` in the app — 21 blocks across 18 files — carried its own hand-written `options={{ ... }}`; several were byte-identical and the rest differed by a `fontSize` or a `wordWrap`. The theme was derived four different ways (MUI `useTheme().palette.mode`, ThemeContext `effectiveMode`, a prop threaded down from `DashboardCanvas`, an aliased `useMuiTheme`), and the light theme did not even agree on its name: `"vs"` in AppFileEditor, DbtFileEditor, PlanDocumentTab, AppDiffTab, DbtExplorer and Console; `"light"` in VersionHistoryPanel, NotebookCell, WidgetInspector and DashboardCodeEditor. They only rendered the same because Monaco falls back to `vs` for any theme name it has not registered — and `"light"` is not one (`@monaco-editor/react` passes the string straight to `monaco.editor.setTheme`).

## What

- New `app/src/lib/monaco-presets.ts`:
  - `useMonacoTheme()` → `"vs-dark" | "vs"` from the MUI palette mode (one rule; also correct under nested MUI providers such as `EmbeddableDashboard`). `"vs"` is the name Monaco actually registers, which is why it wins over `"light"`.
  - `EDITOR_OPTIONS.{code, readOnly, inline, diff}` — the common denominators of the blocks they replace.
- All 21 sites use a preset, keeping their own deviation as a spread (`{ ...EDITOR_OPTIONS.code, wordWrap: "on" }`).
- `DashboardCodeEditor` derives its own theme; the `effectiveMode` prop and its pass-through in `DashboardCanvas` are gone.

No visible change beyond the light-theme name:
- `automaticLayout` is in the presets, but the react wrapper already creates every editor with `{ automaticLayout: true, ...options }`, so the five sites that never set it were already getting it.
- The explicit Monaco defaults that were dropped (`readOnly: false`, `lineNumbers: "on"`, `enableSplitViewResizing: true`, `scrollbar: { vertical: "auto", horizontal: "auto" }`) are what Monaco does anyway.

Checked: `tsc --noEmit`, `eslint` and `prettier --check` on the changed files, `vitest run src/store src/lib` (29 files, 218 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
