### PR TITLE
refactor(app): one home for duration/bytes/relative-time/path helpers — 14 definitions of 5 concepts

### DIFF
--- a/app/src/apps-runtime/shell.ts
+++ b/app/src/apps-runtime/shell.ts
@@ -4,6 +4,7 @@
  * the tab owns file selection, terminal, and preview state (appsStore).
  */
 import { useConsoleStore } from "../store/consoleStore";
+import { basename } from "../utils/path";
 
 export function focusAppsTab(
   appId: string,
@@ -28,7 +29,7 @@ export function focusAppsFileTab(
   path: string,
   slug?: string,
 ): string {
-  const fileName = path.split("/").pop() || path;
+  const fileName = basename(path);
   return useConsoleStore
     .getState()
     .focusOrOpenTab({ kind: "app-file", metadata: { appId, path } }, () => ({
@@ -53,7 +54,7 @@ export function focusAppsDiffTab(
   /** "commit" mode: the commit whose change to `path` is shown. */
   sha?: string,
 ): string {
-  const fileName = path.split("/").pop() || path;
+  const fileName = basename(path);
   const label =
     mode === "commit"
       ? (sha ?? "").slice(0, 7)

--- a/app/src/components/ApiKeyManager.tsx
+++ b/app/src/components/ApiKeyManager.tsx
@@ -33,7 +33,6 @@ import {
   Visibility as VisibilityIcon,
   VisibilityOff as VisibilityOffIcon,
 } from "@mui/icons-material";
-import { formatDistanceToNow } from "date-fns";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
   selectTabBySettingsSection,
@@ -43,6 +42,7 @@ import { SECTION_LABELS } from "../pages/settings/sections";
 import { trackEvent } from "../lib/analytics";
 import { useApiKeyStore } from "../store/apiKeyStore";
 import type { ApiKeyCreateResponse } from "../lib/api-types";
+import { formatRelativeTime } from "../utils/relative-time";
 
 const MCP_STARTER_PROMPT =
   "Using the mako tools, explore my data and build an app showing revenue " +
@@ -488,16 +488,10 @@ export function ApiKeyManager() {
                       </Tooltip>
                     )}
                   </TableCell>
-                  <TableCell>
-                    {formatDistanceToNow(new Date(key.createdAt), {
-                      addSuffix: true,
-                    })}
-                  </TableCell>
+                  <TableCell>{formatRelativeTime(key.createdAt)}</TableCell>
                   <TableCell>
                     {key.lastUsedAt
-                      ? formatDistanceToNow(new Date(key.lastUsedAt), {
-                          addSuffix: true,
-                        })
+                      ? formatRelativeTime(key.lastUsedAt)
                       : "Never"}
                   </TableCell>
                   <TableCell align="right">

--- a/app/src/components/ConsoleExecutionsPanel.tsx
+++ b/app/src/components/ConsoleExecutionsPanel.tsx
@@ -14,6 +14,7 @@ import {
   consoleExecutionSourceLabel,
   isExternalConsoleExecutionSource,
 } from "../lib/console-execution-source";
+import { formatDuration } from "../utils/format";
 
 export interface ConsoleExecutionRow {
   id: string;
@@ -30,12 +31,6 @@ interface ConsoleExecutionsPanelProps {
   loading: boolean;
   error?: string | null;
   executions: ConsoleExecutionRow[];
-}
-
-function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return "—";
-  if (ms < 1000) return `${Math.round(ms)} ms`;
-  return `${(ms / 1000).toFixed(1)} s`;
 }
 
 function TriggerSourceCell({

--- a/app/src/components/ConsoleInfoModal.tsx
+++ b/app/src/components/ConsoleInfoModal.tsx
@@ -23,6 +23,7 @@ import {
   consoleExecutionSourceLabel,
   isExternalConsoleExecutionSource,
 } from "../lib/console-execution-source";
+import { formatDuration } from "../utils/format";
 
 interface ConsoleInfoModalProps {
   open: boolean;
@@ -96,12 +97,6 @@ const accessLabels: Record<string, string> = {
   private: "Private",
   workspace: "Shared with workspace",
 };
-
-function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return "—";
-  if (ms < 1000) return `${Math.round(ms)} ms`;
-  return `${(ms / 1000).toFixed(1)} s`;
-}
 
 function formatExecutedAt(value: string): string {
   const date = new Date(value);

--- a/app/src/components/DataSourceMaterializationControls.tsx
+++ b/app/src/components/DataSourceMaterializationControls.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import MaterializationScheduleControls from "./MaterializationScheduleControls";
 import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
+import { formatRelativeTimeCompact } from "../utils/relative-time";
 
 /**
  * Shared materialization toolbar for app data bindings and dashboard data
@@ -92,16 +93,6 @@ interface Props {
 
 const DEFAULT_FRESHNESS_TTL_MS = 24 * 60 * 60 * 1000;
 
-function formatRelative(ms: number): string {
-  const sec = Math.round(ms / 1000);
-  if (sec < 60) return "just now";
-  const min = Math.round(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.round(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  return `${Math.round(hr / 24)}d ago`;
-}
-
 export default function DataSourceMaterializationControls({
   leadingControls,
   showMaterializeControls = true,
@@ -143,7 +134,10 @@ export default function DataSourceMaterializationControls({
   if (buildStatus === "ready" && builtAtMs) {
     const ageMs = Date.now() - builtAtMs;
     const ttl = dataFreshnessTtlMs ?? DEFAULT_FRESHNESS_TTL_MS;
-    freshness = { label: formatRelative(ageMs), stale: ageMs > ttl };
+    freshness = {
+      label: formatRelativeTimeCompact(builtAtMs),
+      stale: ageMs > ttl,
+    };
   }
 
   // One combined chip carries build status + row count + freshness (the old

--- a/app/src/components/DbtCommandsPanel.tsx
+++ b/app/src/components/DbtCommandsPanel.tsx
@@ -18,13 +18,14 @@ import {
   Clock as ClockIcon,
   GitBranch as EnvIcon,
 } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
 import {
   countDbtSteps,
   type DbtCommandInvocation,
 } from "../lib/dbt-command-history";
 import { formatRowsAffected, formatStepDuration } from "../lib/dbt-step-format";
 import type { DbtRunLogLine, DbtStepResult } from "../store/dbtStore";
+import { formatDuration } from "../utils/format";
+import { formatRelativeTime } from "../utils/relative-time";
 
 function statusColor(status: DbtCommandInvocation["status"]): string {
   return status === "error"
@@ -41,11 +42,6 @@ function StatusIcon({ status }: { status: DbtCommandInvocation["status"] }) {
   ) : (
     <OkIcon size={14} color="var(--mui-palette-success-main)" />
   );
-}
-
-function formatDuration(ms: number | undefined): string {
-  if (ms === undefined) return "";
-  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
 function LogLines({ logs }: { logs: DbtRunLogLine[] }) {
@@ -242,7 +238,7 @@ function InvocationDetail({ entry }: { entry: DbtCommandInvocation }) {
       >
         <ClockIcon size={14} />
         <Typography variant="body2">
-          {formatDistanceToNow(new Date(entry.startedAt), { addSuffix: true })}
+          {formatRelativeTime(entry.startedAt)}
           {entry.durationMs !== undefined
             ? ` · ${formatDuration(entry.durationMs)}`
             : ""}

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -106,6 +106,7 @@ function dbtDiffLanguage(path: string): string {
 }
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
+import { dirname } from "../utils/path";
 
 // Node id encoding (flat ResourceTree ids stay unique and parseable):
 // Project node: "<projectId>"
@@ -119,12 +120,6 @@ const DIR_SEP = DBT_DIR_SEP;
 const JOB_SEP = DBT_JOB_SEP;
 const RUNS_SEP = DBT_RUNS_SEP;
 const JOBS_DIR = "__jobs";
-
-function dirname(path: string): string {
-  const parts = path.split("/").filter(Boolean);
-  parts.pop();
-  return parts.join("/");
-}
 
 interface ParsedNode {
   kind: "project" | "dir" | "file" | "job" | "runs";

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -32,6 +32,7 @@ import {
   StatusPill,
   type BuiPillTone,
 } from "./bui-status";
+import { formatDuration } from "../utils/format";
 
 interface DbtRunCardProps {
   runId: string;
@@ -45,16 +46,6 @@ const ACTIVE_POLL_INTERVAL_MS = 2_000;
 // errors) so a brief network blip doesn't permanently freeze a live card.
 const MAX_POLL_ERRORS = 10;
 const MAX_VISIBLE_LOGS = 200;
-
-function formatDuration(ms: number | undefined): string {
-  if (ms === undefined) return "";
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  return `${minutes}m ${rest}s`;
-}
 
 const STATUS_PILL: Partial<
   Record<

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -47,6 +47,8 @@ import { focusDbtFileTab } from "../dbt-runtime/shell";
 import { envBadgeColor } from "../lib/dbt-env";
 import { formatRowsAffected, formatStepDuration } from "../lib/dbt-step-format";
 import { useIsMobile } from "../hooks/useIsMobile";
+import { formatDuration } from "../utils/format";
+import { formatRelativeTimeCompact } from "../utils/relative-time";
 
 const ARTIFACT_LABELS: Record<DbtArtifactKind, string> = {
   manifest: "manifest.json",
@@ -79,25 +81,6 @@ function statusColor(status: DbtRunItem["status"]): string {
     default:
       return "text.secondary";
   }
-}
-
-function formatDuration(ms?: number): string {
-  if (ms === undefined || ms === null) return "—";
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
-}
-
-function relativeTime(iso?: string): string {
-  if (!iso) return "—";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function absoluteTime(iso?: string): string {
@@ -552,7 +535,7 @@ export default function DbtRunHistory({
                   color="text.secondary"
                   sx={{ flex: 1 }}
                 >
-                  {relativeTime(run.createdAt)}
+                  {formatRelativeTimeCompact(run.createdAt)}
                 </Typography>
                 {run.ci ? (
                   <Typography
@@ -682,7 +665,9 @@ export default function DbtRunHistory({
               (selectedRun ?? selectedRunListItem)?.createdAt,
             )}
           >
-            {relativeTime((selectedRun ?? selectedRunListItem)?.createdAt)}
+            {formatRelativeTimeCompact(
+              (selectedRun ?? selectedRunListItem)?.createdAt,
+            )}
           </Typography>
           <Typography
             variant="caption"
@@ -717,7 +702,7 @@ export default function DbtRunHistory({
             >
               cancelled by {selectedDetail.cancelledBy}
               {selectedDetail.cancelledAt
-                ? ` · ${relativeTime(selectedDetail.cancelledAt)}`
+                ? ` · ${formatRelativeTimeCompact(selectedDetail.cancelledAt)}`
                 : ""}
             </Typography>
           )}

--- a/app/src/components/McpAgentsPanel.tsx
+++ b/app/src/components/McpAgentsPanel.tsx
@@ -24,7 +24,6 @@ import {
   ContentCopy as CopyIcon,
   LinkOff as RevokeIcon,
 } from "@mui/icons-material";
-import { formatDistanceToNow } from "date-fns";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useMcpStore } from "../store/mcpStore";
 import {
@@ -32,6 +31,7 @@ import {
   useConsoleStore,
 } from "../store/consoleStore";
 import { SECTION_LABELS } from "../pages/settings/sections";
+import { formatRelativeTime } from "../utils/relative-time";
 
 const MCP_STARTER_PROMPT =
   "Using the mako tools, explore my data and build an app showing revenue " +
@@ -425,17 +425,13 @@ export function McpConnectedAgents({
                   )}
                   <TableCell>
                     <Typography variant="body2" color="text.secondary">
-                      {formatDistanceToNow(new Date(connection.connectedAt), {
-                        addSuffix: true,
-                      })}
+                      {formatRelativeTime(connection.connectedAt)}
                     </Typography>
                   </TableCell>
                   <TableCell>
                     <Typography variant="body2" color="text.secondary">
                       {connection.lastUsedAt
-                        ? formatDistanceToNow(new Date(connection.lastUsedAt), {
-                            addSuffix: true,
-                          })
+                        ? formatRelativeTime(connection.lastUsedAt)
                         : "Never"}
                     </Typography>
                   </TableCell>

--- a/app/src/components/NotebookHistoryDrawer.tsx
+++ b/app/src/components/NotebookHistoryDrawer.tsx
@@ -18,22 +18,11 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { formatDistanceToNow } from "date-fns";
 import { History, RotateCcw, X } from "lucide-react";
 
 import { useNotebookStore, type NotebookVersion } from "../store/notebookStore";
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatWhen(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "unknown";
-  return `${formatDistanceToNow(date, { addSuffix: true })}`;
-}
+import { formatBytes } from "../utils/format";
+import { formatRelativeTime } from "../utils/relative-time";
 
 interface NotebookHistoryDrawerProps {
   open: boolean;
@@ -154,7 +143,7 @@ export default function NotebookHistoryDrawer({
                 }
               >
                 <ListItemText
-                  primary={formatWhen(v.createdAt)}
+                  primary={formatRelativeTime(v.createdAt) ?? "unknown"}
                   secondary={formatBytes(v.size)}
                   primaryTypographyProps={{ variant: "body2" }}
                   secondaryTypographyProps={{ variant: "caption" }}

--- a/app/src/components/SourceControlExplorer.tsx
+++ b/app/src/components/SourceControlExplorer.tsx
@@ -67,6 +67,7 @@ import {
 import { SECTION_LABELS } from "../pages/settings/sections";
 import { focusAppsDiffTab, focusAppsFileTab } from "../apps-runtime/shell";
 import VSScrollArea from "./VSScrollArea";
+import { basename, dirname } from "../utils/path";
 
 /** VS Code's status letters, in VS Code's colors. */
 const STATUS_STYLE: Record<
@@ -179,9 +180,8 @@ function ChangeRow({
   onOpen: () => void;
   actions: React.ReactNode;
 }) {
-  const slash = change.path.lastIndexOf("/");
-  const name = slash === -1 ? change.path : change.path.slice(slash + 1);
-  const dir = slash === -1 ? "" : change.path.slice(0, slash);
+  const name = basename(change.path);
+  const dir = dirname(change.path);
   const style = STATUS_STYLE[change.status];
   return (
     <Box
@@ -894,7 +894,7 @@ export default function SourceControlExplorer() {
                             title="Discard changes"
                             onClick={() =>
                               setConfirm({
-                                title: `Discard changes to ${change.path.split("/").pop()}?`,
+                                title: `Discard changes to ${basename(change.path)}?`,
                                 body:
                                   change.status === "added"
                                     ? "This deletes the file. It cannot be undone."

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -29,6 +29,7 @@ import {
   type VersionEntityType,
 } from "../store/versionStore";
 import { useWorkspace } from "../contexts/workspace-context";
+import { formatRelativeTimeCompact } from "../utils/relative-time";
 
 interface VersionHistoryPanelProps {
   open: boolean;
@@ -41,24 +42,6 @@ interface VersionHistoryPanelProps {
 
 const LIST_WIDTH = 380;
 const PREVIEW_WIDTH = 640;
-
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHrs = Math.floor(diffMin / 60);
-  if (diffHrs < 24) return `${diffHrs}h ago`;
-  const diffDays = Math.floor(diffHrs / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return d.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: d.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
-  });
-}
 
 function initials(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -245,7 +228,9 @@ export function VersionHistoryPanel({
                   sx={{ minWidth: 0 }}
                 >
                   {selectedVersion.savedByName} ·{" "}
-                  {formatDate(selectedVersion.createdAt)}
+                  {formatRelativeTimeCompact(selectedVersion.createdAt, {
+                    absoluteAfterDays: 7,
+                  })}
                 </Typography>
               </Stack>
               <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
@@ -401,7 +386,9 @@ export function VersionHistoryPanel({
                     {v.savedByName}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    {formatDate(v.createdAt)}
+                    {formatRelativeTimeCompact(v.createdAt, {
+                      absoluteAfterDays: 7,
+                    })}
                   </Typography>
                   <Tooltip title="Restore this version">
                     <IconButton

--- a/app/src/components/dashboard/DashboardRuntimeChrome.tsx
+++ b/app/src/components/dashboard/DashboardRuntimeChrome.tsx
@@ -18,12 +18,7 @@ import type {
   Dashboard,
   DashboardSessionRuntimeState,
 } from "../../dashboard-runtime/types";
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
+import { formatBytes } from "../../utils/format";
 
 function summarizeLoadingLabel(options: {
   sourceNames: string[];

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -60,6 +60,7 @@ import { useDashboardRuntimeStore } from "../../dashboard-runtime/store";
 import { focusDashboardDataSourceTab } from "../../dashboard-runtime/shell";
 import { useSchemaStore } from "../../store/schemaStore";
 import { formatRelativeTime } from "../../utils/relative-time";
+import { formatBytes } from "../../utils/format";
 
 interface ConsoleResult {
   id: string;
@@ -84,17 +85,6 @@ const STATUS_CHIP_PROPS: Record<
   error: { label: "Error", color: "error" },
 };
 
-function formatBytes(value?: number): string | null {
-  if (!value || value <= 0) return null;
-  if (value >= 1024 * 1024) {
-    return `${(value / (1024 * 1024)).toFixed(1)} MB`;
-  }
-  if (value >= 1024) {
-    return `${Math.round(value / 1024)} KB`;
-  }
-  return `${value} B`;
-}
-
 function formatLoadingStatus(options: {
   loadingMessage?: string | null;
   rowsLoaded: number;
@@ -108,7 +98,7 @@ function formatLoadingStatus(options: {
       : "Preparing stream");
   const byteProgress =
     options.totalBytes != null && options.totalBytes > 0
-      ? `${formatBytes(options.bytesLoaded) ?? "0 B"} / ${formatBytes(options.totalBytes) ?? "0 B"}`
+      ? `${formatBytes(options.bytesLoaded ?? 0)} / ${formatBytes(options.totalBytes)}`
       : null;
   return [baseMessage, byteProgress].filter(Boolean).join(" · ");
 }
@@ -895,7 +885,9 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
               const materializedAt = formatRelativeTime(
                 ds.cache?.parquetBuiltAt,
               );
-              const sizeLabel = formatBytes(ds.cache?.byteSize);
+              const sizeLabel = ds.cache?.byteSize
+                ? formatBytes(ds.cache.byteSize)
+                : null;
               const materializationError =
                 materializationStatus === "error"
                   ? ds.cache?.parquetLastError || null
@@ -1337,7 +1329,10 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
                     {selectedRunDetail.rowCount?.toLocaleString() || "unknown"}
                   </Typography>
                   <Typography variant="body2">
-                    Size: {formatBytes(selectedRunDetail.byteSize) || "unknown"}
+                    Size:{" "}
+                    {selectedRunDetail.byteSize
+                      ? formatBytes(selectedRunDetail.byteSize)
+                      : "unknown"}
                   </Typography>
                   {selectedRunDetail.error && (
                     <Typography variant="body2" color="error.main">

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -22,7 +22,8 @@ import {
 } from "../agent-runtime/client-tool-manifest";
 import { resolveDataSourceCodeEdit } from "@mako/agent-tools";
 import { captureScreenshot } from "../agent-runtime/screenshot-agent-tools";
-import { focusDashboardTab, getCurrentWorkspaceId } from "./shell";
+import { getCurrentWorkspaceId } from "../store/uiStore";
+import { focusDashboardTab } from "./shell";
 import {
   validateCrossFilterWidgetSql,
   validateDuckDBQuery,

--- a/app/src/dashboard-runtime/shell.ts
+++ b/app/src/dashboard-runtime/shell.ts
@@ -1,10 +1,6 @@
 import { useConsoleStore } from "../store/consoleStore";
 import { useUIStore } from "../store/uiStore";
 
-export function getCurrentWorkspaceId(): string | null {
-  return useUIStore.getState().currentWorkspaceId ?? null;
-}
-
 export function focusDashboardTab(dashboardId: string, title: string): string {
   const tabId = useConsoleStore
     .getState()

--- a/app/src/dbt-runtime/agent-tools.ts
+++ b/app/src/dbt-runtime/agent-tools.ts
@@ -8,7 +8,8 @@
  */
 
 import { useDbtStore } from "../store/dbtStore";
-import { focusDbtFileTab, getCurrentWorkspaceId } from "./shell";
+import { getCurrentWorkspaceId } from "../store/uiStore";
+import { focusDbtFileTab } from "./shell";
 
 type ToolResult = Record<string, unknown>;
 

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -4,16 +4,8 @@
  */
 
 import { findTab, useConsoleStore } from "../store/consoleStore";
-import { useUIStore } from "../store/uiStore";
 import { useDbtStore } from "../store/dbtStore";
-
-export function getCurrentWorkspaceId(): string | null {
-  return useUIStore.getState().currentWorkspaceId ?? null;
-}
-
-function basename(path: string): string {
-  return path.split("/").filter(Boolean).pop() || path;
-}
+import { basename } from "../utils/path";
 
 /** Open (or focus) a full-screen editor tab for a single dbt project file. */
 export function focusDbtFileTab(projectId: string, path: string): string {

--- a/app/src/lib/dbt-editor-logic.ts
+++ b/app/src/lib/dbt-editor-logic.ts
@@ -5,6 +5,7 @@
  */
 import type { DbtRunLogLine } from "../store/dbtStore";
 import { DBT_JINJA_LANGUAGE_ID } from "./dbt-monaco";
+import { basename } from "../utils/path";
 
 export interface Problem {
   severity: "error" | "warn";
@@ -53,12 +54,11 @@ export function isMarkdownDbtPath(path: string): boolean {
 export function modelNamesFromPaths(paths: string[]): string[] {
   return paths
     .filter(p => p.startsWith("models/") && p.endsWith(".sql"))
-    .map(p => (p.split("/").pop() ?? "").replace(/\.sql$/, ""))
+    .map(p => basename(p).replace(/\.sql$/, ""))
     .filter(Boolean);
 }
 
 export function modelNameForPath(path: string): string | null {
   if (!path.startsWith("models/") || !path.endsWith(".sql")) return null;
-  const base = path.split("/").pop() ?? "";
-  return base.replace(/\.sql$/, "");
+  return basename(path).replace(/\.sql$/, "");
 }

--- a/app/src/pages/settings/SettingsSandbox.tsx
+++ b/app/src/pages/settings/SettingsSandbox.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { useWorkspace } from "../../contexts/workspace-context";
 import { useAppsStore } from "../../store/appsStore";
+import { formatBytes } from "../../utils/format";
 
 interface SandboxStats {
   running: boolean;
@@ -47,12 +48,6 @@ interface SandboxStats {
   diskUsed?: number;
   sessions?: number;
   connectCommand?: string;
-}
-
-function formatBytes(n: number): string {
-  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)} GiB`;
-  if (n >= 1024 ** 2) return `${(n / 1024 ** 2).toFixed(0)} MiB`;
-  return `${n} B`;
 }
 
 function formatUptime(sec: number): string {

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -255,6 +255,15 @@ export const selectActiveEditorContent = (state: UIStore) =>
   state.activeEditorContent;
 
 /**
+ * Imperative read of the current workspace id for code that runs outside
+ * React (agent client tools, tab-open shells). Components should subscribe
+ * with `selectCurrentWorkspaceId` instead.
+ */
+export function getCurrentWorkspaceId(): string | null {
+  return useUIStore.getState().currentWorkspaceId ?? null;
+}
+
+/**
  * The "active explorer" — the explorer panel currently visible on the left,
  * or `null` when no explorer is open (pane collapsed). Unlike `leftPane`,
  * which is the last-selected view and is retained across collapse/expand

--- a/app/src/utils/format.test.ts
+++ b/app/src/utils/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes, formatDuration } from "./format";
+
+describe("formatDuration", () => {
+  it("renders missing or invalid input as an em dash, never empty", () => {
+    expect(formatDuration(undefined)).toBe("—");
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(Number.NaN)).toBe("—");
+    expect(formatDuration(-1)).toBe("—");
+  });
+
+  it("uses whole milliseconds under a second, no space before the unit", () => {
+    expect(formatDuration(0)).toBe("0ms");
+    expect(formatDuration(450)).toBe("450ms");
+    expect(formatDuration(12.6)).toBe("13ms");
+  });
+
+  it("uses one decimal of seconds under a minute", () => {
+    expect(formatDuration(1000)).toBe("1.0s");
+    expect(formatDuration(1500)).toBe("1.5s");
+    expect(formatDuration(59_940)).toBe("59.9s");
+  });
+
+  it("splits minutes and seconds past a minute", () => {
+    expect(formatDuration(60_000)).toBe("1m 0s");
+    expect(formatDuration(125_000)).toBe("2m 5s");
+    expect(formatDuration(119_600)).toBe("2m 0s");
+    expect(formatDuration(3_600_000)).toBe("60m 0s");
+  });
+});
+
+describe("formatBytes", () => {
+  it("renders invalid input as an em dash", () => {
+    expect(formatBytes(Number.NaN)).toBe("—");
+    expect(formatBytes(-5)).toBe("—");
+  });
+
+  it("scales by 1024 with one decimal above bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(12 * 1024 * 1024)).toBe("12.0 MB");
+    expect(formatBytes(3.8 * 1024 ** 3)).toBe("3.8 GB");
+  });
+});

--- a/app/src/utils/format.ts
+++ b/app/src/utils/format.ts
@@ -1,0 +1,37 @@
+/**
+ * Human-readable number formatting shared across the UI. One definition each
+ * so a duration reads the same in a dbt run card, a console execution row and
+ * a run-history table.
+ */
+
+/**
+ * Elapsed time: "450ms", "1.5s", "2m 5s". Missing, non-finite or negative
+ * input renders as "—" (an em dash), never as an empty string, so the label
+ * stays visible in a table cell.
+ */
+export function formatDuration(ms?: number | null): string {
+  if (ms === undefined || ms === null || !Number.isFinite(ms) || ms < 0) {
+    return "—";
+  }
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  // Round to whole seconds first so 119.6s reads "2m 0s", not "1m 60s".
+  const totalSeconds = Math.round(seconds);
+  return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`;
+}
+
+/**
+ * Binary-scaled size with one decimal above bytes: "512 B", "1.5 KB",
+ * "12.0 MB", "3.8 GB". Non-finite or negative input renders as "—".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  const KB = 1024;
+  const MB = KB * 1024;
+  const GB = MB * 1024;
+  if (bytes < KB) return `${Math.round(bytes)} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  if (bytes < GB) return `${(bytes / MB).toFixed(1)} MB`;
+  return `${(bytes / GB).toFixed(1)} GB`;
+}

--- a/app/src/utils/path.test.ts
+++ b/app/src/utils/path.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { basename, dirname } from "./path";
+
+describe("basename", () => {
+  it("returns the last segment", () => {
+    expect(basename("models/staging/orders.sql")).toBe("orders.sql");
+    expect(basename("orders.sql")).toBe("orders.sql");
+  });
+
+  it("ignores a trailing slash", () => {
+    expect(basename("models/staging/")).toBe("staging");
+  });
+
+  it("falls back to the input when there is no segment", () => {
+    expect(basename("")).toBe("");
+    expect(basename("/")).toBe("/");
+  });
+});
+
+describe("dirname", () => {
+  it("returns everything before the last segment", () => {
+    expect(dirname("models/staging/orders.sql")).toBe("models/staging");
+    expect(dirname("models/orders.sql")).toBe("models");
+  });
+
+  it("is empty at the top level", () => {
+    expect(dirname("orders.sql")).toBe("");
+    expect(dirname("")).toBe("");
+  });
+
+  it("ignores a trailing slash", () => {
+    expect(dirname("models/staging/")).toBe("models");
+  });
+});

--- a/app/src/utils/path.ts
+++ b/app/src/utils/path.ts
@@ -1,0 +1,20 @@
+/**
+ * Slash-separated path helpers for repo-relative and project-relative paths
+ * (dbt files, app files, git changes). Not Node's `path`: there is no
+ * platform separator, no ".", and a top-level file has an empty dirname.
+ */
+
+/** Last non-empty segment: "models/staging/orders.sql" → "orders.sql". */
+export function basename(path: string): string {
+  return path.split("/").filter(Boolean).pop() || path;
+}
+
+/**
+ * Everything before the last non-empty segment, "" at the top level:
+ * "models/staging/orders.sql" → "models/staging", "orders.sql" → "".
+ */
+export function dirname(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  parts.pop();
+  return parts.join("/");
+}

--- a/app/src/utils/relative-time.test.ts
+++ b/app/src/utils/relative-time.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  formatRelativeTime,
+  formatRelativeTimeCompact,
+  toDate,
+} from "./relative-time";
+
+const NOW = new Date("2026-08-31T12:00:00Z");
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+/** A timestamp `ms` before NOW, in the given input form. */
+function ago(ms: number): number {
+  return NOW.getTime() - ms;
+}
+
+describe("relative-time", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("toDate", () => {
+    it("accepts ISO strings, epoch millis and Date objects", () => {
+      expect(toDate("2026-08-31T11:00:00Z")?.getTime()).toBe(ago(HOUR));
+      expect(toDate(ago(HOUR))?.getTime()).toBe(ago(HOUR));
+      expect(toDate(new Date(ago(HOUR)))?.getTime()).toBe(ago(HOUR));
+    });
+
+    it("is null for absent or unparseable input", () => {
+      expect(toDate(undefined)).toBeNull();
+      expect(toDate(null)).toBeNull();
+      expect(toDate("")).toBeNull();
+      expect(toDate("not a date")).toBeNull();
+    });
+  });
+
+  describe("formatRelativeTime", () => {
+    it("is null for absent or invalid input", () => {
+      expect(formatRelativeTime(undefined)).toBeNull();
+      expect(formatRelativeTime("nope")).toBeNull();
+    });
+
+    it("spells out minutes, hours and days", () => {
+      expect(formatRelativeTime(ago(10_000))).toBe("just now");
+      expect(formatRelativeTime(ago(5 * MIN))).toBe("5 min ago");
+      expect(formatRelativeTime(ago(3 * HOUR))).toBe("3 hr ago");
+      expect(formatRelativeTime(ago(DAY))).toBe("1 day ago");
+      expect(formatRelativeTime(ago(2 * DAY))).toBe("2 days ago");
+    });
+
+    it("rolls days into months and years", () => {
+      expect(formatRelativeTime(ago(29 * DAY))).toBe("29 days ago");
+      expect(formatRelativeTime(ago(31 * DAY))).toBe("1 month ago");
+      expect(formatRelativeTime(ago(90 * DAY))).toBe("3 months ago");
+      expect(formatRelativeTime(ago(400 * DAY))).toBe("1 year ago");
+      expect(formatRelativeTime(ago(800 * DAY))).toBe("2 years ago");
+    });
+
+    it("takes an ISO string like the data layer provides", () => {
+      expect(formatRelativeTime(new Date(ago(3 * HOUR)).toISOString())).toBe(
+        "3 hr ago",
+      );
+    });
+  });
+
+  describe("formatRelativeTimeCompact", () => {
+    it("renders an em dash (or the given placeholder) for missing input", () => {
+      expect(formatRelativeTimeCompact(undefined)).toBe("—");
+      expect(formatRelativeTimeCompact("bad", { empty: "unknown" })).toBe(
+        "unknown",
+      );
+    });
+
+    it("uses single-letter units and floors", () => {
+      expect(formatRelativeTimeCompact(ago(30_000))).toBe("just now");
+      expect(formatRelativeTimeCompact(ago(90_000))).toBe("1m ago");
+      expect(formatRelativeTimeCompact(ago(5 * HOUR + 59 * MIN))).toBe(
+        "5h ago",
+      );
+      expect(formatRelativeTimeCompact(ago(40 * DAY))).toBe("40d ago");
+    });
+
+    it("switches to an absolute date after the given number of days", () => {
+      const opts = { absoluteAfterDays: 7 };
+      expect(formatRelativeTimeCompact(ago(6 * DAY), opts)).toBe("6d ago");
+      const sameYear = formatRelativeTimeCompact(ago(40 * DAY), opts);
+      expect(sameYear).toMatch(/^Jul 2\d$/);
+      const lastYear = formatRelativeTimeCompact(ago(400 * DAY), opts);
+      expect(lastYear).toMatch(/2025/);
+    });
+  });
+});

--- a/app/src/utils/relative-time.ts
+++ b/app/src/utils/relative-time.ts
@@ -1,11 +1,35 @@
 /**
- * Compact relative-time formatting for data freshness labels
- * ("just now", "5 min ago", "3 hr ago", "2 days ago").
+ * Relative-time labels ("5 min ago") in one place. Two styles, both
+ * past-only and both rendering "just now" under a minute:
+ *
+ * - `formatRelativeTime` — spelled-out units for prose-like labels:
+ *   "5 min ago", "3 hr ago", "2 days ago", "3 months ago", "1 year ago".
+ * - `formatRelativeTimeCompact` — single-letter units for dense tables and
+ *   chips: "5m ago", "3h ago", "2d ago".
  */
-export function formatRelativeTime(value?: string | null): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
+
+/** Anything the UI holds a timestamp as: ISO string, epoch ms, or Date. */
+export type DateInput = string | number | Date | null | undefined;
+
+/** Parse a `DateInput`; `null` when absent or unparseable. */
+export function toDate(value: DateInput): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function plural(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? "" : "s"} ago`;
+}
+
+/**
+ * Spelled-out relative time for data freshness and "last used" labels.
+ * `null` when the input is absent or invalid so callers can substitute
+ * their own placeholder ("Never", "unknown").
+ */
+export function formatRelativeTime(value: DateInput): string | null {
+  const date = toDate(value);
+  if (!date) return null;
   const diffMs = Date.now() - date.getTime();
   const diffMinutes = Math.round(diffMs / 60000);
   if (diffMinutes < 1) return "just now";
@@ -13,5 +37,48 @@ export function formatRelativeTime(value?: string | null): string | null {
   const diffHours = Math.round(diffMinutes / 60);
   if (diffHours < 24) return `${diffHours} hr ago`;
   const diffDays = Math.round(diffHours / 24);
-  return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
+  if (diffDays < 30) return plural(diffDays, "day");
+  const diffMonths = Math.round(diffDays / 30);
+  if (diffMonths < 12) return plural(diffMonths, "month");
+  return plural(Math.round(diffDays / 365), "year");
+}
+
+export interface CompactRelativeTimeOptions {
+  /** Rendered when the input is absent or invalid. Default "—". */
+  empty?: string;
+  /**
+   * Past this many days, render a short absolute date ("Mar 4", or "Mar 4,
+   * 2025" outside the current year) instead of "40d ago".
+   */
+  absoluteAfterDays?: number;
+}
+
+/** Compact relative time for tables and chips: "5m ago", "3h ago", "2d ago". */
+export function formatRelativeTimeCompact(
+  value: DateInput,
+  options: CompactRelativeTimeOptions = {},
+): string {
+  const date = toDate(value);
+  if (!date) return options.empty ?? "—";
+  const now = Date.now();
+  const minutes = Math.floor((now - date.getTime()) / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (
+    options.absoluteAfterDays !== undefined &&
+    days >= options.absoluteAfterDays
+  ) {
+    return date.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year:
+        date.getFullYear() !== new Date(now).getFullYear()
+          ? "numeric"
+          : undefined,
+    });
+  }
+  return `${days}d ago`;
 }


### PR DESCRIPTION
## Why

Five tiny helpers were defined 14 times across `app/src`, and their outputs had drifted apart:

- `formatDuration` x5 with three bodies: `"1.5s"` (dbt views), `"1.5 s"` (console execution views), and `""` vs `"—"` for a missing value.
- `formatBytes` x4: KB with and without a decimal, plus a GiB/MiB variant in sandbox settings, plus one returning `null`.
- Relative time: three inline `"5m ago"` implementations and four call sites of date-fns `formatDistanceToNow`, even though `utils/relative-time.ts` already existed.
- `getCurrentWorkspaceId` byte-identical in `dbt-runtime/shell.ts` and `dashboard-runtime/shell.ts`.
- `basename` / `dirname` re-derived inline in five files.

## What

- **`app/src/utils/format.ts`** — `formatDuration(ms?)` (`"450ms"`, `"1.5s"`, `"2m 5s"`, missing/invalid → `"—"`) and `formatBytes(bytes)` (`"512 B"`, `"1.5 KB"`, `"12.0 MB"`, `"3.8 GB"`).
- **`app/src/utils/path.ts`** — `basename(path)` and `dirname(path)` for slash-separated repo-relative paths.
- **`app/src/utils/relative-time.ts`** — now accepts a `DateInput` (ISO string / epoch ms / `Date`); the spelled-out `formatRelativeTime` gains month/year tiers; new `formatRelativeTimeCompact` (`"5m ago"`, `"3h ago"`, `"2d ago"`, optional `absoluteAfterDays` fallback to a short date, `empty` placeholder).
- **`app/src/store/uiStore.ts`** — exports `getCurrentWorkspaceId()` next to `selectCurrentWorkspaceId`; both agent-tools importers updated.
- Every former local definition is replaced by an import. Edits in the components are limited to deleting the helper, adding the import, and the call-site rename — nothing else in those files changed (they are concurrently being edited elsewhere).
- Vitest coverage for all three utils (`format.test.ts`, `path.test.ts`, `relative-time.test.ts`).

## Visible output changes

All converge on the majority format:

| Where | Before | After |
| --- | --- | --- |
| ConsoleExecutionsPanel, ConsoleInfoModal (duration) | `120 ms`, `1.5 s`, `125.0 s` | `120ms`, `1.5s`, `2m 5s` |
| DbtCommandsPanel, DbtRunCard (missing duration) | empty | `—` |
| DbtCommandsPanel (duration ≥ 60 s) | `125.0s` | `2m 5s` |
| SettingsSandbox (memory/disk) | `3.8 GiB`, `512 MiB` | `3.8 GB`, `512.0 MB` |
| DataSourcePanel (size) | `512 KB` | `512.0 KB` |
| ApiKeyManager, McpAgentsPanel, NotebookHistoryDrawer, DbtCommandsPanel (relative time) | `about 3 hours ago`, `less than a minute ago`, `5 months ago` | `3 hr ago`, `just now`, `5 months ago` |
| ResourceRefreshControl, DataSourcePanel (freshness ≥ 30 days) | `45 days ago` | `2 months ago` |
| DataSourceMaterializationControls (freshness) | rounded (`90 s` → `2m ago`) | floored (`1m ago`) |

Unchanged on purpose: `FlowLogs.formatDuration` (d/h/m/s wall-clock format), `DataSourcePanel.formatDurationMs` (two timestamps in), `CollectionEditor.formatBytes` (Mongo collection stats, `"Bytes"` label, 2 decimals) and `CommitRow`'s `formatDistanceToNowStrict` — different concepts or formats, out of scope here.

## Verification

- `cd app && npx tsc --noEmit -p tsconfig.json` clean
- `npx eslint` on all changed files clean (one pre-existing non-null-assertion warning in `apps-runtime/shell.ts`, not from this change)
- `npx vitest run src/utils src/store src/lib src/apps-runtime src/dbt-runtime src/dashboard-runtime` — 25 files, 151 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
