### PR TITLE
refactor(app): one confirmation primitive — ConfirmDialog + useConfirm — instead of thirty copies

### DIFF
--- a/app/src/components/ApiKeyManager.tsx
+++ b/app/src/components/ApiKeyManager.tsx
@@ -43,6 +43,7 @@ import { trackEvent } from "../lib/analytics";
 import { useApiKeyStore } from "../store/apiKeyStore";
 import type { ApiKeyCreateResponse } from "../lib/api-types";
 import { formatRelativeTime } from "../utils/relative-time";
+import { useConfirm } from "./ConfirmDialog";
 
 const MCP_STARTER_PROMPT =
   "Using the mako tools, explore my data and build an app showing revenue " +
@@ -260,6 +261,7 @@ function McpConnectSection({
 
 export function ApiKeyManager() {
   const { currentWorkspace, loading: workspaceLoading } = useWorkspace();
+  const confirm = useConfirm();
   const { keys, loading, fetchKeys, createKey, deleteKey } = useApiKeyStore();
   const apiKeys = currentWorkspace ? keys[currentWorkspace.id] || [] : [];
   const isLoading = currentWorkspace
@@ -330,9 +332,12 @@ export function ApiKeyManager() {
     if (!currentWorkspace) return;
 
     if (
-      !confirm(
-        "Are you sure you want to delete this API key? This action cannot be undone.",
-      )
+      !(await confirm({
+        title: "Delete API key?",
+        body: "Are you sure you want to delete this API key? This action cannot be undone.",
+        confirmLabel: "Delete",
+        destructive: true,
+      }))
     ) {
       return;
     }

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -55,6 +55,7 @@ import { APP_DIR_SEP, APP_FILE_SEP } from "../lib/explorer-reveal";
 import { TAB_KIND_ICONS } from "../lib/entity-icons";
 import ExplorerShell from "./ExplorerShell";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
+import { useConfirm } from "./ConfirmDialog";
 
 const AppIcon = TAB_KIND_ICONS["app"];
 
@@ -152,6 +153,7 @@ function buildFileNodes(
 
 export default function AppsExplorer() {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const workspaceId = currentWorkspace?.id;
 
   const apps = useAppsStore(s => s.apps);
@@ -406,9 +408,12 @@ export default function AppsExplorer() {
     async (appId: string) => {
       if (!workspaceId) return;
       if (
-        !window.confirm(
-          "Delete this app? Its folder is removed from the workspace repo (history stays in git).",
-        )
+        !(await confirm({
+          title: "Delete this app?",
+          body: "Its folder is removed from the workspace repo (history stays in git).",
+          confirmLabel: "Delete",
+          destructive: true,
+        }))
       ) {
         return;
       }
@@ -423,7 +428,7 @@ export default function AppsExplorer() {
         }
       }
     },
-    [workspaceId, deleteApp],
+    [workspaceId, deleteApp, confirm],
   );
 
   const getContextMenuItems = useCallback(

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -49,6 +49,7 @@ import {
   StatusPill,
 } from "./bui-status";
 import { BUI_MONO_FONT_FAMILY } from "./chat/bui-styles";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface BackfillPanelProps {
   workspaceId: string;
@@ -2398,40 +2399,32 @@ export function BackfillPanel({
       </Box>
 
       {/* Reset entity table dialog */}
-      <Dialog
+      <ConfirmDialog
         open={entityResetOpen}
-        onClose={() => !busy && setEntityResetOpen(false)}
-      >
-        <DialogTitle>Reset table and rebackfill</DialogTitle>
-        <DialogContent sx={{ display: "grid", gap: 1, minWidth: 420 }}>
-          <Typography variant="body2">
-            Entity:{" "}
-            <Box
-              component="span"
-              sx={{ fontFamily: "monospace", fontWeight: 600 }}
-            >
-              {entityResetEntity ? entityLabel(entityResetEntity) : "—"}
-            </Box>
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            This drops the destination table for this entity, clears its CDC
-            state, and starts a fresh backfill.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setEntityResetOpen(false)} disabled={busy}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            color="warning"
-            disabled={!entityResetEntity || busy}
-            onClick={handleResetEntityTable}
-          >
-            {busy ? "Resetting…" : "Reset + rebackfill"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title="Reset table and rebackfill"
+        body={
+          <Box sx={{ display: "grid", gap: 1 }}>
+            <Typography variant="body2">
+              Entity:{" "}
+              <Box
+                component="span"
+                sx={{ fontFamily: "monospace", fontWeight: 600 }}
+              >
+                {entityResetEntity ? entityLabel(entityResetEntity) : "—"}
+              </Box>
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              This drops the destination table for this entity, clears its CDC
+              state, and starts a fresh backfill.
+            </Typography>
+          </Box>
+        }
+        confirmLabel="Reset + rebackfill"
+        destructive
+        busy={busy}
+        onConfirm={() => void handleResetEntityTable()}
+        onCancel={() => setEntityResetOpen(false)}
+      />
 
       {/* Reset dialog */}
       <Dialog open={resyncOpen} onClose={() => setResyncOpen(false)}>

--- a/app/src/components/CollectionEditor.tsx
+++ b/app/src/components/CollectionEditor.tsx
@@ -9,11 +9,6 @@ import {
   Box,
   Button,
   Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
   Card,
   CardContent,
   Chip,
@@ -32,6 +27,7 @@ import Editor from "@monaco-editor/react";
 import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore } from "../store/schemaStore";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface CollectionInfo {
   name: string;
@@ -211,15 +207,14 @@ db.createCollection("new_collection_name", {
   };
 
   const handleDelete = () => {
-    setIsDeleting(true);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (onDelete && selectedCollection && !isCreatingNew) {
+      setIsDeleting(true);
       try {
         await onDelete(selectedCollection);
-        setDeleteDialogOpen(false);
       } catch (error) {
         console.error("Failed to delete collection:", error);
       }
@@ -449,35 +444,16 @@ db.createCollection("new_collection_name", {
         )}
       </Box>
 
-      <Dialog
+      <ConfirmDialog
         open={deleteDialogOpen}
-        onClose={handleDeleteCancel}
-        aria-labelledby="delete-dialog-title"
-        aria-describedby="delete-dialog-description"
-      >
-        <DialogTitle id="delete-dialog-title">Delete Collection</DialogTitle>
-        <DialogContent>
-          <DialogContentText id="delete-dialog-description">
-            Are you sure you want to delete the collection &quot;
-            {selectedCollection}&quot;? This action cannot be undone and will
-            permanently delete all documents in the collection.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleDeleteCancel} disabled={isDeleting}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleDeleteConfirm}
-            color="error"
-            variant="contained"
-            disabled={isDeleting}
-            disableElevation
-          >
-            {isDeleting ? "Deleting..." : "Delete"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title="Delete Collection"
+        body={`Are you sure you want to delete the collection "${selectedCollection}"? This action cannot be undone and will permanently delete all documents in the collection.`}
+        confirmLabel="Delete"
+        destructive
+        busy={isDeleting}
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={handleDeleteCancel}
+      />
     </Box>
   );
 };

--- a/app/src/components/ConfirmDialog.tsx
+++ b/app/src/components/ConfirmDialog.tsx
@@ -1,0 +1,153 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
+/**
+ * The one confirmation primitive.
+ *
+ * Two ways in:
+ * - `<ConfirmDialog>` when the caller owns the busy/loading state (the action
+ *   runs while the dialog stays open: buttons disabled, spinner on confirm).
+ * - `useConfirm()` for the plain "are you sure?" gate from an event handler:
+ *   `if (!(await confirm({ title, body }))) return;` — backed by the one
+ *   `<ConfirmProvider>` mounted in main.tsx.
+ */
+
+export interface ConfirmOptions {
+  title: ReactNode;
+  /** A string renders as `DialogContentText`; any other node renders as-is. */
+  body?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Renders the confirm button in the error color. */
+  destructive?: boolean;
+}
+
+export interface ConfirmDialogProps extends ConfirmOptions {
+  open: boolean;
+  /** Disables both buttons, shows a spinner on confirm, ignores backdrop/escape. */
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={() => !busy && onCancel()}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="confirm-dialog-title"
+    >
+      <DialogTitle id="confirm-dialog-title">{title}</DialogTitle>
+      {body != null && body !== "" && (
+        <DialogContent>
+          {typeof body === "string" ? (
+            <DialogContentText>{body}</DialogContentText>
+          ) : (
+            body
+          )}
+        </DialogContent>
+      )}
+      <DialogActions>
+        <Button onClick={onCancel} disabled={busy}>
+          {cancelLabel}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color={destructive ? "error" : "primary"}
+          variant="contained"
+          disableElevation
+          disabled={busy}
+          startIcon={busy ? <CircularProgress size={14} /> : undefined}
+        >
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn>(() => {
+  throw new Error("useConfirm() requires a <ConfirmProvider> above it");
+});
+
+interface PendingConfirm {
+  options: ConfirmOptions;
+  resolve: (confirmed: boolean) => void;
+}
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingConfirm | null>(null);
+  // Kept after settle so the dialog fades out with its content intact.
+  const [lastOptions, setLastOptions] = useState<ConfirmOptions | null>(null);
+
+  const confirm = useCallback<ConfirmFn>(
+    options =>
+      new Promise<boolean>(resolve => {
+        setLastOptions(options);
+        setPending(prev => {
+          // A second confirm while one is open supersedes it: the first
+          // caller sees "cancelled" rather than hanging forever.
+          prev?.resolve(false);
+          return { options, resolve };
+        });
+      }),
+    [],
+  );
+
+  const settle = useCallback((confirmed: boolean) => {
+    setPending(prev => {
+      prev?.resolve(confirmed);
+      return null;
+    });
+  }, []);
+
+  const onConfirm = useCallback(() => settle(true), [settle]);
+  const onCancel = useCallback(() => settle(false), [settle]);
+
+  const options = pending?.options ?? lastOptions;
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {options && (
+        <ConfirmDialog
+          open={pending !== null}
+          {...options}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useConfirm(): ConfirmFn {
+  return useContext(ConfirmContext);
+}

--- a/app/src/components/ConnectorExplorer.tsx
+++ b/app/src/components/ConnectorExplorer.tsx
@@ -5,13 +5,7 @@ import {
   IconButton,
   CircularProgress,
   Tooltip,
-  Alert,
   MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
 } from "@mui/material";
 import {
   Plus as AddIcon,
@@ -31,6 +25,7 @@ import ResourceTree, {
   type ResourceTreeSection,
 } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface Connector {
   _id: string;
@@ -251,32 +246,15 @@ function ConnectorExplorer() {
         }
       </ExplorerShell>
 
-      <Dialog
+      <ConfirmDialog
         open={deleteDialogOpen}
-        onClose={() => setDeleteDialogOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Delete Connector</DialogTitle>
-        <DialogContent>
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            This will permanently delete the connector.
-          </Alert>
-          <Typography>
-            Are you sure you want to delete &quot;{selectedItem?.name}&quot;?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
-          <Button
-            onClick={handleDeleteConfirm}
-            color="error"
-            variant="contained"
-          >
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title="Delete Connector"
+        body={`This will permanently delete the connector. Are you sure you want to delete "${selectedItem?.name}"?`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteDialogOpen(false)}
+      />
     </>
   );
 }

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -17,13 +17,7 @@ import {
   Skeleton,
   Menu,
   MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
   Tooltip,
-  Alert,
 } from "@mui/material";
 import {
   SquareTerminal as ConsoleIcon,
@@ -45,6 +39,7 @@ import ConsoleInfoModal from "./ConsoleInfoModal";
 import FolderInfoModal from "./FolderInfoModal";
 import ConsoleTree from "./ConsoleTree";
 import ExplorerShell from "./ExplorerShell";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface ConsoleExplorerProps {
   onConsoleSelect: (
@@ -648,36 +643,19 @@ function ConsoleExplorer(
         </MenuItem>
       </Menu>
 
-      <Dialog
+      <ConfirmDialog
         open={deleteDialogOpen}
-        onClose={() => setDeleteDialogOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>
-          Delete {selectedItem?.isDirectory ? "Folder" : "Console"}
-        </DialogTitle>
-        <DialogContent>
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            {selectedItem?.isDirectory
-              ? "This will permanently delete the folder and all its contents (subfolders and consoles)."
-              : "This will permanently delete the console."}
-          </Alert>
-          <Typography>
-            Are you sure you want to delete &ldquo;{selectedItem?.name}&rdquo;?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
-          <Button
-            onClick={handleDeleteConfirm}
-            color="error"
-            variant="contained"
-          >
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title={`Delete ${selectedItem?.isDirectory ? "Folder" : "Console"}`}
+        body={`${
+          selectedItem?.isDirectory
+            ? "This will permanently delete the folder and all its contents (subfolders and consoles)."
+            : "This will permanently delete the console."
+        } Are you sure you want to delete "${selectedItem?.name}"?`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteDialogOpen(false)}
+      />
 
       <ConsoleInfoModal
         open={infoModalOpen}

--- a/app/src/components/CreateDatabaseDialog.tsx
+++ b/app/src/components/CreateDatabaseDialog.tsx
@@ -58,6 +58,7 @@ import {
   parseMySQLConnectionString,
   buildMySQLConnectionString,
 } from "../utils/mysql-connection-string";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 /** Set a value at a dot-separated path inside a nested object, creating intermediate objects as needed. */
 function setNested(obj: Record<string, any>, path: string, value: any) {
@@ -1125,40 +1126,30 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
 
       {/* Connection test failed before save: let the user fix the config or
         persist it unverified. Save anyways never counts as activation. */}
-      <Dialog
+      <ConfirmDialog
         open={failedTest.open}
-        onClose={handleEditConnection}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle>Connection test failed</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" sx={{ mb: 1 }}>
-            Mako couldn&apos;t connect to this database, so we haven&apos;t
-            saved it yet. This can happen if the credentials are wrong, or if
-            the database isn&apos;t reachable from Mako (for example a private
-            network or an allowlist).
-          </Typography>
-          {failedTest.error && (
-            <Alert severity="error" sx={{ mt: 1 }}>
-              {failedTest.error}
-            </Alert>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleEditConnection} variant="outlined">
-            Edit connection string
-          </Button>
-          <Button
-            onClick={handleSaveAnyways}
-            variant="contained"
-            disabled={loading}
-            startIcon={loading ? <CircularProgress size={16} /> : null}
-          >
-            Save anyways
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title="Connection test failed"
+        body={
+          <>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              Mako couldn&apos;t connect to this database, so we haven&apos;t
+              saved it yet. This can happen if the credentials are wrong, or if
+              the database isn&apos;t reachable from Mako (for example a private
+              network or an allowlist).
+            </Typography>
+            {failedTest.error && (
+              <Alert severity="error" sx={{ mt: 1 }}>
+                {failedTest.error}
+              </Alert>
+            )}
+          </>
+        }
+        cancelLabel="Edit connection string"
+        confirmLabel="Save anyways"
+        busy={loading}
+        onConfirm={() => void handleSaveAnyways()}
+        onCancel={handleEditConnection}
+      />
     </>
   );
 };

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -9,7 +9,6 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogContentText,
   DialogActions,
   Button,
 } from "@mui/material";
@@ -21,6 +20,7 @@ import {
   Database as DataSourceIcon,
 } from "lucide-react";
 import { TAB_KIND_ICONS } from "../lib/entity-icons";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 const DashboardIcon = TAB_KIND_ICONS.dashboard;
 import { useWorkspace } from "../contexts/workspace-context";
@@ -540,28 +540,23 @@ export function DashboardsExplorer() {
       </ExplorerShell>
 
       {/* Delete Confirmation Dialog */}
-      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
-        <DialogTitle>
-          Delete{" "}
-          {deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete ${
+          deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
             ? "Folder"
-            : "Dashboard"}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete &quot;{deleteTarget?.name}&quot;?
-            {deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
-              ? " All dashboards inside will be moved to the root level."
-              : " This action cannot be undone."}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button onClick={handleDeleteConfirm} color="error">
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+            : "Dashboard"
+        }`}
+        body={`Are you sure you want to delete "${deleteTarget?.name}"?${
+          deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
+            ? " All dashboards inside will be moved to the root level."
+            : " This action cannot be undone."
+        }`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteTarget(null)}
+      />
 
       {/* Move Dialog */}
       <Dialog

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -46,6 +46,7 @@ import ResourceTree, {
   type ResourceTreeSection,
 } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
+import { useConfirm } from "./ConfirmDialog";
 
 export interface CollectionInfo {
   name: string;
@@ -137,6 +138,7 @@ function DatabaseExplorer({
   onCollectionClick,
 }: DatabaseExplorerProps) {
   const connections = useSchemaStore(s => s.connections);
+  const confirm = useConfirm();
   const treeNodes = useSchemaStore(s => s.treeNodes);
   const loading = useSchemaStore(s => s.loading);
   const error = useSchemaStore(s => s.error);
@@ -541,9 +543,12 @@ function DatabaseExplorer({
             onClick={async () => {
               helpers.closeMenu();
               if (
-                !window.confirm(
-                  `Are you sure you want to delete database "${info.displayName}"? This action cannot be undone.`,
-                )
+                !(await confirm({
+                  title: "Delete database?",
+                  body: `Are you sure you want to delete database "${info.displayName}"? This action cannot be undone.`,
+                  confirmLabel: "Delete",
+                  destructive: true,
+                }))
               ) {
                 return;
               }
@@ -601,7 +606,7 @@ function DatabaseExplorer({
         </MenuItem>,
       ];
     },
-    [nodeInfoById, currentWorkspace, deleteConnection],
+    [nodeInfoById, currentWorkspace, deleteConnection, confirm],
   );
 
   const connectionTypeById = useMemo(() => {

--- a/app/src/components/DbFlowForm.tsx
+++ b/app/src/components/DbFlowForm.tsx
@@ -53,6 +53,7 @@ import { ConnectionSelector } from "./ConnectionSelector";
 import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
 import { SchemaMappingTable, TypeCoercion } from "./SchemaMappingTable";
 import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
+import { useConfirm } from "./ConfirmDialog";
 
 interface DbFlowFormProps {
   flowId?: string;
@@ -198,6 +199,7 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
     ref,
   ) {
     const { currentWorkspace } = useWorkspace();
+    const confirm = useConfirm();
     const {
       flows: flowsMap,
       loading: _loadingMap,
@@ -1047,14 +1049,21 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
               size="small"
               startIcon={<DeleteIcon />}
               onClick={async () => {
-                if (confirm("Are you sure you want to delete this flow?")) {
-                  if (currentWorkspace?.id) {
-                    try {
-                      await deleteFlow(currentWorkspace.id, currentFlowId);
-                      onCancel?.();
-                    } catch (error) {
-                      console.error("Failed to delete flow:", error);
-                    }
+                if (
+                  !(await confirm({
+                    title: "Are you sure you want to delete this flow?",
+                    confirmLabel: "Delete",
+                    destructive: true,
+                  }))
+                ) {
+                  return;
+                }
+                if (currentWorkspace?.id) {
+                  try {
+                    await deleteFlow(currentWorkspace.id, currentFlowId);
+                    onCancel?.();
+                  } catch (error) {
+                    console.error("Failed to delete flow:", error);
                   }
                 }
               }}

--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -56,6 +56,7 @@ import EntityLoadErrorState, {
   EntityLoadingState,
 } from "./EntityLoadErrorState";
 import { missingEntityError } from "../lib/entity-labels";
+import { useConfirmProdRun } from "../dbt-runtime/confirm-prod-run";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
@@ -94,6 +95,7 @@ function logsToProblems(logs: DbtRunLogLine[]): Problem[] {
 
 export default function DbtConsoleView({ projectId }: { projectId: string }) {
   const { currentWorkspace } = useWorkspace();
+  const confirmProdRun = useConfirmProdRun();
   const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
 
@@ -166,10 +168,7 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
 
   const handleRunCommand = useCallback(async () => {
     if (!workspaceId || !command.trim()) return;
-    if (
-      environment === "prod" &&
-      !window.confirm(`Run "${command}" against the prod environment?`)
-    ) {
+    if (environment === "prod" && !(await confirmProdRun(command))) {
       return;
     }
     setBusy("command");
@@ -207,7 +206,15 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
       }),
     );
     setBusy(null);
-  }, [workspaceId, projectId, command, environment, defer, runCommand]);
+  }, [
+    workspaceId,
+    projectId,
+    command,
+    environment,
+    defer,
+    runCommand,
+    confirmProdRun,
+  ]);
 
   const errorCount = useMemo(
     () => problems?.filter(p => p.severity === "error").length ?? 0,

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -97,6 +97,7 @@ import {
   DBT_JOB_SEP,
   DBT_RUNS_SEP,
 } from "../lib/explorer-reveal";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 function dbtDiffLanguage(path: string): string {
   if (path.endsWith(".sql")) return DBT_JINJA_LANGUAGE_ID;
@@ -2125,24 +2126,19 @@ export function DbtExplorer() {
       </Menu>
 
       {/* Delete confirmation */}
-      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
-        <DialogTitle>Delete {deleteKindLabel}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete &quot;{deleteTarget?.name}&quot;?
-            {deleteTarget?.parsed.kind === "project"
-              ? " This deletes all files, jobs and run history."
-              : ""}{" "}
-            This action cannot be undone.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button onClick={handleDeleteConfirm} color="error">
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete ${deleteKindLabel}`}
+        body={`Are you sure you want to delete "${deleteTarget?.name}"?${
+          deleteTarget?.parsed.kind === "project"
+            ? " This deletes all files, jobs and run history."
+            : ""
+        } This action cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteTarget(null)}
+      />
 
       {/* Commit & push dialog */}
       <Dialog

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -102,6 +102,7 @@ import EntityLoadErrorState, {
 } from "./EntityLoadErrorState";
 import StreamingMarkdown from "./StreamingMarkdown";
 import DbtCommandsPanel from "./DbtCommandsPanel";
+import { useConfirmProdRun } from "../dbt-runtime/confirm-prod-run";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 // The results grid drags in MUI's DataGrid (+ its stylesheet) and the charting
@@ -235,6 +236,7 @@ export default function DbtFileEditor({
   path: string;
 }) {
   const { currentWorkspace } = useWorkspace();
+  const confirmProdRun = useConfirmProdRun();
   const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
   const monacoTheme = useMonacoTheme();
@@ -620,10 +622,7 @@ export default function DbtFileEditor({
     async (verb: DbtRunVerb, scope: DbtSelectScope) => {
       if (!workspaceId || !modelName) return;
       const cmd = buildDbtNodeCommand(verb, modelName, scope, { fullRefresh });
-      if (
-        environment === "prod" &&
-        !window.confirm(`Run "dbt ${cmd}" against the prod environment?`)
-      ) {
+      if (environment === "prod" && !(await confirmProdRun(`dbt ${cmd}`))) {
         return;
       }
       saveNow();
@@ -660,15 +659,13 @@ export default function DbtFileEditor({
       runCommand,
       saveNow,
       recordInvocation,
+      confirmProdRun,
     ],
   );
 
   const handleRunCommand = useCallback(async () => {
     if (!workspaceId || !command.trim()) return;
-    if (
-      environment === "prod" &&
-      !window.confirm(`Run "${command}" against the prod environment?`)
-    ) {
+    if (environment === "prod" && !(await confirmProdRun(command))) {
       return;
     }
     saveNow();
@@ -706,6 +703,7 @@ export default function DbtFileEditor({
     runCommand,
     saveNow,
     recordInvocation,
+    confirmProdRun,
   ]);
 
   const errorCount = useMemo(

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -52,6 +52,7 @@ import {
 } from "lucide-react";
 import { tabKindIcon } from "../lib/entity-icons";
 import type { TabKind } from "../store/lib/types";
+import { useConfirm } from "./ConfirmDialog";
 
 /** Renders the canonical icon for a tab kind (see lib/entity-icons.ts). */
 function TabKindGlyph({ kind }: { kind: TabKind | undefined }) {
@@ -350,6 +351,7 @@ function Editor({
   resultsContextRef,
 }: EditorProps = {}) {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const { user } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const [tabResults, setTabResults] = useState<
@@ -1721,11 +1723,12 @@ function Editor({
       const hasChanges = !existingHash || currentHash !== existingHash;
 
       if (hasChanges) {
-        const confirmed = window.confirm(
-          `The file "${existingTab.title || conflictData.existingName}" is open in another tab with unsaved changes.\n\n` +
-            `If you proceed, those unsaved changes will be lost.\n\n` +
-            `Do you want to continue with the overwrite?`,
-        );
+        const confirmed = await confirm({
+          title: "Overwrite with unsaved changes?",
+          body: `The file "${existingTab.title || conflictData.existingName}" is open in another tab with unsaved changes. If you proceed, those unsaved changes will be lost. Do you want to continue with the overwrite?`,
+          confirmLabel: "Overwrite",
+          destructive: true,
+        });
         if (!confirmed) {
           return;
         }

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -46,6 +46,7 @@ import {
   ruleSummary,
   useNotificationRuleStore,
 } from "../store/notificationRuleStore";
+import { useConfirm } from "./ConfirmDialog";
 
 export interface FlowRunNotificationsSectionProps {
   workspaceId: string;
@@ -118,6 +119,7 @@ export function FlowRunNotificationsSection({
   );
   const fetchRules = useNotificationRuleStore(s => s.fetchRules);
   const fetchDeliveries = useNotificationRuleStore(s => s.fetchDeliveries);
+  const confirm = useConfirm();
   const createRule = useNotificationRuleStore(s => s.createRule);
   const updateRule = useNotificationRuleStore(s => s.updateRule);
   const deleteRule = useNotificationRuleStore(s => s.deleteRule);
@@ -354,7 +356,15 @@ export function FlowRunNotificationsSection({
 
   const handleDelete = async (ruleId: string) => {
     if (!workspaceId || !canManage) return;
-    if (!confirm("Delete this notification?")) return;
+    if (
+      !(await confirm({
+        title: "Delete this notification?",
+        confirmLabel: "Delete",
+        destructive: true,
+      }))
+    ) {
+      return;
+    }
     try {
       await deleteRule(workspaceId, ruleId);
     } catch (e) {

--- a/app/src/components/GitHubConnectionSection.tsx
+++ b/app/src/components/GitHubConnectionSection.tsx
@@ -40,6 +40,7 @@ import {
   type AppGithubInstallation,
   type AppGithubRepo,
 } from "../store/appsStore";
+import { useConfirm } from "./ConfirmDialog";
 
 function installationSettingsUrl(inst: AppGithubInstallation): string {
   const base =
@@ -64,6 +65,7 @@ function AccountAvatar({ login, size = 18 }: { login: string; size?: number }) {
 
 export default function GitHubConnectionSection() {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const workspaceId = currentWorkspace?.id;
   const isAdmin = useIsWorkspaceAdmin();
 
@@ -186,24 +188,30 @@ export default function GitHubConnectionSection() {
     async (owner: string, repo: string) => {
       if (!workspaceId) return;
       if (
-        !window.confirm(
-          `Disconnect ${owner}/${repo}? Its content stays in GitHub; this workspace just stops pointing at it.`,
-        )
+        !(await confirm({
+          title: `Disconnect ${owner}/${repo}?`,
+          body: "Its content stays in GitHub; this workspace just stops pointing at it.",
+          confirmLabel: "Disconnect",
+          destructive: true,
+        }))
       ) {
         return;
       }
       await disconnectRepo(workspaceId, owner, repo);
     },
-    [workspaceId, disconnectRepo],
+    [workspaceId, disconnectRepo, confirm],
   );
 
   const handleForgetInstallation = useCallback(
     async (inst: AppGithubInstallation) => {
       if (!workspaceId) return;
       if (
-        !window.confirm(
-          `Forget the "${inst.accountLogin}" account? This only clears Mako's record — it does not uninstall the app on GitHub.`,
-        )
+        !(await confirm({
+          title: `Forget the "${inst.accountLogin}" account?`,
+          body: "This only clears Mako's record — it does not uninstall the app on GitHub.",
+          confirmLabel: "Forget",
+          destructive: true,
+        }))
       ) {
         return;
       }
@@ -220,7 +228,13 @@ export default function GitHubConnectionSection() {
         setError(result.error ?? "Failed to forget account");
       }
     },
-    [workspaceId, disconnectGithubInstallation, installationId, reloadStatus],
+    [
+      workspaceId,
+      disconnectGithubInstallation,
+      installationId,
+      reloadStatus,
+      confirm,
+    ],
   );
 
   if (!isAdmin) {

--- a/app/src/components/McpAgentsPanel.tsx
+++ b/app/src/components/McpAgentsPanel.tsx
@@ -32,6 +32,7 @@ import {
 } from "../store/consoleStore";
 import { SECTION_LABELS } from "../pages/settings/sections";
 import { formatRelativeTime } from "../utils/relative-time";
+import { useConfirm } from "./ConfirmDialog";
 
 const MCP_STARTER_PROMPT =
   "Using the mako tools, explore my data and build an app showing revenue " +
@@ -310,6 +311,7 @@ export function McpConnectedAgents({
   onNotify: (message: string, severity: "success" | "error") => void;
 }) {
   const { currentWorkspace, loading: workspaceLoading } = useWorkspace();
+  const confirm = useConfirm();
   const workspaceId = currentWorkspace?.id;
   const fetchMcpConnections = useMcpStore(s => s.fetchMcpConnections);
   const revokeMcpConnection = useMcpStore(s => s.revokeMcpConnection);
@@ -343,9 +345,12 @@ export function McpConnectedAgents({
   const handleRevoke = async (connection: McpConnection) => {
     if (!workspaceId) return;
     if (
-      !confirm(
-        `Disconnect "${connection.clientName}"? The agent loses access immediately and must sign in again to reconnect.`,
-      )
+      !(await confirm({
+        title: `Disconnect "${connection.clientName}"?`,
+        body: "The agent loses access immediately and must sign in again to reconnect.",
+        confirmLabel: "Disconnect",
+        destructive: true,
+      }))
     ) {
       return;
     }

--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -45,6 +45,7 @@ import {
   type McpWriteScope,
   useMcpStore,
 } from "../store/mcpStore";
+import { useConfirm } from "./ConfirmDialog";
 
 const WRITE_SCOPE_LABELS: Record<McpWriteScope, string> = {
   read: "Read only",
@@ -902,6 +903,7 @@ function ServerDetail({
   onNotify: (message: string, severity: "success" | "error") => void;
 }) {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const {
     testServer,
     updateServer,
@@ -1005,9 +1007,12 @@ function ServerDetail({
   const handleDelete = async () => {
     if (!currentWorkspace) return;
     if (
-      !window.confirm(
-        `Remove "${server.name}"? Stored credentials and grants are deleted too.`,
-      )
+      !(await confirm({
+        title: `Remove "${server.name}"?`,
+        body: "Stored credentials and grants are deleted too.",
+        confirmLabel: "Remove",
+        destructive: true,
+      }))
     ) {
       return;
     }

--- a/app/src/components/NotebookHistoryDrawer.tsx
+++ b/app/src/components/NotebookHistoryDrawer.tsx
@@ -2,14 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Backdrop,
   Box,
-  Button,
   Chip,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   Drawer,
   IconButton,
   List,
@@ -23,6 +17,7 @@ import { History, RotateCcw, X } from "lucide-react";
 import { useNotebookStore, type NotebookVersion } from "../store/notebookStore";
 import { formatBytes } from "../utils/format";
 import { formatRelativeTime } from "../utils/relative-time";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface NotebookHistoryDrawerProps {
   open: boolean;
@@ -154,35 +149,15 @@ export default function NotebookHistoryDrawer({
         )}
       </Drawer>
 
-      <Dialog open={!!confirmId} onClose={() => setConfirmId(null)}>
-        <DialogTitle>Restore this version?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            The current notebook will be replaced with this version. This is
-            saved as a new version, so nothing is lost — you can restore the
-            current state again from history.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmId(null)} disabled={restoring}>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => void doRestore()}
-            variant="contained"
-            disabled={restoring}
-            startIcon={
-              restoring ? (
-                <CircularProgress size={14} />
-              ) : (
-                <RotateCcw size={14} />
-              )
-            }
-          >
-            Restore
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={!!confirmId}
+        title="Restore this version?"
+        body="The current notebook will be replaced with this version. This is saved as a new version, so nothing is lost — you can restore the current state again from history."
+        confirmLabel="Restore"
+        busy={restoring}
+        onConfirm={() => void doRestore()}
+        onCancel={() => setConfirmId(null)}
+      />
     </>
   );
 }

--- a/app/src/components/NotebooksExplorer.tsx
+++ b/app/src/components/NotebooksExplorer.tsx
@@ -6,16 +6,7 @@ import {
   useState,
   type ChangeEvent,
 } from "react";
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  IconButton,
-  Tooltip,
-} from "@mui/material";
+import { IconButton, Tooltip } from "@mui/material";
 import {
   Download,
   Globe as GlobeIcon,
@@ -44,6 +35,7 @@ import {
   notebookToIpynb,
   type Ipynb,
 } from "../notebook-runtime/ipynb";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 const EMPTY_TREE: ResourceTreeNode[] = [];
 
@@ -372,24 +364,19 @@ export default function NotebooksExplorer() {
         )}
       </ExplorerShell>
 
-      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
-        <DialogTitle>
-          Delete {deleteTarget?.isDirectory ? "Folder" : "Notebook"}?
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            {deleteTarget?.isDirectory
-              ? `"${deleteTarget.name}" and its subfolders will be deleted. Notebooks inside will move to the root level.`
-              : `"${deleteTarget?.name}" will be permanently deleted. This cannot be undone.`}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button color="error" onClick={() => void handleDeleteConfirm()}>
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete ${deleteTarget?.isDirectory ? "Folder" : "Notebook"}?`}
+        body={
+          deleteTarget?.isDirectory
+            ? `"${deleteTarget.name}" and its subfolders will be deleted. Notebooks inside will move to the root level.`
+            : `"${deleteTarget?.name}" will be permanently deleted. This cannot be undone.`
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => void handleDeleteConfirm()}
+        onCancel={() => setDeleteTarget(null)}
+      />
 
       <input
         ref={fileInputRef}

--- a/app/src/components/SkillsSection.tsx
+++ b/app/src/components/SkillsSection.tsx
@@ -23,6 +23,7 @@ import {
   Save as SaveIcon,
 } from "@mui/icons-material";
 import { useWorkspace } from "../contexts/workspace-context";
+import { useConfirm } from "./ConfirmDialog";
 
 interface SkillSummary {
   id: string;
@@ -53,6 +54,7 @@ function formatDate(iso: string | null | undefined): string {
 
 export function SkillsSection() {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const workspaceId = currentWorkspace?.id;
 
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -121,9 +123,12 @@ export function SkillsSection() {
   const handleDelete = async (skill: SkillSummary) => {
     if (!workspaceId) return;
     if (
-      !window.confirm(
-        `Delete skill "${skill.name}"? This is permanent — the agent can still recreate it later.`,
-      )
+      !(await confirm({
+        title: `Delete skill "${skill.name}"?`,
+        body: "This is permanent — the agent can still recreate it later.",
+        confirmLabel: "Delete",
+        destructive: true,
+      }))
     ) {
       return;
     }

--- a/app/src/components/SourceControlExplorer.tsx
+++ b/app/src/components/SourceControlExplorer.tsx
@@ -68,6 +68,7 @@ import { SECTION_LABELS } from "../pages/settings/sections";
 import { focusAppsDiffTab, focusAppsFileTab } from "../apps-runtime/shell";
 import VSScrollArea from "./VSScrollArea";
 import { basename, dirname } from "../utils/path";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 /** VS Code's status letters, in VS Code's colors. */
 const STATUS_STYLE: Record<
@@ -668,34 +669,20 @@ export default function SourceControlExplorer() {
           </DialogActions>
         </Dialog>
 
-        <Dialog open={!!confirm} onClose={() => !acting && setConfirm(null)}>
-          <DialogTitle sx={{ fontSize: 15 }}>{confirm?.title}</DialogTitle>
-          <DialogContent>
-            <Typography variant="body2">{confirm?.body}</Typography>
-          </DialogContent>
-          <DialogActions>
-            <Button
-              size="small"
-              onClick={() => setConfirm(null)}
-              disabled={acting}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="small"
-              color="error"
-              variant="contained"
-              disabled={acting}
-              onClick={async () => {
-                const paths = confirm?.paths ?? [];
-                await runGit("discard", paths);
-                setConfirm(null);
-              }}
-            >
-              {acting ? "Discarding…" : "Discard"}
-            </Button>
-          </DialogActions>
-        </Dialog>
+        <ConfirmDialog
+          open={!!confirm}
+          title={confirm?.title ?? ""}
+          body={confirm?.body}
+          confirmLabel="Discard"
+          destructive
+          busy={acting}
+          onConfirm={async () => {
+            const paths = confirm?.paths ?? [];
+            await runGit("discard", paths);
+            setConfirm(null);
+          }}
+          onCancel={() => setConfirm(null)}
+        />
 
         {error && (
           <Alert

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -68,6 +68,7 @@ import {
 } from "../store/availableEntitiesStore";
 import { trackEvent } from "../lib/analytics";
 import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
+import { useConfirm } from "./ConfirmDialog";
 
 interface SyncFlowFormProps {
   flowId?: string;
@@ -204,6 +205,7 @@ export function SyncFlowForm({
   onSwitchToDbSync,
 }: SyncFlowFormProps) {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const {
     flows: flowsMap,
     error: errorMap,
@@ -1331,14 +1333,21 @@ export function SyncFlowForm({
             size="small"
             startIcon={<DeleteIcon />}
             onClick={async () => {
-              if (confirm("Are you sure you want to delete this sync?")) {
-                if (currentWorkspace?.id) {
-                  try {
-                    await deleteFlow(currentWorkspace.id, currentFlowId);
-                    onCancel?.();
-                  } catch {
-                    setError("Failed to delete sync");
-                  }
+              if (
+                !(await confirm({
+                  title: "Are you sure you want to delete this sync?",
+                  confirmLabel: "Delete",
+                  destructive: true,
+                }))
+              ) {
+                return;
+              }
+              if (currentWorkspace?.id) {
+                try {
+                  await deleteFlow(currentWorkspace.id, currentFlowId);
+                  onCancel?.();
+                } catch {
+                  setError("Failed to delete sync");
                 }
               }
             }}

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -11,10 +11,6 @@ import {
   Tooltip,
   Button,
   CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   TextField,
   Avatar,
   Stack,
@@ -30,6 +26,7 @@ import {
 } from "../store/versionStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { formatRelativeTimeCompact } from "../utils/relative-time";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface VersionHistoryPanelProps {
   open: boolean;
@@ -457,43 +454,30 @@ export function VersionHistoryPanel({
         )}
       </Drawer>
 
-      <Dialog
+      <ConfirmDialog
         open={restoreDialogOpen}
-        onClose={() => !restoring && setRestoreDialogOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Restore Version {restoreTarget?.version}?</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            This will create a new version with the content from v
-            {restoreTarget?.version}. The current state is not lost.
-          </Typography>
-          <TextField
-            fullWidth
-            size="small"
-            label="Comment"
-            value={restoreComment}
-            onChange={e => setRestoreComment(e.target.value)}
-            placeholder="Describe the restore reason"
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => setRestoreDialogOpen(false)}
-            disabled={restoring}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handleRestoreConfirm}
-            variant="contained"
-            disabled={restoring}
-          >
-            {restoring ? "Restoring..." : "Restore"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title={`Restore Version ${restoreTarget?.version}?`}
+        body={
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              This will create a new version with the content from v
+              {restoreTarget?.version}. The current state is not lost.
+            </Typography>
+            <TextField
+              fullWidth
+              size="small"
+              label="Comment"
+              value={restoreComment}
+              onChange={e => setRestoreComment(e.target.value)}
+              placeholder="Describe the restore reason"
+            />
+          </>
+        }
+        confirmLabel="Restore"
+        busy={restoring}
+        onConfirm={() => void handleRestoreConfirm()}
+        onCancel={() => setRestoreDialogOpen(false)}
+      />
     </>
   );
 }

--- a/app/src/components/ViewEditor.tsx
+++ b/app/src/components/ViewEditor.tsx
@@ -5,16 +5,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import {
-  Box,
-  Button,
-  Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-} from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import {
   PlayArrow,
   Save as SaveIcon,
@@ -25,6 +16,7 @@ import Editor from "@monaco-editor/react";
 import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useSchemaStore } from "../store/schemaStore";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface ViewDefinition {
   name: string;
@@ -358,34 +350,16 @@ const ViewEditor = forwardRef<ViewEditorRef, ViewEditorProps>(
           )}
         </Box>
 
-        <Dialog
+        <ConfirmDialog
           open={deleteDialogOpen}
-          onClose={handleDeleteCancel}
-          aria-labelledby="delete-dialog-title"
-          aria-describedby="delete-dialog-description"
-        >
-          <DialogTitle id="delete-dialog-title">Delete View</DialogTitle>
-          <DialogContent>
-            <DialogContentText id="delete-dialog-description">
-              Are you sure you want to delete the view &quot;{selectedView}
-              &quot;? This action cannot be undone.
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleDeleteCancel} disabled={isDeleting}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleDeleteConfirm}
-              color="error"
-              variant="contained"
-              disabled={isDeleting}
-              disableElevation
-            >
-              {isDeleting ? "Deleting..." : "Delete"}
-            </Button>
-          </DialogActions>
-        </Dialog>
+          title="Delete View"
+          body={`Are you sure you want to delete the view "${selectedView}"? This action cannot be undone.`}
+          confirmLabel="Delete"
+          destructive
+          busy={isDeleting}
+          onConfirm={() => void handleDeleteConfirm()}
+          onCancel={handleDeleteCancel}
+        />
       </Box>
     );
   },

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -36,6 +36,7 @@ import {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import { trackEvent } from "../lib/analytics";
+import { useConfirm } from "./ConfirmDialog";
 
 interface MemberRow {
   id: string;
@@ -50,6 +51,7 @@ interface MemberRow {
 
 export function WorkspaceMembers() {
   const { user } = useAuth();
+  const confirm = useConfirm();
   const {
     currentWorkspace,
     members,
@@ -120,12 +122,20 @@ export function WorkspaceMembers() {
       return;
     }
 
-    if (window.confirm("Are you sure you want to remove this member?")) {
-      try {
-        await removeMember(userId);
-      } catch (error: any) {
-        setError(error.message || "Failed to remove member");
-      }
+    if (
+      !(await confirm({
+        title: "Remove member?",
+        body: "Are you sure you want to remove this member?",
+        confirmLabel: "Remove",
+        destructive: true,
+      }))
+    ) {
+      return;
+    }
+    try {
+      await removeMember(userId);
+    } catch (error: any) {
+      setError(error.message || "Failed to remove member");
     }
   };
 

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -15,7 +15,6 @@ import {
   Typography,
   Box,
   Divider,
-  Alert,
 } from "@mui/material";
 import { Copy, RotateCcw, Trash2 } from "lucide-react";
 import { useDashboardStore } from "../../store/dashboardStore";
@@ -23,6 +22,7 @@ import { useWorkspace } from "../../contexts/workspace-context";
 import { useConsoleStore } from "../../store/consoleStore";
 import MaterializationScheduleControls from "../MaterializationScheduleControls";
 import type { MaterializationScheduleValue } from "../../lib/materializationSchedule";
+import { useConfirm } from "../ConfirmDialog";
 
 interface DashboardSettingsDialogProps {
   open: boolean;
@@ -36,6 +36,7 @@ export default function DashboardSettingsDialog({
   dashboardId,
 }: DashboardSettingsDialogProps) {
   const { currentWorkspace } = useWorkspace();
+  const confirm = useConfirm();
   const workspaceId = currentWorkspace?.id;
   const dashboard = useDashboardStore(s =>
     dashboardId ? s.openDashboards[dashboardId] : undefined,
@@ -59,7 +60,6 @@ export default function DashboardSettingsDialog({
   const [crossFilterEngine, setCrossFilterEngine] = useState<
     "mosaic" | "legacy"
   >("mosaic");
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const isReadOnly = dashboard?.readOnly === true;
 
   useEffect(() => {
@@ -83,7 +83,6 @@ export default function DashboardSettingsDialog({
       setCrossFilterEnabled(dashboard.crossFilter.enabled);
       setCrossFilterResolution(dashboard.crossFilter.resolution);
       setCrossFilterEngine(dashboard.crossFilter.engine ?? "mosaic");
-      setConfirmDelete(false);
     }
   }, [dashboard, open]);
 
@@ -148,6 +147,16 @@ export default function DashboardSettingsDialog({
 
   const handleDelete = async () => {
     if (!workspaceId || !dashboard) return;
+    if (
+      !(await confirm({
+        title: "Delete dashboard?",
+        body: "This dashboard will be permanently deleted.",
+        confirmLabel: "Delete",
+        destructive: true,
+      }))
+    ) {
+      return;
+    }
     await useDashboardStore
       .getState()
       .deleteDashboard(workspaceId, dashboard._id);
@@ -333,24 +342,12 @@ export default function DashboardSettingsDialog({
                 color="error"
                 size="small"
                 startIcon={<Trash2 size={16} />}
-                onClick={() => setConfirmDelete(true)}
+                onClick={handleDelete}
               >
                 Delete
               </Button>
             )}
           </Box>
-          {confirmDelete && (
-            <Alert
-              severity="error"
-              action={
-                <Button color="error" size="small" onClick={handleDelete}>
-                  Confirm
-                </Button>
-              }
-            >
-              This dashboard will be permanently deleted.
-            </Alert>
-          )}
         </Box>
       </DialogContent>
       <DialogActions>

--- a/app/src/dbt-runtime/confirm-prod-run.ts
+++ b/app/src/dbt-runtime/confirm-prod-run.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+import { useConfirm } from "../components/ConfirmDialog";
+
+/**
+ * The one "run against prod?" gate. The dbt console and the file editor both
+ * ask it before any command targets the prod environment; `command` is the
+ * full string the user is about to run (e.g. `dbt build --select foo+`).
+ */
+export function useConfirmProdRun(): (command: string) => Promise<boolean> {
+  const confirm = useConfirm();
+  return useCallback(
+    (command: string) =>
+      confirm({
+        title: `Run "${command}" against the prod environment?`,
+        confirmLabel: "Run against prod",
+        destructive: true,
+      }),
+    [confirm],
+  );
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -10,6 +10,7 @@ import App from "./App.tsx";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { AuthProvider } from "./contexts/auth-context.tsx";
+import { ConfirmProvider } from "./components/ConfirmDialog";
 import { initializeStoreVersion } from "./store/lib/storeVersion";
 
 // Register MUI X Premium license key (same provisioning as realadvisor.crm:
@@ -47,9 +48,11 @@ ReactDOM.createRoot(rootElement).render(
       <BrowserRouter>
         <ThemeProvider>
           <CssBaseline />
-          <AuthProvider>
-            <App />
-          </AuthProvider>
+          <ConfirmProvider>
+            <AuthProvider>
+              <App />
+            </AuthProvider>
+          </ConfirmProvider>
         </ThemeProvider>
       </BrowserRouter>
     </AppErrorBoundary>

--- a/app/src/pages/settings/SettingsSandbox.tsx
+++ b/app/src/pages/settings/SettingsSandbox.tsx
@@ -15,10 +15,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   IconButton,
   LinearProgress,
   Tooltip,
@@ -33,6 +29,7 @@ import {
 import { useWorkspace } from "../../contexts/workspace-context";
 import { useAppsStore } from "../../store/appsStore";
 import { formatBytes } from "../../utils/format";
+import { ConfirmDialog } from "../../components/ConfirmDialog";
 
 interface SandboxStats {
   running: boolean;
@@ -329,9 +326,10 @@ export default function SettingsSandbox() {
         </>
       )}
 
-      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle>Kill &amp; recycle the sandbox?</DialogTitle>
-        <DialogContent>
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Kill & recycle the sandbox?"
+        body={
           <Typography variant="body2">
             Running processes, terminal sessions and{" "}
             <strong>uncommitted working-copy changes</strong> die with the
@@ -339,20 +337,13 @@ export default function SettingsSandbox() {
             work is safe. A fresh sandbox boots on your next terminal or dev
             session.
           </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
-          <Button
-            color="error"
-            variant="contained"
-            disabled={recycling}
-            onClick={() => void recycle()}
-            startIcon={recycling ? <CircularProgress size={14} /> : undefined}
-          >
-            {recycling ? "Recycling…" : "Kill it"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        }
+        confirmLabel="Kill it"
+        destructive
+        busy={recycling}
+        onConfirm={() => void recycle()}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## Why

Every "are you sure?" in the app was hand-rolled. ~16 components each carried their own open-state + `<Dialog>` + Cancel + `color="error"` action (explorers, editors, history panels, settings), and 16 more call sites used the browser's `window.confirm` — unstyled, blocking, and impossible to keep in step with the MUI theme. The dbt "run against prod?" question was phrased three slightly different ways. Nothing was shared, so nothing was consistent: some dialogs disabled Cancel while busy, some closed on backdrop click mid-action, some had no title at all.

## What

One primitive, `app/src/components/ConfirmDialog.tsx`, with two ways in:

- **`<ConfirmDialog open title body confirmLabel destructive busy onConfirm onCancel />`** for callers that own the busy state — the action runs while the dialog stays open, both buttons disabled, spinner on confirm, backdrop/escape ignored. `body` accepts a string (rendered as `DialogContentText`) or any node.
- **`useConfirm()`** → `confirm({ title, body, confirmLabel?, destructive? }): Promise<boolean>` for the plain gate from an event handler (`if (!(await confirm({...}))) return;`), backed by one `<ConfirmProvider>` mounted in `main.tsx` inside `ThemeProvider`.

Converted (14 hand-rolled dialogs): Notebooks/Dashboards/Console/Connector/Dbt explorers, ViewEditor, CollectionEditor, NotebookHistoryDrawer, VersionHistoryPanel, SourceControlExplorer, SettingsSandbox, BackfillPanel (entity reset), CreateDatabaseDialog, and DashboardSettingsDialog's inline-Alert confirm (now the hook).

Converted (16 `window.confirm` sites): DatabaseExplorer, AppsExplorer, Editor, ApiKeyManager, McpServersSection, SkillsSection, McpAgentsPanel, GitHubConnectionSection ×2, WorkspaceMembers, SyncFlowForm, DbFlowForm, FlowRunNotificationsSection, DbtConsoleView, DbtFileEditor ×2. The dbt prod gate is one `useConfirmProdRun(command)` hook (`app/src/dbt-runtime/confirm-prod-run.ts`).

Copy is kept verbatim where it existed; `window.confirm` messages gained a title (their first sentence) since the dialog has one. CollectionEditor's delete dialog used to open with both buttons already disabled (`isDeleting` was set on open, not on confirm) — fixed as part of the conversion.

Deliberately left alone: `AppHistoryPopover` (rich content + inline error) and BackfillPanel's "Reset sync" dialog (two checkboxes + a type-RESET field — a form, not a confirm).

Verification: `tsc --noEmit` clean, `eslint` on all changed files clean (0 errors; the two `editingByApp` exhaustive-deps warnings in AppsExplorer pre-exist on untouched lines), `vitest run src/store src/lib` 29 files / 218 tests passing, `DbtFileEditor.test.tsx` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
