### PR TITLE
refactor(api): one workspace-scoped resource loader

### DIFF
--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -1,4 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { workspaceResourceLoader } from "./lib/load-resource";
 import type { Context } from "hono";
 import { ConsoleManager } from "../utils/console-manager";
 import {
@@ -235,15 +236,7 @@ consoleRoutes.use("/:id/schedule", requireWorkspaceAdmin);
 consoleRoutes.use("/:id/schedule/*", requireWorkspaceAdmin);
 
 // ── Sharing (collaborators + general access) ──
-const loadConsoleById = async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId") as string;
-  const id = c.req.param("id");
-  if (!Types.ObjectId.isValid(id)) return null;
-  return SavedConsole.findOne({
-    _id: new Types.ObjectId(id),
-    workspaceId: new Types.ObjectId(workspaceId),
-  });
-};
+const loadConsoleById = workspaceResourceLoader(SavedConsole);
 
 registerCollaboratorRoutes(consoleRoutes, {
   resourceName: "Console",

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -1,4 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { workspaceResourceLoader } from "./lib/load-resource";
 import {
   Dashboard,
   DashboardFolder,
@@ -2710,15 +2711,7 @@ app.openapi(
 
 // ── Sharing (collaborators, general access, public link) ──
 
-const loadDashboardById = async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId") as string;
-  const id = c.req.param("id");
-  if (!Types.ObjectId.isValid(id)) return null;
-  return Dashboard.findOne({
-    _id: new Types.ObjectId(id),
-    workspaceId: new Types.ObjectId(workspaceId),
-  });
-};
+const loadDashboardById = workspaceResourceLoader(Dashboard);
 
 registerCollaboratorRoutes(app, {
   resourceName: "Dashboard",

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -7,6 +7,7 @@
  */
 
 import { Hono } from "hono";
+import { workspaceResourceLoader } from "./lib/load-resource";
 import { Readable } from "stream";
 import { Types } from "mongoose";
 import { z } from "zod";
@@ -483,22 +484,7 @@ dbtRoutes.post("/projects", async (c: AuthenticatedContext) => {
   }
 });
 
-async function findProject(c: AuthenticatedContext) {
-  const workspaceId = c.req.param("workspaceId");
-  const projectId = c.req.param("projectId");
-  if (
-    !workspaceId ||
-    !Types.ObjectId.isValid(workspaceId) ||
-    !projectId ||
-    !Types.ObjectId.isValid(projectId)
-  ) {
-    return null;
-  }
-  return DbtProject.findOne({
-    _id: new Types.ObjectId(projectId),
-    workspaceId: new Types.ObjectId(workspaceId),
-  });
-}
+const findProject = workspaceResourceLoader(DbtProject, "projectId");
 
 dbtRoutes.get("/projects/:projectId", async (c: AuthenticatedContext) => {
   try {

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -1,4 +1,5 @@
 import { createRoute, z } from "@hono/zod-openapi";
+import { findInWorkspace } from "./lib/load-resource";
 import {
   Flow,
   CdcChangeEvent,
@@ -46,6 +47,9 @@ import {
   validateSyncConfig,
   type IncrementalCapabilities,
 } from "@mako/schemas";
+
+/** `findOne({ _id, workspaceId })` for flows — was written inline sixteen times. */
+const findFlow = findInWorkspace(Flow);
 
 const logger = loggers.inngest("flow");
 
@@ -1095,10 +1099,7 @@ flowRoutes.openapi(
       const workspaceId = c.req.param("workspaceId") as string;
       const flowId = c.req.param("flowId") as string;
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -1165,10 +1166,7 @@ flowRoutes.openapi(
       const body = await c.req.json();
 
       // Find and validate flow
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -1590,10 +1588,7 @@ flowRoutes.openapi(
       const workspaceId = c.req.param("workspaceId");
       const flowId = c.req.param("flowId");
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -1731,10 +1726,7 @@ flowRoutes.openapi(
       const workspaceId = c.req.param("workspaceId") as string;
       const flowId = c.req.param("flowId") as string;
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -1831,10 +1823,7 @@ flowRoutes.openapi(
         );
       }
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
       }
@@ -1950,10 +1939,7 @@ flowRoutes.openapi(
         }
       }
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
       }
@@ -2156,10 +2142,7 @@ flowRoutes.openapi(
         return c.json({ success: false, error: "entity is required" }, 400);
       }
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
       }
@@ -2873,10 +2856,7 @@ flowRoutes.openapi(
 
       const body = await c.req.json().catch(() => ({}));
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
       }
@@ -4152,10 +4132,7 @@ flowRoutes.openapi(
       const flowId = c.req.param("flowId");
 
       // Verify flow exists and belongs to workspace
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -4228,10 +4205,7 @@ flowRoutes.openapi(
       const { executionId } = body;
 
       // Verify flow exists and belongs to workspace
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);
@@ -4322,10 +4296,7 @@ flowRoutes.openapi(
       const offset = parseInt(c.req.query("offset") || "0");
 
       // Verify flow exists and belongs to workspace
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
+      const flow = await findFlow(workspaceId, flowId);
 
       if (!flow) {
         return c.json({ success: false, error: "Flow not found" }, 404);

--- a/api/src/routes/lib/load-resource.ts
+++ b/api/src/routes/lib/load-resource.ts
@@ -1,0 +1,37 @@
+/**
+ * Loading a workspace-scoped resource by route param — the one shape every
+ * router used to write for itself: validate the ids, `findOne({ _id,
+ * workspaceId })`, null when absent. consoles and dashboards had
+ * byte-identical copies, dbt had a third with a different param name, and
+ * flows wrote the query inline nineteen times.
+ */
+import { Types, type Model } from "mongoose";
+import type { AuthenticatedContext } from "../../middleware/workspace.middleware";
+
+/** `findOne({ _id, workspaceId })` with id validation — null when absent. */
+export function findInWorkspace<T>(model: Model<T>) {
+  return async (workspaceId: string | undefined, id: string | undefined) => {
+    if (
+      !workspaceId ||
+      !id ||
+      !Types.ObjectId.isValid(workspaceId) ||
+      !Types.ObjectId.isValid(id)
+    ) {
+      return null;
+    }
+    return model.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+  };
+}
+
+/**
+ * The route-param flavour: `c.req.param("workspaceId")` + `c.req.param(idParam)`.
+ * Matches the `load` contract of collaborator-routes / public-share-routes.
+ */
+export function workspaceResourceLoader<T>(model: Model<T>, idParam = "id") {
+  const find = findInWorkspace(model);
+  return (c: AuthenticatedContext) =>
+    find(c.req.param("workspaceId"), c.req.param(idParam));
+}


### PR DESCRIPTION
## Why
`loadConsoleById` ≡ `loadDashboardById` (byte-identical), dbt's `findProject` a third copy with another param name, and `flows.ts` inlined `Flow.findOne({ _id, workspaceId })` 16–19 times.

## What
- `routes/lib/load-resource.ts`: `findInWorkspace(model)` (validates both ids, `findOne`) and `workspaceResourceLoader(model, idParam)` (route-param flavour; satisfies the collaborator / public-share `load` contract).
- consoles, dashboards, dbt loaders are one-liners; 11 flows copies replaced (`.lean()` / pre-built-ObjectId variants left).
- OpenAPI drift test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5