### PR TITLE
refactor(api): one folder-cycle check and one tree sort for the three managers

### DIFF
--- a/api/src/utils/console-manager.ts
+++ b/api/src/utils/console-manager.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { sortTreeNodes } from "./folder-tree";
 import * as path from "path";
 import { Types } from "mongoose";
 import {
@@ -337,19 +338,7 @@ export class ConsoleManager {
       }
     }
 
-    const sortNodes = (nodes: ConsoleFile[]) => {
-      nodes.sort((a, b) => {
-        if (a.isDirectory && !b.isDirectory) return -1;
-        if (!a.isDirectory && b.isDirectory) return 1;
-        return a.name.localeCompare(b.name);
-      });
-      for (const node of nodes) {
-        if (node.isDirectory && node.children) {
-          sortNodes(node.children);
-        }
-      }
-    };
-    sortNodes(rootItems);
+    sortTreeNodes(rootItems);
 
     return rootItems;
   }

--- a/api/src/utils/dashboard-manager.ts
+++ b/api/src/utils/dashboard-manager.ts
@@ -1,4 +1,5 @@
 import { Types } from "mongoose";
+import { sortTreeNodes, wouldCreateFolderCycle } from "./folder-tree";
 import {
   Dashboard,
   DashboardFolder,
@@ -161,19 +162,7 @@ export class DashboardManager {
       }
     }
 
-    const sortNodes = (nodes: DashboardTreeNode[]) => {
-      nodes.sort((a, b) => {
-        if (a.isDirectory && !b.isDirectory) return -1;
-        if (!a.isDirectory && b.isDirectory) return 1;
-        return a.name.localeCompare(b.name);
-      });
-      for (const node of nodes) {
-        if (node.isDirectory && node.children) {
-          sortNodes(node.children);
-        }
-      }
-    };
-    sortNodes(rootItems);
+    sortTreeNodes(rootItems);
 
     return rootItems;
   }
@@ -292,26 +281,11 @@ export class DashboardManager {
     targetParentId: string | null,
     workspaceId: string,
   ): Promise<boolean> {
-    if (!targetParentId) return false;
-    if (folderId === targetParentId) return true;
-
-    const folders = await DashboardFolder.find({
-      workspaceId: new Types.ObjectId(workspaceId),
-    }).lean();
-
-    const parentMap = new Map<string, string | undefined>();
-    for (const f of folders) {
-      parentMap.set(f._id.toString(), f.parentId?.toString());
-    }
-
-    let current: string | undefined = targetParentId;
-    const visited = new Set<string>();
-    while (current) {
-      if (current === folderId) return true;
-      if (visited.has(current)) return true;
-      visited.add(current);
-      current = parentMap.get(current);
-    }
-    return false;
+    return wouldCreateFolderCycle(
+      DashboardFolder,
+      folderId,
+      targetParentId,
+      workspaceId,
+    );
   }
 }

--- a/api/src/utils/folder-tree.ts
+++ b/api/src/utils/folder-tree.ts
@@ -1,0 +1,66 @@
+/**
+ * Folder-tree mechanics shared by every foldered resource (dashboards,
+ * notebooks, consoles). These were copied into each manager: the cycle
+ * check was byte-identical modulo the folder model, and the "folders first,
+ * then alphabetical" sort existed three times.
+ */
+import { Types, type Model } from "mongoose";
+
+interface FolderLike {
+  _id: Types.ObjectId;
+  parentId?: Types.ObjectId | null;
+}
+
+/**
+ * Would making `folderId` a child of `targetParentId` create a cycle?
+ * Walks up from the target through the workspace's folders.
+ */
+export async function wouldCreateFolderCycle<T extends FolderLike>(
+  folderModel: Model<T>,
+  folderId: string,
+  targetParentId: string | null,
+  workspaceId: string,
+): Promise<boolean> {
+  if (!targetParentId) return false;
+  if (folderId === targetParentId) return true;
+
+  const folders = await folderModel
+    .find({ workspaceId: new Types.ObjectId(workspaceId) })
+    .lean();
+
+  const parentMap = new Map<string, string | undefined>();
+  for (const f of folders as unknown as FolderLike[]) {
+    parentMap.set(f._id.toString(), f.parentId?.toString());
+  }
+
+  let current: string | undefined = targetParentId;
+  const visited = new Set<string>();
+  while (current) {
+    if (current === folderId) return true;
+    if (visited.has(current)) return true;
+    visited.add(current);
+    current = parentMap.get(current);
+  }
+  return false;
+}
+
+interface TreeNodeLike {
+  name: string;
+  isDirectory: boolean;
+  children?: TreeNodeLike[];
+}
+
+/** Folders before files, then by name — recursively, in place. */
+export function sortTreeNodes<T extends TreeNodeLike>(nodes: T[]): T[] {
+  nodes.sort((a, b) => {
+    if (a.isDirectory && !b.isDirectory) return -1;
+    if (!a.isDirectory && b.isDirectory) return 1;
+    return a.name.localeCompare(b.name);
+  });
+  for (const node of nodes) {
+    if (node.isDirectory && node.children) {
+      sortTreeNodes(node.children as T[]);
+    }
+  }
+  return nodes;
+}

--- a/api/src/utils/notebook-manager.ts
+++ b/api/src/utils/notebook-manager.ts
@@ -1,4 +1,5 @@
 import { Types } from "mongoose";
+import { sortTreeNodes, wouldCreateFolderCycle } from "./folder-tree";
 
 import {
   NotebookFolder,
@@ -203,19 +204,7 @@ export class NotebookManager {
       }
     }
 
-    const sortNodes = (nodes: NotebookTreeNode[]) => {
-      nodes.sort((a, b) => {
-        if (a.isDirectory && !b.isDirectory) return -1;
-        if (!a.isDirectory && b.isDirectory) return 1;
-        return a.name.localeCompare(b.name);
-      });
-      for (const node of nodes) {
-        if (node.isDirectory && node.children) {
-          sortNodes(node.children);
-        }
-      }
-    };
-    sortNodes(rootItems);
+    sortTreeNodes(rootItems);
 
     return rootItems;
   }
@@ -336,27 +325,12 @@ export class NotebookManager {
     targetParentId: string | null,
     workspaceId: string,
   ): Promise<boolean> {
-    if (!targetParentId) return false;
-    if (folderId === targetParentId) return true;
-
-    const folders = await NotebookFolder.find({
-      workspaceId: new Types.ObjectId(workspaceId),
-    }).lean();
-
-    const parentMap = new Map<string, string | undefined>();
-    for (const f of folders) {
-      parentMap.set(f._id.toString(), f.parentId?.toString());
-    }
-
-    let current: string | undefined = targetParentId;
-    const visited = new Set<string>();
-    while (current) {
-      if (current === folderId) return true;
-      if (visited.has(current)) return true;
-      visited.add(current);
-      current = parentMap.get(current);
-    }
-    return false;
+    return wouldCreateFolderCycle(
+      NotebookFolder,
+      folderId,
+      targetParentId,
+      workspaceId,
+    );
   }
 
   static async getEffectiveAccessForNotebook(


### PR DESCRIPTION
## What
- `utils/folder-tree.ts`: `wouldCreateFolderCycle(folderModel, …)` (was byte-identical in DashboardManager and NotebookManager) and `sortTreeNodes()` (the same closure in all three managers, consoles included).
- Managers keep their static method names; no caller changes.

Next slice of the same audit item (`buildTree` / `listSplit` / `effectiveAccess`) differs per manager in item shape and needs an adapter — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5