### PR TITLE
refactor(app): one explorer hook — useResourceTreeExplorer — for the store-side wiring every explorer repeated

### DIFF
--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   Box,
   Chip,
@@ -15,8 +15,6 @@ import {
 import {
   Plus as AddIcon,
   RefreshCw as RefreshIcon,
-  Globe as GlobeIcon,
-  User as UserIcon,
   Database as DataSourceIcon,
 } from "lucide-react";
 import { TAB_KIND_ICONS } from "../lib/entity-icons";
@@ -28,6 +26,7 @@ import { useAuth } from "../contexts/auth-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useDashboardTreeStore } from "../store/dashboardTreeStore";
+import { useResourceTreeExplorer } from "../hooks/useResourceTreeExplorer";
 import { useExplorerStore } from "../store/explorerStore";
 import {
   useExplorerRevealStore,
@@ -43,7 +42,6 @@ import { computeDashboardStateHash } from "../utils/stateHash";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
 
-const EMPTY_TREE: ResourceTreeNode[] = [];
 const DATA_SOURCES_DIR = "__datasources";
 const DASHBOARD_DATA_SOURCE_DIR_SEP = "::dashboard-data-sources::";
 const NEW_DASHBOARD_TEMPLATE = {
@@ -74,25 +72,30 @@ export function DashboardsExplorer() {
   const isAdmin =
     currentWorkspace?.role === "owner" || currentWorkspace?.role === "admin";
 
-  const myDashboards = useDashboardTreeStore(
-    s => (workspaceId && s.myItems[workspaceId]) || EMPTY_TREE,
+  // A dashboard renders as a folder (it holds its data sources) but is an
+  // item to the store; only real folders are folders. Read from the store
+  // rather than the hook's selections so the predicate can be handed to the
+  // hook without a circular definition.
+  const isDashboardEntryId = useCallback(
+    (id: string) => {
+      const s = useDashboardTreeStore.getState();
+      const nodes = workspaceId
+        ? [
+            ...(s.myItems[workspaceId] ?? []),
+            ...(s.workspaceItems[workspaceId] ?? []),
+          ]
+        : [];
+      return nodes.some(function visit(node: ResourceTreeNode): boolean {
+        if (node.id === id) return !node.isDirectory;
+        return node.children?.some(visit) ?? false;
+      });
+    },
+    [workspaceId],
   );
-  const workspaceDashboards = useDashboardTreeStore(
-    s => (workspaceId && s.workspaceItems[workspaceId]) || EMPTY_TREE,
-  );
-  const loading = useDashboardTreeStore(s =>
-    workspaceId ? !!s.loading[workspaceId] : false,
-  );
-  const error = useDashboardTreeStore(s =>
-    workspaceId ? s.error[workspaceId] || null : null,
-  );
-  const fetchTree = useDashboardTreeStore(s => s.fetchTree);
-  const moveItem = useDashboardTreeStore(s => s.moveItem);
-  const moveFolder = useDashboardTreeStore(s => s.moveFolder);
-  const createFolder = useDashboardTreeStore(s => s.createFolder);
-  const renameItem = useDashboardTreeStore(s => s.renameItem);
-  const deleteItem = useDashboardTreeStore(s => s.deleteItem);
-  const resortItem = useDashboardTreeStore(s => s.resortItem);
+  const tree = useResourceTreeExplorer(useDashboardTreeStore, workspaceId, {
+    isFolder: (id, isDirectory) => isDirectory && !isDashboardEntryId(id),
+  });
+  const { loading, fetchTree } = tree;
   const createDashboard = useDashboardStore(s => s.createDashboard);
   const duplicateDashboard = useDashboardStore(s => s.duplicateDashboard);
   const openDashboard = useDashboardStore(s => s.openDashboard);
@@ -111,26 +114,13 @@ export function DashboardsExplorer() {
 
   const reveal = useExplorerRevealStore(selectRevealFor("dashboards"));
 
-  const { openTab, setActiveTab, activeTabId, tabs } = useConsoleStore();
+  const { activeTabId, tabs } = useConsoleStore();
 
-  const [deleteTarget, setDeleteTarget] = useState<ResourceTreeNode | null>(
-    null,
-  );
   const [moveTarget, setMoveTarget] = useState<ResourceTreeNode | null>(null);
   const [infoTarget, setInfoTarget] = useState<ResourceTreeNode | null>(null);
   const [loadingDashboards, setLoadingDashboards] = useState<
     Record<string, boolean>
   >({});
-
-  useEffect(() => {
-    if (workspaceId) {
-      fetchTree(workspaceId);
-    }
-  }, [workspaceId, fetchTree]);
-
-  const handleRefresh = useCallback(async () => {
-    if (workspaceId) await fetchTree(workspaceId);
-  }, [workspaceId, fetchTree]);
 
   const handleCreate = useCallback(async () => {
     if (!workspaceId) return;
@@ -149,60 +139,18 @@ export function DashboardsExplorer() {
     void fetchTree(workspaceId);
   }, [workspaceId, createDashboard, fetchTree]);
 
-  const handleItemClick = useCallback(
-    (node: ResourceTreeNode) => {
-      if (node.id.includes(DASHBOARD_DATA_SOURCE_SEP)) {
-        const [dashboardId, dataSourceId] = node.id.split(
-          DASHBOARD_DATA_SOURCE_SEP,
-        );
-        focusDashboardDataSourceTab(dashboardId, dataSourceId, node.name);
-        return;
-      }
-      if (node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)) return;
-
-      const existingTab = Object.values(tabs).find(
-        (tab: any) =>
-          tab.kind === "dashboard" && tab.metadata?.dashboardId === node.id,
+  const handleItemClick = useCallback((node: ResourceTreeNode) => {
+    if (node.id.includes(DASHBOARD_DATA_SOURCE_SEP)) {
+      const [dashboardId, dataSourceId] = node.id.split(
+        DASHBOARD_DATA_SOURCE_SEP,
       );
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        const id = openTab({
-          title: node.name,
-          content: "",
-          kind: "dashboard",
-          metadata: { dashboardId: node.id },
-        });
-        setActiveTab(id);
-      }
-    },
-    [tabs, openTab, setActiveTab],
-  );
+      focusDashboardDataSourceTab(dashboardId, dataSourceId, node.name);
+      return;
+    }
+    if (node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)) return;
 
-  const handleDeleteItem = useCallback((node: ResourceTreeNode) => {
-    setDeleteTarget(node);
+    focusDashboardTab(node.id, node.name);
   }, []);
-
-  const isDashboardEntryId = useCallback(
-    (id: string) =>
-      [...myDashboards, ...workspaceDashboards].some(function visit(
-        node: ResourceTreeNode,
-      ): boolean {
-        if (node.id === id) return !node.isDirectory;
-        return node.children?.some(visit) ?? false;
-      }),
-    [myDashboards, workspaceDashboards],
-  );
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteTarget || !workspaceId) return;
-    await deleteItem(
-      workspaceId,
-      deleteTarget.id,
-      deleteTarget.isDirectory && !isDashboardEntryId(deleteTarget.id),
-    );
-    setDeleteTarget(null);
-  }, [deleteTarget, workspaceId, deleteItem, isDashboardEntryId]);
 
   const handleDuplicate = useCallback(
     async (node: ResourceTreeNode) => {
@@ -210,85 +158,10 @@ export function DashboardsExplorer() {
       const result = await duplicateDashboard(workspaceId, node.id);
       if (result) {
         await fetchTree(workspaceId);
-        const id = openTab({
-          title: result.title,
-          content: "",
-          kind: "dashboard",
-          metadata: { dashboardId: result._id },
-        });
-        setActiveTab(id);
+        focusDashboardTab(result._id, result.title);
       }
     },
-    [workspaceId, duplicateDashboard, fetchTree, openTab, setActiveTab],
-  );
-
-  const handleCreateFolder = useCallback(
-    async (
-      parentId: string | null,
-      access?: string,
-    ): Promise<{ id: string; name: string } | null> => {
-      if (!workspaceId) return null;
-      const id = await createFolder(
-        workspaceId,
-        "New Folder",
-        parentId,
-        (access as "private" | "workspace") || undefined,
-      );
-      return id ? { id, name: "New Folder" } : null;
-    },
-    [workspaceId, createFolder],
-  );
-
-  const handleMoveItem = useCallback(
-    (itemId: string, targetFolderId: string | null, access?: string) => {
-      if (!workspaceId) return;
-      moveItem(
-        workspaceId,
-        itemId,
-        targetFolderId,
-        (access as "private" | "workspace") || undefined,
-      );
-    },
-    [workspaceId, moveItem],
-  );
-
-  const handleMoveFolder = useCallback(
-    (folderId: string, parentId: string | null, access?: string) => {
-      if (!workspaceId) return;
-      const isDashboard = isDashboardEntryId(folderId);
-      if (isDashboard) {
-        moveItem(
-          workspaceId,
-          folderId,
-          parentId,
-          (access as "private" | "workspace") || undefined,
-        );
-        return;
-      }
-      moveFolder(
-        workspaceId,
-        folderId,
-        parentId,
-        (access as "private" | "workspace") || undefined,
-      );
-    },
-    [workspaceId, isDashboardEntryId, moveItem, moveFolder],
-  );
-
-  const handleRenameItem = useCallback(
-    (id: string, name: string, isDirectory: boolean) => {
-      if (!workspaceId) return;
-      renameItem(workspaceId, id, name, isDirectory && !isDashboardEntryId(id));
-    },
-    [workspaceId, renameItem, isDashboardEntryId],
-  );
-
-  const handleResortItem = useCallback(
-    (id: string) => {
-      if (!workspaceId) return;
-      resortItem(workspaceId, id);
-    },
-    [workspaceId, resortItem],
+    [workspaceId, duplicateDashboard, fetchTree],
   );
 
   const canManageItem = useCallback(
@@ -395,25 +268,8 @@ export function DashboardsExplorer() {
   );
 
   const sectionsDef = useMemo(
-    () => [
-      {
-        key: "my",
-        label: "My Dashboards",
-        icon: <UserIcon size={16} strokeWidth={1.5} />,
-        nodes: withDataSourceNodes(myDashboards as ResourceTreeNode[]),
-        droppableId: "__section_my",
-        defaultAccess: "private" as const,
-      },
-      {
-        key: "workspace",
-        label: "Workspace",
-        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
-        nodes: withDataSourceNodes(workspaceDashboards as ResourceTreeNode[]),
-        droppableId: "__section_workspace",
-        defaultAccess: "workspace" as const,
-      },
-    ],
-    [myDashboards, workspaceDashboards, withDataSourceNodes],
+    () => tree.sections({ my: "My Dashboards" }, withDataSourceNodes),
+    [tree, withDataSourceNodes],
   );
 
   const folderOnlyNodes = useCallback(function onlyFolders(
@@ -428,25 +284,8 @@ export function DashboardsExplorer() {
   }, []);
 
   const pickerSectionsDef = useMemo(
-    () => [
-      {
-        key: "my",
-        label: "My Dashboards",
-        icon: <UserIcon size={16} strokeWidth={1.5} />,
-        nodes: folderOnlyNodes(myDashboards as ResourceTreeNode[]),
-        droppableId: "__section_my",
-        defaultAccess: "private" as const,
-      },
-      {
-        key: "workspace",
-        label: "Workspace",
-        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
-        nodes: folderOnlyNodes(workspaceDashboards as ResourceTreeNode[]),
-        droppableId: "__section_workspace",
-        defaultAccess: "workspace" as const,
-      },
-    ],
-    [myDashboards, workspaceDashboards, folderOnlyNodes],
+    () => tree.sections({ my: "My Dashboards" }, folderOnlyNodes),
+    [tree, folderOnlyNodes],
   );
 
   const activeDashboardTabId = (() => {
@@ -469,15 +308,16 @@ export function DashboardsExplorer() {
         </IconButton>
       </Tooltip>
       <Tooltip title="Refresh">
-        <IconButton size="small" onClick={handleRefresh} disabled={loading}>
+        <IconButton
+          size="small"
+          onClick={() => void tree.refresh()}
+          disabled={loading}
+        >
           <RefreshIcon size={20} strokeWidth={2} />
         </IconButton>
       </Tooltip>
     </>
   );
-
-  const isInitialLoading =
-    loading && myDashboards.length === 0 && workspaceDashboards.length === 0;
 
   return (
     <>
@@ -485,20 +325,9 @@ export function DashboardsExplorer() {
         title="Dashboards"
         actions={actions}
         searchPlaceholder="Search dashboards..."
-        error={error}
-        onErrorClose={() => {
-          if (workspaceId) {
-            useDashboardTreeStore.setState(state => {
-              state.error[workspaceId] = null;
-            });
-          }
-        }}
-        loading={isInitialLoading}
-        skeleton={
-          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
-            <Typography variant="body2">Loading...</Typography>
-          </Box>
-        }
+        error={tree.error}
+        onErrorClose={tree.clearError}
+        loading={tree.isInitialLoading}
       >
         {({ searchQuery }) => (
           <ResourceTree
@@ -518,13 +347,8 @@ export function DashboardsExplorer() {
             shouldFolderClickActivate={node => node.entityType === "dashboard"}
             onLoadChildren={handleLoadChildren}
             isLoadingChildren={node => !!loadingDashboards[node.id]}
-            onMoveItem={handleMoveItem}
-            onMoveFolder={handleMoveFolder}
-            onRenameItem={handleRenameItem}
-            onDeleteItem={handleDeleteItem}
+            {...tree.treeHandlers}
             onDuplicateItem={handleDuplicate}
-            onCreateFolder={handleCreateFolder}
-            onResortItem={handleResortItem}
             enableMove
             enableInfo
             onMoveRequest={handleMoveRequest}
@@ -541,21 +365,23 @@ export function DashboardsExplorer() {
 
       {/* Delete Confirmation Dialog */}
       <ConfirmDialog
-        open={!!deleteTarget}
+        open={!!tree.deleteTarget}
         title={`Delete ${
-          deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
+          tree.deleteTarget?.isDirectory &&
+          !isDashboardEntryId(tree.deleteTarget.id)
             ? "Folder"
             : "Dashboard"
         }`}
-        body={`Are you sure you want to delete "${deleteTarget?.name}"?${
-          deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
+        body={`Are you sure you want to delete "${tree.deleteTarget?.name}"?${
+          tree.deleteTarget?.isDirectory &&
+          !isDashboardEntryId(tree.deleteTarget.id)
             ? " All dashboards inside will be moved to the root level."
             : " This action cannot be undone."
         }`}
         confirmLabel="Delete"
         destructive
-        onConfirm={() => void handleDeleteConfirm()}
-        onCancel={() => setDeleteTarget(null)}
+        onConfirm={() => void tree.confirmDelete()}
+        onCancel={tree.cancelDelete}
       />
 
       {/* Move Dialog */}
@@ -585,13 +411,12 @@ export function DashboardsExplorer() {
               if (!moveTarget || !workspaceId) return;
               const access =
                 sectionKey === "workspace" ? "workspace" : "private";
-              if (
-                moveTarget.isDirectory &&
-                !isDashboardEntryId(moveTarget.id)
-              ) {
-                moveFolder(workspaceId, moveTarget.id, folderId, access);
+              // onMoveFolder already moves a dashboard-that-looks-like-a-
+              // folder as an item.
+              if (moveTarget.isDirectory) {
+                tree.treeHandlers.onMoveFolder(moveTarget.id, folderId, access);
               } else {
-                moveItem(workspaceId, moveTarget.id, folderId, access);
+                tree.treeHandlers.onMoveItem(moveTarget.id, folderId, access);
               }
               setMoveTarget(null);
             }}

--- a/app/src/components/NotebooksExplorer.tsx
+++ b/app/src/components/NotebooksExplorer.tsx
@@ -1,20 +1,11 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-} from "react";
+import { useCallback, useRef, type ChangeEvent } from "react";
 import { IconButton, Tooltip } from "@mui/material";
 import {
   Download,
-  Globe as GlobeIcon,
   Notebook as NotebookIcon,
   Plus,
   RefreshCw as RefreshIcon,
   Upload,
-  User as UserIcon,
 } from "lucide-react";
 
 import ExplorerShell from "./ExplorerShell";
@@ -28,6 +19,7 @@ import {
 } from "../store/explorerRevealStore";
 import { useNotebookStore } from "../store/notebookStore";
 import { useNotebookTreeStore } from "../store/notebookTreeStore";
+import { useResourceTreeExplorer } from "../hooks/useResourceTreeExplorer";
 import { focusNotebookTab } from "../notebook-runtime/shell";
 import {
   blocksFromIpynb,
@@ -37,31 +29,17 @@ import {
 } from "../notebook-runtime/ipynb";
 import { ConfirmDialog } from "./ConfirmDialog";
 
-const EMPTY_TREE: ResourceTreeNode[] = [];
-
 export default function NotebooksExplorer() {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
 
-  const myNotebooks = useNotebookTreeStore(
-    s => (workspaceId && s.myItems[workspaceId]) || EMPTY_TREE,
-  );
-  const workspaceNotebooks = useNotebookTreeStore(
-    s => (workspaceId && s.workspaceItems[workspaceId]) || EMPTY_TREE,
-  );
-  const loading = useNotebookTreeStore(s =>
-    workspaceId ? !!s.loading[workspaceId] : false,
-  );
-  const error = useNotebookTreeStore(s =>
-    workspaceId ? s.error[workspaceId] || null : null,
-  );
-  const fetchTree = useNotebookTreeStore(s => s.fetchTree);
-  const moveItem = useNotebookTreeStore(s => s.moveItem);
-  const moveFolder = useNotebookTreeStore(s => s.moveFolder);
-  const createFolder = useNotebookTreeStore(s => s.createFolder);
-  const renameItem = useNotebookTreeStore(s => s.renameItem);
-  const deleteItem = useNotebookTreeStore(s => s.deleteItem);
-  const resortItem = useNotebookTreeStore(s => s.resortItem);
+  const tree = useResourceTreeExplorer(useNotebookTreeStore, workspaceId);
+  const {
+    myItems: myNotebooks,
+    workspaceItems: workspaceNotebooks,
+    loading,
+    fetchTree,
+  } = tree;
 
   const createNotebook = useNotebookStore(s => s.createNotebook);
   const getNotebook = useNotebookStore(s => s.getNotebook);
@@ -82,20 +60,7 @@ export default function NotebooksExplorer() {
 
   const { activeTabId, tabs } = useConsoleStore();
 
-  const [deleteTarget, setDeleteTarget] = useState<ResourceTreeNode | null>(
-    null,
-  );
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (workspaceId) {
-      void fetchTree(workspaceId);
-    }
-  }, [workspaceId, fetchTree]);
-
-  const handleRefresh = useCallback(async () => {
-    if (workspaceId) await fetchTree(workspaceId);
-  }, [workspaceId, fetchTree]);
 
   const handleCreate = useCallback(async () => {
     const doc = await createNotebook();
@@ -168,96 +133,7 @@ export default function NotebooksExplorer() {
     [getNotebook],
   );
 
-  const handleMoveItem = useCallback(
-    (itemId: string, targetFolderId: string | null, access?: string) => {
-      if (!workspaceId) return;
-      void moveItem(
-        workspaceId,
-        itemId,
-        targetFolderId,
-        (access as "private" | "workspace") || undefined,
-      );
-    },
-    [workspaceId, moveItem],
-  );
-
-  const handleMoveFolder = useCallback(
-    (folderId: string, parentId: string | null, access?: string) => {
-      if (!workspaceId) return;
-      void moveFolder(
-        workspaceId,
-        folderId,
-        parentId,
-        (access as "private" | "workspace") || undefined,
-      );
-    },
-    [workspaceId, moveFolder],
-  );
-
-  const handleRenameItem = useCallback(
-    (itemId: string, name: string, isDirectory: boolean) => {
-      if (!workspaceId) return;
-      void renameItem(workspaceId, itemId, name, isDirectory);
-    },
-    [workspaceId, renameItem],
-  );
-
-  const handleDeleteItem = useCallback((node: ResourceTreeNode) => {
-    setDeleteTarget(node);
-  }, []);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteTarget || !workspaceId) return;
-    await deleteItem(workspaceId, deleteTarget.id, deleteTarget.isDirectory);
-    setDeleteTarget(null);
-  }, [deleteTarget, workspaceId, deleteItem]);
-
-  const handleCreateFolder = useCallback(
-    async (
-      parentId: string | null,
-      access?: string,
-    ): Promise<{ id: string; name: string } | null> => {
-      if (!workspaceId) return null;
-      const id = await createFolder(
-        workspaceId,
-        "New Folder",
-        parentId,
-        (access as "private" | "workspace") || undefined,
-      );
-      return id ? { id, name: "New Folder" } : null;
-    },
-    [workspaceId, createFolder],
-  );
-
-  const handleResortItem = useCallback(
-    (itemId: string) => {
-      if (!workspaceId) return;
-      resortItem(workspaceId, itemId);
-    },
-    [workspaceId, resortItem],
-  );
-
-  const sectionsDef = useMemo(
-    () => [
-      {
-        key: "my",
-        label: "My Notebooks",
-        icon: <UserIcon size={16} strokeWidth={1.5} />,
-        nodes: myNotebooks as ResourceTreeNode[],
-        droppableId: "__section_my",
-        defaultAccess: "private" as const,
-      },
-      {
-        key: "workspace",
-        label: "Workspace",
-        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
-        nodes: workspaceNotebooks as ResourceTreeNode[],
-        droppableId: "__section_workspace",
-        defaultAccess: "workspace" as const,
-      },
-    ],
-    [myNotebooks, workspaceNotebooks],
-  );
+  const sectionsDef = tree.sections({ my: "My Notebooks" });
 
   const activeNotebookTabId = (() => {
     if (!activeTabId) return null;
@@ -306,7 +182,7 @@ export default function NotebooksExplorer() {
       <Tooltip title="Refresh">
         <IconButton
           size="small"
-          onClick={() => void handleRefresh()}
+          onClick={() => void tree.refresh()}
           disabled={loading}
         >
           <RefreshIcon size={20} strokeWidth={2} />
@@ -315,23 +191,14 @@ export default function NotebooksExplorer() {
     </>
   );
 
-  const isInitialLoading =
-    loading && myNotebooks.length === 0 && workspaceNotebooks.length === 0;
-
   return (
     <>
       <ExplorerShell
         title="Notebooks"
         searchPlaceholder="Search notebooks..."
-        loading={isInitialLoading}
-        error={error}
-        onErrorClose={() => {
-          if (workspaceId) {
-            useNotebookTreeStore.setState(state => {
-              state.error[workspaceId] = null;
-            });
-          }
-        }}
+        loading={tree.isInitialLoading}
+        error={tree.error}
+        onErrorClose={tree.clearError}
         actions={actions}
       >
         {({ searchQuery }) => (
@@ -349,13 +216,8 @@ export default function NotebooksExplorer() {
             enableDelete
             enableNewFolder
             onItemClick={handleItemClick}
-            onMoveItem={handleMoveItem}
-            onMoveFolder={handleMoveFolder}
-            onRenameItem={handleRenameItem}
-            onDeleteItem={handleDeleteItem}
+            {...tree.treeHandlers}
             onDuplicateItem={handleDuplicate}
-            onCreateFolder={handleCreateFolder}
-            onResortItem={handleResortItem}
             isFolderExpanded={isNotebookFolderExpanded}
             onToggleFolder={toggleNotebookFolder}
             onExpandFolder={expandNotebookFolder}
@@ -365,17 +227,17 @@ export default function NotebooksExplorer() {
       </ExplorerShell>
 
       <ConfirmDialog
-        open={!!deleteTarget}
-        title={`Delete ${deleteTarget?.isDirectory ? "Folder" : "Notebook"}?`}
+        open={!!tree.deleteTarget}
+        title={`Delete ${tree.deleteTarget?.isDirectory ? "Folder" : "Notebook"}?`}
         body={
-          deleteTarget?.isDirectory
-            ? `"${deleteTarget.name}" and its subfolders will be deleted. Notebooks inside will move to the root level.`
-            : `"${deleteTarget?.name}" will be permanently deleted. This cannot be undone.`
+          tree.deleteTarget?.isDirectory
+            ? `"${tree.deleteTarget.name}" and its subfolders will be deleted. Notebooks inside will move to the root level.`
+            : `"${tree.deleteTarget?.name}" will be permanently deleted. This cannot be undone.`
         }
         confirmLabel="Delete"
         destructive
-        onConfirm={() => void handleDeleteConfirm()}
-        onCancel={() => setDeleteTarget(null)}
+        onConfirm={() => void tree.confirmDelete()}
+        onCancel={tree.cancelDelete}
       />
 
       <input

--- a/app/src/hooks/useResourceTreeExplorer.tsx
+++ b/app/src/hooks/useResourceTreeExplorer.tsx
@@ -1,0 +1,215 @@
+/**
+ * The explorer half of a foldered resource — what every explorer used to
+ * re-implement above its <ResourceTree>: select the two sections for the
+ * current workspace, fetch on workspace change, the loading/error flags,
+ * the "delete this node?" state, and the move / rename / create-folder /
+ * delete / resort handlers that just forward to the store. Notebooks and
+ * dashboards had these blocks line-for-line; consoles and apps had their
+ * own variants. With createResourceTreeStore owning the store side, an
+ * explorer is now its kind-specific bits (create, click, icons, extra
+ * dialogs) on top of this hook.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { StoreApi, UseBoundStore } from "zustand";
+import { Globe as GlobeIcon, User as UserIcon } from "lucide-react";
+import type {
+  ResourceTreeEntry,
+  ResourceTreeState,
+  TreeAccessLevel,
+} from "../store/lib/createResourceTreeStore";
+import type {
+  ResourceTreeNode,
+  ResourceTreeSection,
+} from "../components/ResourceTree";
+
+const EMPTY: ResourceTreeNode[] = [];
+
+type TreeStore<T extends ResourceTreeEntry> = UseBoundStore<
+  StoreApi<ResourceTreeState<T>>
+>;
+
+export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
+  store: TreeStore<T>,
+  workspaceId: string | undefined,
+  options: {
+    /**
+     * Whether a node that renders as a directory is a real folder for the
+     * store (dashboards render as folders holding their data sources, but
+     * are items). Default: the node's own `isDirectory`.
+     */
+    isFolder?: (id: string, isDirectory: boolean) => boolean;
+  } = {},
+) {
+  const isFolderOption = options.isFolder;
+  const isFolder = useMemo(
+    () => isFolderOption ?? ((_id: string, d: boolean) => d),
+    [isFolderOption],
+  );
+
+  const myItems = store(s =>
+    workspaceId
+      ? ((s.myItems[workspaceId] as ResourceTreeNode[]) ?? EMPTY)
+      : EMPTY,
+  );
+  const workspaceItems = store(s =>
+    workspaceId
+      ? ((s.workspaceItems[workspaceId] as ResourceTreeNode[]) ?? EMPTY)
+      : EMPTY,
+  );
+  const loading = store(s => (workspaceId ? !!s.loading[workspaceId] : false));
+  const error = store(s => (workspaceId ? s.error[workspaceId] || null : null));
+  const fetchTree = store(s => s.fetchTree);
+  const moveItem = store(s => s.moveItem);
+  const moveFolder = store(s => s.moveFolder);
+  const createFolder = store(s => s.createFolder);
+  const renameItem = store(s => s.renameItem);
+  const deleteItem = store(s => s.deleteItem);
+  const resortItem = store(s => s.resortItem);
+
+  useEffect(() => {
+    if (workspaceId) void fetchTree(workspaceId);
+  }, [workspaceId, fetchTree]);
+
+  const refresh = useCallback(async () => {
+    if (workspaceId) await fetchTree(workspaceId);
+  }, [workspaceId, fetchTree]);
+
+  const clearError = useCallback(() => {
+    if (!workspaceId) return;
+    store.setState(state => ({
+      error: { ...state.error, [workspaceId]: null },
+    }));
+  }, [store, workspaceId]);
+
+  const [deleteTarget, setDeleteTarget] = useState<ResourceTreeNode | null>(
+    null,
+  );
+  const requestDelete = useCallback(
+    (node: ResourceTreeNode) => setDeleteTarget(node),
+    [],
+  );
+  const cancelDelete = useCallback(() => setDeleteTarget(null), []);
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget || !workspaceId) return;
+    await deleteItem(
+      workspaceId,
+      deleteTarget.id,
+      isFolder(deleteTarget.id, deleteTarget.isDirectory),
+    );
+    setDeleteTarget(null);
+  }, [deleteTarget, workspaceId, deleteItem, isFolder]);
+
+  const access = (a?: string) => (a as TreeAccessLevel) || undefined;
+
+  const onMoveItem = useCallback(
+    (itemId: string, targetFolderId: string | null, a?: string) => {
+      if (!workspaceId) return;
+      void moveItem(workspaceId, itemId, targetFolderId, access(a));
+    },
+    [workspaceId, moveItem],
+  );
+  const onMoveFolder = useCallback(
+    (folderId: string, parentId: string | null, a?: string) => {
+      if (!workspaceId) return;
+      // A node that only LOOKS like a folder moves as an item.
+      if (!isFolder(folderId, true)) {
+        void moveItem(workspaceId, folderId, parentId, access(a));
+        return;
+      }
+      void moveFolder(workspaceId, folderId, parentId, access(a));
+    },
+    [workspaceId, isFolder, moveItem, moveFolder],
+  );
+  const onRenameItem = useCallback(
+    (id: string, name: string, isDirectory: boolean) => {
+      if (!workspaceId) return;
+      void renameItem(workspaceId, id, name, isFolder(id, isDirectory));
+    },
+    [workspaceId, renameItem, isFolder],
+  );
+  const onCreateFolder = useCallback(
+    async (
+      parentId: string | null,
+      a?: string,
+    ): Promise<{ id: string; name: string } | null> => {
+      if (!workspaceId) return null;
+      const id = await createFolder(
+        workspaceId,
+        "New Folder",
+        parentId,
+        access(a),
+      );
+      return id ? { id, name: "New Folder" } : null;
+    },
+    [workspaceId, createFolder],
+  );
+  const onResortItem = useCallback(
+    (id: string) => {
+      if (workspaceId) resortItem(workspaceId, id);
+    },
+    [workspaceId, resortItem],
+  );
+
+  const treeHandlers = useMemo(
+    () => ({
+      onMoveItem,
+      onMoveFolder,
+      onRenameItem,
+      onDeleteItem: requestDelete,
+      onCreateFolder,
+      onResortItem,
+    }),
+    [
+      onMoveItem,
+      onMoveFolder,
+      onRenameItem,
+      requestDelete,
+      onCreateFolder,
+      onResortItem,
+    ],
+  );
+
+  /** The two standard sections; `mapNodes` decorates each section's tree. */
+  const sections = useCallback(
+    (
+      labels: { my: string; workspace?: string },
+      mapNodes: (nodes: ResourceTreeNode[]) => ResourceTreeNode[] = n => n,
+    ): ResourceTreeSection[] => [
+      {
+        key: "my",
+        label: labels.my,
+        icon: <UserIcon size={16} strokeWidth={1.5} />,
+        nodes: mapNodes(myItems),
+        droppableId: "__section_my",
+        defaultAccess: "private" as const,
+      },
+      {
+        key: "workspace",
+        label: labels.workspace ?? "Workspace",
+        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
+        nodes: mapNodes(workspaceItems),
+        droppableId: "__section_workspace",
+        defaultAccess: "workspace" as const,
+      },
+    ],
+    [myItems, workspaceItems],
+  );
+
+  return {
+    myItems,
+    workspaceItems,
+    loading,
+    error,
+    clearError,
+    isInitialLoading:
+      loading && myItems.length === 0 && workspaceItems.length === 0,
+    fetchTree,
+    refresh,
+    deleteTarget,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    treeHandlers,
+    sections,
+  };
+}


### PR DESCRIPTION
## Why
NotebooksExplorer and DashboardsExplorer repeated the same block above `<ResourceTree>`: section selectors, fetch-on-workspace effect, loading/error, delete-target state, and move/rename/create-folder/delete/resort handlers that forward to the store.

## What
- `hooks/useResourceTreeExplorer(store, workspaceId, { isFolder? })` on top of `createResourceTreeStore` (#851): returns `{ myItems, workspaceItems, loading, error, clearError, isInitialLoading, refresh, deleteTarget, requestDelete/confirmDelete/cancelDelete, treeHandlers, sections(labels, mapNodes?) }`.
- Both explorers rebuilt on it; dashboards pass `isFolder` for their dashboard-as-folder twist (move dialog reuses the hook's handler).
- Dashboards' hand-rolled open-or-focus (click + duplicate) → `focusDashboardTab`.
- Next: ConsoleTree/ConsoleExplorer once `consoleTreeStore` moves to the factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5