### PR TITLE
refactor(app): consoleTreeStore on createResourceTreeStore

### DIFF
--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -3,7 +3,6 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
-  useEffect,
   useCallback,
 } from "react";
 import {
@@ -34,6 +33,7 @@ import {
 import { useConsoleStore } from "../store/consoleStore";
 import { useConsoleContentStore } from "../store/consoleContentStore";
 import { filterTree } from "../store/lib/tree-helpers";
+import { useResourceTreeExplorer } from "../hooks/useResourceTreeExplorer";
 import FileExplorerDialog from "./FileExplorerDialog";
 import ConsoleInfoModal from "./ConsoleInfoModal";
 import FolderInfoModal from "./FolderInfoModal";
@@ -64,9 +64,20 @@ function ConsoleExplorer(
   const { onConsoleSelect } = props;
   const { currentWorkspace } = useWorkspace();
 
-  const loadingMap = useConsoleTreeStore(state => state.loading);
-  const refreshTree = useConsoleTreeStore(state => state.refresh);
-  const moveConsole = useConsoleTreeStore(state => state.moveConsole);
+  // The console tree is preloaded by workspace-context (so it is ready for
+  // optimistic addConsole calls before this explorer mounts) — no autoFetch.
+  const tree = useResourceTreeExplorer(
+    useConsoleTreeStore,
+    currentWorkspace?.id,
+    { autoFetch: false },
+  );
+  const {
+    myItems: myConsoles,
+    workspaceItems: sharedWithWorkspace,
+    loading,
+    error,
+  } = tree;
+  const moveConsole = useConsoleTreeStore(state => state.moveItem);
   const moveFolder = useConsoleTreeStore(state => state.moveFolder);
   const deleteItem = useConsoleTreeStore(state => state.deleteItem);
   const searchConsoles = useConsoleTreeStore(state => state.searchConsoles);
@@ -76,23 +87,9 @@ function ConsoleExplorer(
   const updateTabFilePath = useConsoleStore(state => state.updateFilePath);
   const updateTabTitle = useConsoleStore(state => state.updateTitle);
   const updateTabAccess = useConsoleStore(state => state.updateAccess);
-  const myConsolesMap = useConsoleTreeStore(state => state.myConsoles);
-  const sharedWithWorkspaceMap = useConsoleTreeStore(
-    state => state.sharedWithWorkspace,
-  );
-
-  const myConsoles = currentWorkspace
-    ? myConsolesMap[currentWorkspace.id] || []
-    : [];
-  const sharedWithWorkspace = currentWorkspace
-    ? sharedWithWorkspaceMap[currentWorkspace.id] || []
-    : [];
-  const loading = currentWorkspace ? !!loadingMap[currentWorkspace.id] : false;
-  const error = currentWorkspace ? _errorFor(currentWorkspace.id) : null;
 
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const [explorerDialogOpen, setExplorerDialogOpen] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ConsoleEntry | null>(null);
   const [infoModalOpen, setInfoModalOpen] = useState(false);
   const [infoConsoleId, setInfoConsoleId] = useState<string>("");
@@ -108,7 +105,7 @@ function ConsoleExplorer(
   const collectIds = (nodes: ConsoleEntry[]): Set<string> => {
     const ids = new Set<string>();
     for (const node of nodes) {
-      if (node.id) ids.add(node.id);
+      ids.add(node.id);
       if (node.isDirectory && node.children) {
         for (const id of collectIds(node.children)) ids.add(id);
       }
@@ -116,25 +113,11 @@ function ConsoleExplorer(
     return ids;
   };
 
-  function _errorFor(wid: string) {
-    const map = useConsoleTreeStore.getState().error;
-    return map[wid] || null;
-  }
-
-  const fetchConsoleEntries = async () => {
-    if (!currentWorkspace) return;
-    await refreshTree(currentWorkspace.id);
-  };
-
   useImperativeHandle(ref, () => ({
     refresh: () => {
-      fetchConsoleEntries();
+      void tree.refresh();
     },
   }));
-
-  useEffect(() => {
-    // Tree store handles its own initial load
-  }, [currentWorkspace]);
 
   const handleSearchChange = useCallback(
     (value: string) => {
@@ -424,11 +407,6 @@ function ConsoleExplorer(
     setFolderInfoOpen(true);
   };
 
-  const handleDeleteRequest = (item: ConsoleEntry) => {
-    setSelectedItem(item);
-    setDeleteDialogOpen(true);
-  };
-
   const handleSoftDelete = async (item: ConsoleEntry) => {
     if (!currentWorkspace || !item.id) return;
     const itemId = item.id;
@@ -455,17 +433,6 @@ function ConsoleExplorer(
         setUndoStack(prev => prev.slice(0, -1));
       }
     }
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!currentWorkspace || !selectedItem?.id) return;
-    await deleteItem(
-      currentWorkspace.id,
-      selectedItem.id,
-      selectedItem.isDirectory,
-    );
-    setDeleteDialogOpen(false);
-    setSelectedItem(null);
   };
 
   const treeRef = useRef<import("./ConsoleTree").ConsoleTreeRef | null>(null);
@@ -500,7 +467,7 @@ function ConsoleExplorer(
         </IconButton>
       </Tooltip>
       <Tooltip title="Refresh">
-        <IconButton onClick={fetchConsoleEntries} size="small">
+        <IconButton onClick={() => void tree.refresh()} size="small">
           <RefreshIcon size={20} strokeWidth={2} />
         </IconButton>
       </Tooltip>
@@ -562,7 +529,7 @@ function ConsoleExplorer(
                 onMoveRequest={handleMoveTo}
                 onInfoRequest={handleGetInfo}
                 onFolderInfoRequest={handleFolderInfo}
-                onDeleteRequest={handleDeleteRequest}
+                onDeleteRequest={tree.requestDelete}
                 onSoftDelete={handleSoftDelete}
                 onDuplicate={handleDuplicate}
                 onUndo={handleUndo}
@@ -644,17 +611,17 @@ function ConsoleExplorer(
       </Menu>
 
       <ConfirmDialog
-        open={deleteDialogOpen}
-        title={`Delete ${selectedItem?.isDirectory ? "Folder" : "Console"}`}
+        open={!!tree.deleteTarget}
+        title={`Delete ${tree.deleteTarget?.isDirectory ? "Folder" : "Console"}`}
         body={`${
-          selectedItem?.isDirectory
+          tree.deleteTarget?.isDirectory
             ? "This will permanently delete the folder and all its contents (subfolders and consoles)."
             : "This will permanently delete the console."
-        } Are you sure you want to delete "${selectedItem?.name}"?`}
+        } Are you sure you want to delete "${tree.deleteTarget?.name}"?`}
         confirmLabel="Delete"
         destructive
-        onConfirm={() => void handleDeleteConfirm()}
-        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={() => void tree.confirmDelete()}
+        onCancel={tree.cancelDelete}
       />
 
       <ConsoleInfoModal

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -25,8 +25,8 @@ import {
   useConsoleTreeStore,
   type ConsoleEntry,
 } from "../store/consoleTreeStore";
+import { useResourceTreeExplorer } from "../hooks/useResourceTreeExplorer";
 import ResourceTree, {
-  type CreatedFolderResult,
   type ResourceTreeNode,
   type ResourceTreeRef,
   type ResourceTreeSection,
@@ -135,16 +135,15 @@ function ConsoleTreeInner(
     return byConnection;
   }, [connections, dbTypes]);
 
-  const myConsolesMap = useConsoleTreeStore(state => state.myConsoles);
-  const sharedWithWorkspaceMap = useConsoleTreeStore(
-    state => state.sharedWithWorkspace,
+  // The console tree is preloaded by workspace-context; a sidebar or picker
+  // mounting must not refetch it.
+  const tree = useResourceTreeExplorer(
+    useConsoleTreeStore,
+    currentWorkspace?.id,
+    { autoFetch: false },
   );
-  const moveConsole = useConsoleTreeStore(state => state.moveConsole);
-  const moveFolder = useConsoleTreeStore(state => state.moveFolder);
-  const renameItem = useConsoleTreeStore(state => state.renameItem);
+  const { myItems: myConsoles, workspaceItems: sharedWithWorkspace } = tree;
   const deleteItem = useConsoleTreeStore(state => state.deleteItem);
-  const createFolder = useConsoleTreeStore(state => state.createFolder);
-  const resortItem = useConsoleTreeStore(state => state.resortItem);
 
   const activeTabId = useConsoleStore(state => state.activeTabId);
 
@@ -209,13 +208,6 @@ function ConsoleTreeInner(
     [mode, storeExpandFolder],
   );
 
-  const myConsoles = currentWorkspace
-    ? myConsolesMap[currentWorkspace.id] || []
-    : [];
-  const sharedWithWorkspace = currentWorkspace
-    ? sharedWithWorkspaceMap[currentWorkspace.id] || []
-    : [];
-
   const isOwner = useCallback(
     (item: ConsoleEntry) => item.owner_id === user?.id,
     [user?.id],
@@ -272,40 +264,9 @@ function ConsoleTreeInner(
     [onLocationChange],
   );
 
-  const handleMoveItem = useCallback(
-    (itemId: string, targetFolderId: string | null, access?: string) => {
-      if (!currentWorkspace) return;
-      void moveConsole(
-        currentWorkspace.id,
-        itemId,
-        targetFolderId,
-        (access as "private" | "workspace" | undefined) ?? undefined,
-      );
-    },
-    [currentWorkspace, moveConsole],
-  );
-
-  const handleMoveFolder = useCallback(
-    (folderId: string, parentId: string | null, access?: string) => {
-      if (!currentWorkspace) return;
-      void moveFolder(
-        currentWorkspace.id,
-        folderId,
-        parentId,
-        (access as "private" | "workspace" | undefined) ?? undefined,
-      );
-    },
-    [currentWorkspace, moveFolder],
-  );
-
-  const handleRenameItem = useCallback(
-    (id: string, name: string, isDirectory: boolean) => {
-      if (!currentWorkspace) return;
-      void renameItem(currentWorkspace.id, id, name, isDirectory);
-    },
-    [currentWorkspace, renameItem],
-  );
-
+  // Delete is the one handler the hook's confirm-dialog flow does not cover:
+  // the sidebar hands it to the explorer (confirm for folders, soft delete
+  // with undo for consoles); the picker deletes outright.
   const handleDeleteItem = useCallback(
     async (node: ResourceTreeNode) => {
       if (!currentWorkspace) return;
@@ -320,7 +281,6 @@ function ConsoleTreeInner(
         return;
       }
 
-      if (!consoleNode.id) return;
       await deleteItem(
         currentWorkspace.id,
         consoleNode.id,
@@ -330,34 +290,20 @@ function ConsoleTreeInner(
     [currentWorkspace, deleteItem, mode, onDeleteRequest, onSoftDelete],
   );
 
-  const handleCreateFolder = useCallback(
-    async (
-      parentId: string | null,
-      access?: string,
-    ): Promise<CreatedFolderResult | null> => {
-      if (!currentWorkspace) return null;
-      return createFolder(
-        currentWorkspace.id,
-        "New Folder",
-        parentId,
-        (access as "private" | "workspace" | undefined) ?? undefined,
-      );
-    },
-    [createFolder, currentWorkspace],
-  );
-
+  // Not `tree.sections`: console sections carry no header icon and are only
+  // drop targets when drag-and-drop is on (the picker turns it off).
   const sections = [
     {
       key: "my",
       label: "My Consoles",
-      nodes: myConsoles as ResourceTreeNode[],
+      nodes: myConsoles,
       droppableId: enableDragDrop ? "__section_my" : undefined,
       defaultAccess: "private" as const,
     },
     {
       key: "workspace",
       label: "Workspace",
-      nodes: sharedWithWorkspace as ResourceTreeNode[],
+      nodes: sharedWithWorkspace,
       droppableId: enableDragDrop ? "__section_workspace" : undefined,
       defaultAccess: "workspace" as const,
     },
@@ -399,13 +345,6 @@ function ConsoleTreeInner(
     (node: ResourceTreeNode) => onMoveRequest?.(node as ConsoleEntry),
     [onMoveRequest],
   );
-  const handleResortItem = useCallback(
-    (id: string) => {
-      if (!currentWorkspace) return;
-      resortItem(currentWorkspace.id, id);
-    },
-    [currentWorkspace, resortItem],
-  );
   const handleCanManageItem = useCallback(
     (node: ResourceTreeNode) => canManage(node as ConsoleEntry),
     [canManage],
@@ -445,16 +384,12 @@ function ConsoleTreeInner(
       selectedSectionKey={selectedSectionKey}
       initialFolderId={initialFolderId}
       initialSectionKey={initialSection}
-      onMoveItem={handleMoveItem}
-      onMoveFolder={handleMoveFolder}
-      onRenameItem={handleRenameItem}
+      {...tree.treeHandlers}
       onDeleteItem={handleDeleteItem}
       onDuplicateItem={handleDuplicateItem}
-      onCreateFolder={handleCreateFolder}
       onInfoRequest={handleInfoRequest}
       onFolderInfoRequest={handleFolderInfoRequest}
       onMoveRequest={handleMoveRequest}
-      onResortItem={handleResortItem}
       onUndo={onUndo}
       isFolderExpanded={isFolderExpandedLocal}
       onToggleFolder={toggleFolder}

--- a/app/src/components/FileExplorerDialog.tsx
+++ b/app/src/components/FileExplorerDialog.tsx
@@ -67,9 +67,9 @@ export default function FileExplorerDialog({
   isDirectory = false,
 }: FileExplorerDialogProps) {
   const { currentWorkspace } = useWorkspace();
-  const myConsolesMap = useConsoleTreeStore(state => state.myConsoles);
+  const myConsolesMap = useConsoleTreeStore(state => state.myItems);
   const sharedWithWorkspaceMap = useConsoleTreeStore(
-    state => state.sharedWithWorkspace,
+    state => state.workspaceItems,
   );
 
   const [consoleName, setConsoleName] = useState(defaultName);

--- a/app/src/hooks/useResourceTreeExplorer.tsx
+++ b/app/src/hooks/useResourceTreeExplorer.tsx
@@ -10,7 +10,6 @@
  * dialogs) on top of this hook.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { StoreApi, UseBoundStore } from "zustand";
 import { Globe as GlobeIcon, User as UserIcon } from "lucide-react";
 import type {
   ResourceTreeEntry,
@@ -22,11 +21,19 @@ import type {
   ResourceTreeSection,
 } from "../components/ResourceTree";
 
-const EMPTY: ResourceTreeNode[] = [];
+const EMPTY: never[] = [];
 
-type TreeStore<T extends ResourceTreeEntry> = UseBoundStore<
-  StoreApi<ResourceTreeState<T>>
->;
+/**
+ * What the hook needs from a bound store: the selector call and `setState`.
+ * Structural (not `UseBoundStore<StoreApi<…>>`) so a store extended past
+ * ResourceTreeState — consoles add search / duplicate / restore — still fits.
+ */
+interface TreeStore<T extends ResourceTreeEntry> {
+  <U>(selector: (state: ResourceTreeState<T>) => U): U;
+  setState: (
+    updater: (state: ResourceTreeState<T>) => Partial<ResourceTreeState<T>>,
+  ) => void;
+}
 
 export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
   store: TreeStore<T>,
@@ -38,23 +45,26 @@ export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
      * are items). Default: the node's own `isDirectory`.
      */
     isFolder?: (id: string, isDirectory: boolean) => boolean;
+    /**
+     * Fetch the tree whenever the workspace changes (default). Consoles opt
+     * out: workspace-context preloads their tree so it is ready before the
+     * explorer mounts, and the save/move picker must not refetch on open.
+     */
+    autoFetch?: boolean;
   } = {},
 ) {
+  const { autoFetch = true } = options;
   const isFolderOption = options.isFolder;
   const isFolder = useMemo(
     () => isFolderOption ?? ((_id: string, d: boolean) => d),
     [isFolderOption],
   );
 
-  const myItems = store(s =>
-    workspaceId
-      ? ((s.myItems[workspaceId] as ResourceTreeNode[]) ?? EMPTY)
-      : EMPTY,
+  const myItems: T[] = store(s =>
+    workspaceId ? (s.myItems[workspaceId] ?? EMPTY) : EMPTY,
   );
-  const workspaceItems = store(s =>
-    workspaceId
-      ? ((s.workspaceItems[workspaceId] as ResourceTreeNode[]) ?? EMPTY)
-      : EMPTY,
+  const workspaceItems: T[] = store(s =>
+    workspaceId ? (s.workspaceItems[workspaceId] ?? EMPTY) : EMPTY,
   );
   const loading = store(s => (workspaceId ? !!s.loading[workspaceId] : false));
   const error = store(s => (workspaceId ? s.error[workspaceId] || null : null));
@@ -67,8 +77,8 @@ export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
   const resortItem = store(s => s.resortItem);
 
   useEffect(() => {
-    if (workspaceId) void fetchTree(workspaceId);
-  }, [workspaceId, fetchTree]);
+    if (autoFetch && workspaceId) void fetchTree(workspaceId);
+  }, [autoFetch, workspaceId, fetchTree]);
 
   const refresh = useCallback(async () => {
     if (workspaceId) await fetchTree(workspaceId);
@@ -179,7 +189,7 @@ export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
         key: "my",
         label: labels.my,
         icon: <UserIcon size={16} strokeWidth={1.5} />,
-        nodes: mapNodes(myItems),
+        nodes: mapNodes(myItems as ResourceTreeNode[]),
         droppableId: "__section_my",
         defaultAccess: "private" as const,
       },
@@ -187,7 +197,7 @@ export function useResourceTreeExplorer<T extends ResourceTreeEntry>(
         key: "workspace",
         label: labels.workspace ?? "Workspace",
         icon: <GlobeIcon size={16} strokeWidth={1.5} />,
-        nodes: mapNodes(workspaceItems),
+        nodes: mapNodes(workspaceItems as ResourceTreeNode[]),
         droppableId: "__section_workspace",
         defaultAccess: "workspace" as const,
       },

--- a/app/src/store/consoleTreeStore.test.ts
+++ b/app/src/store/consoleTreeStore.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const http = vi.hoisted(() => ({
+  GET: vi.fn(),
+  PATCH: vi.fn(),
+  POST: vi.fn(),
+  DELETE: vi.fn(),
+}));
+
+vi.mock("../api", async importOriginal => {
+  const actual = await importOriginal<typeof import("../api")>();
+  return { ...actual, api: http };
+});
+
+import { useConsoleTreeStore, type ConsoleEntry } from "./consoleTreeStore";
+
+const WID = "ws-1";
+
+/** What openapi-fetch resolves for a 200 with a JSON body. */
+const ok = (body: unknown) => ({
+  data: body,
+  error: undefined,
+  response: { ok: true, status: 200 },
+});
+
+const file = (id: string, name: string): ConsoleEntry => ({
+  id,
+  name,
+  path: name,
+  isDirectory: false,
+});
+
+const folder = (
+  id: string,
+  name: string,
+  children: ConsoleEntry[] = [],
+): ConsoleEntry => ({ id, name, path: name, isDirectory: true, children });
+
+const names = (nodes: ConsoleEntry[]) => nodes.map(n => n.name);
+
+function seed(my: ConsoleEntry[], workspace: ConsoleEntry[] = []) {
+  useConsoleTreeStore.setState({
+    myItems: { [WID]: my },
+    workspaceItems: { [WID]: workspace },
+    loading: {},
+    error: {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seed([], []);
+});
+
+describe("consoleTreeStore fetchTree", () => {
+  it("maps the API sections onto the shared my/workspace slots", async () => {
+    http.GET.mockResolvedValueOnce(
+      ok({
+        success: true,
+        myConsoles: [file("a", "alpha")],
+        sharedWithWorkspace: [folder("f", "shared", [file("b", "beta")])],
+      }),
+    );
+
+    await useConsoleTreeStore.getState().fetchTree(WID);
+
+    const state = useConsoleTreeStore.getState();
+    expect(names(state.myItems[WID])).toEqual(["alpha"]);
+    expect(names(state.workspaceItems[WID])).toEqual(["shared"]);
+    expect(state.loading[WID]).toBeUndefined();
+    expect(state.error[WID]).toBeNull();
+    expect(http.GET).toHaveBeenCalledWith(
+      "/api/workspaces/{workspaceId}/consoles",
+      { params: { path: { workspaceId: WID } } },
+    );
+  });
+
+  it("falls back to the legacy `tree` field for the my section", async () => {
+    http.GET.mockResolvedValueOnce(
+      ok({ success: true, tree: [file("a", "x")] }),
+    );
+
+    await useConsoleTreeStore.getState().fetchTree(WID);
+
+    expect(names(useConsoleTreeStore.getState().myItems[WID])).toEqual(["x"]);
+    expect(useConsoleTreeStore.getState().workspaceItems[WID]).toEqual([]);
+  });
+
+  it("records the error and clears loading when the request fails", async () => {
+    http.GET.mockRejectedValueOnce(new Error("boom"));
+
+    await useConsoleTreeStore.getState().fetchTree(WID);
+
+    const state = useConsoleTreeStore.getState();
+    expect(state.error[WID]).toBe("boom");
+    expect(state.loading[WID]).toBeUndefined();
+  });
+});
+
+describe("consoleTreeStore renameItem", () => {
+  it("renames and re-sorts optimistically, before the server answers", async () => {
+    seed([file("a", "alpha"), file("c", "charlie")]);
+    let release!: (value: unknown) => void;
+    http.PATCH.mockReturnValueOnce(
+      new Promise(resolve => {
+        release = resolve;
+      }),
+    );
+
+    const pending = useConsoleTreeStore
+      .getState()
+      .renameItem(WID, "a", "zulu", false);
+
+    expect(names(useConsoleTreeStore.getState().myItems[WID])).toEqual([
+      "charlie",
+      "zulu",
+    ]);
+    expect(http.PATCH).toHaveBeenCalledWith(
+      "/api/workspaces/{workspaceId}/consoles/{id}/rename",
+      {
+        params: { path: { workspaceId: WID, id: "a" } },
+        body: { name: "zulu" },
+      },
+    );
+
+    release(ok({ success: true }));
+    await expect(pending).resolves.toBe(true);
+    expect(http.GET).not.toHaveBeenCalled();
+  });
+
+  it("refetches the tree when the server reports success: false", async () => {
+    seed([file("a", "alpha")]);
+    http.PATCH.mockResolvedValueOnce(ok({ success: false }));
+    http.GET.mockResolvedValueOnce(
+      ok({ success: true, myConsoles: [file("a", "alpha")] }),
+    );
+
+    const result = await useConsoleTreeStore
+      .getState()
+      .renameItem(WID, "a", "zulu", false);
+
+    expect(result).toBe(false);
+    expect(http.GET).toHaveBeenCalledTimes(1);
+    expect(names(useConsoleTreeStore.getState().myItems[WID])).toEqual([
+      "alpha",
+    ]);
+  });
+});
+
+describe("consoleTreeStore extras", () => {
+  it("applyRemoteRename patches the node in place without a request", () => {
+    seed([], [folder("f", "shared", [file("a", "alpha"), file("b", "bravo")])]);
+
+    useConsoleTreeStore.getState().applyRemoteRename(WID, "a", "zulu");
+
+    const shared = useConsoleTreeStore.getState().workspaceItems[WID][0];
+    expect(names(shared.children ?? [])).toEqual(["bravo", "zulu"]);
+    expect(http.PATCH).not.toHaveBeenCalled();
+    expect(http.GET).not.toHaveBeenCalled();
+  });
+
+  it("addConsole files a saved console under its folder path", () => {
+    seed([folder("f", "reports", [file("z", "zeta")])]);
+
+    useConsoleTreeStore.getState().addConsole(WID, "reports/monthly", "m");
+
+    const reports = useConsoleTreeStore.getState().myItems[WID][0];
+    expect(names(reports.children ?? [])).toEqual(["monthly", "zeta"]);
+    expect(reports.children?.[0]).toMatchObject({
+      id: "m",
+      path: "reports/monthly",
+      isDirectory: false,
+    });
+  });
+});

--- a/app/src/store/consoleTreeStore.ts
+++ b/app/src/store/consoleTreeStore.ts
@@ -1,25 +1,21 @@
-import { create } from "zustand";
-import { immer } from "zustand/middleware/immer";
-import { apiClient } from "../lib/api-client";
 import { api, unwrapBody } from "../api";
 import {
-  findById,
+  createResourceTreeStore,
+  type ResourceTreeEntry,
+  type TreeAccessLevel,
+} from "./lib/createResourceTreeStore";
+import {
   findParentArray,
   findTargetArray,
   insertAlphabetically,
-  insertAtTop,
   removeById,
 } from "./lib/tree-helpers";
 
-export type ConsoleAccessLevel = "private" | "workspace";
+export type ConsoleAccessLevel = TreeAccessLevel;
 
-export interface ConsoleEntry {
-  name: string;
-  path: string;
-  isDirectory: boolean;
+export interface ConsoleEntry extends ResourceTreeEntry {
   children?: ConsoleEntry[];
   content?: string;
-  id?: string;
   folderId?: string;
   connectionId?: string;
   databaseId?: string;
@@ -29,82 +25,7 @@ export interface ConsoleEntry {
   isPrivate?: boolean;
   lastExecutedAt?: Date;
   executionCount?: number;
-  access?: ConsoleAccessLevel;
-  owner_id?: string;
-  createdAt?: string;
 }
-
-/** Get both section arrays for a workspace */
-const allSections = (state: TreeState, wid: string): ConsoleEntry[][] => [
-  state.myConsoles[wid] || [],
-  state.sharedWithWorkspace[wid] || [],
-];
-
-/** Find a node across all three sections */
-const findInAnySectionMut = (
-  state: TreeState,
-  wid: string,
-  id: string,
-): ConsoleEntry | null => {
-  for (const section of allSections(state, wid)) {
-    const found = findById(section, id);
-    if (found) return found;
-  }
-  return null;
-};
-
-/** Remove a node from whichever section contains it */
-const removeFromAnySection = (
-  state: TreeState,
-  wid: string,
-  id: string,
-): ConsoleEntry | null => {
-  for (const section of allSections(state, wid)) {
-    const removed = removeById(section, id);
-    if (removed) return removed;
-  }
-  return null;
-};
-
-/** Insert into the children of a target folder, or at root of a section */
-const insertIntoFolder = (
-  state: TreeState,
-  wid: string,
-  entry: ConsoleEntry,
-  targetFolderId: string | null,
-  targetSection: "my" | "workspace",
-  placement: "alphabetical" | "top" = "alphabetical",
-): void => {
-  const sectionKey =
-    targetSection === "my" ? "myConsoles" : "sharedWithWorkspace";
-  const sectionArr = state[sectionKey][wid] || [];
-  state[sectionKey][wid] = sectionArr;
-  const insert = placement === "top" ? insertAtTop : insertAlphabetically;
-
-  if (targetFolderId) {
-    const folder = findById(sectionArr, targetFolderId);
-    if (folder && folder.isDirectory) {
-      if (!folder.children) folder.children = [];
-      insert(folder.children, entry);
-      return;
-    }
-  }
-  insert(sectionArr, entry);
-};
-
-/** Determine which section a folder ID belongs to */
-const sectionOfFolder = (
-  state: TreeState,
-  wid: string,
-  folderId: string,
-): "my" | "workspace" => {
-  if (findById(state.sharedWithWorkspace[wid] || [], folderId)) {
-    return "workspace";
-  }
-  return "my";
-};
-
-// ── Store ──
 
 export interface ConsoleSearchResult {
   id: string;
@@ -117,49 +38,16 @@ export interface ConsoleSearchResult {
   score: number;
 }
 
-interface TreeState {
-  myConsoles: Record<string, ConsoleEntry[]>;
-  sharedWithWorkspace: Record<string, ConsoleEntry[]>;
-  trees: Record<string, ConsoleEntry[]>;
-  loading: Record<string, boolean>;
-  error: Record<string, string | null>;
-
+/** What consoles need beyond the shared tree slice. */
+export interface ConsoleTreeExtra {
   searchQuery: string;
   searchResults: ConsoleSearchResult[];
   searchLoading: boolean;
-
-  fetchTree: (workspaceId: string) => Promise<ConsoleEntry[]>;
-  refresh: (workspaceId: string) => Promise<ConsoleEntry[]>;
-  init: (workspaceId: string) => Promise<void>;
-  setTree: (workspaceId: string, tree: ConsoleEntry[]) => void;
-  addConsole: (workspaceId: string, path: string, id: string) => void;
+  /** Server-side search (matches descriptions the tree filter cannot see). */
   searchConsoles: (workspaceId: string, query: string) => Promise<void>;
   clearSearch: () => void;
-
-  moveConsole: (
-    workspaceId: string,
-    consoleId: string,
-    folderId: string | null,
-    access?: ConsoleAccessLevel,
-  ) => Promise<boolean>;
-  moveFolder: (
-    workspaceId: string,
-    folderId: string,
-    parentId: string | null,
-    access?: ConsoleAccessLevel,
-  ) => Promise<boolean>;
-  createFolder: (
-    workspaceId: string,
-    name: string,
-    parentId?: string | null,
-    access?: ConsoleAccessLevel,
-  ) => Promise<{ id: string; name: string } | null>;
-  renameItem: (
-    workspaceId: string,
-    itemId: string,
-    newName: string,
-    isDirectory: boolean,
-  ) => Promise<boolean>;
+  /** Place a just-saved console at `path` in "My consoles" (no request). */
+  addConsole: (workspaceId: string, path: string, id: string) => void;
   /**
    * Surgically rename a tree node by id from a REMOTE signal (agent edit or
    * another window) — in place, WITHOUT an API call and WITHOUT a full
@@ -172,33 +60,113 @@ interface TreeState {
     itemId: string,
     newName: string,
   ) => void;
-  deleteItem: (
-    workspaceId: string,
-    itemId: string,
-    isDirectory: boolean,
-  ) => Promise<boolean>;
-  resortItem: (workspaceId: string, itemId: string) => void;
   duplicateConsole: (
     workspaceId: string,
     consoleId: string,
   ) => Promise<{ id: string; name: string } | null>;
+  /** Undo a soft delete; refetches the tree on success. */
   restoreConsole: (workspaceId: string, consoleId: string) => Promise<boolean>;
-  updateAccess: (
-    workspaceId: string,
-    itemId: string,
-    isDirectory: boolean,
-    access: ConsoleAccessLevel,
-  ) => Promise<boolean>;
 }
 
-export const useConsoleTreeStore = create<TreeState>()(
-  immer((set, _get) => ({
-    myConsoles: {},
-    sharedWithWorkspace: {},
-    trees: {},
-    loading: {},
-    error: {},
+const base = "/api/workspaces/{workspaceId}/consoles" as const;
 
+/**
+ * The console API answers `{ success: false }` with a 200; the factory's
+ * refresh-on-failure path is driven by thrown errors, so surface it as one.
+ */
+const ok = <R extends { success?: boolean }>(res: R): R => {
+  if (!res.success) throw new Error("Request failed");
+  return res;
+};
+
+/** The consoles tree: entry type + endpoints + console-only extras. */
+export const useConsoleTreeStore = createResourceTreeStore<
+  ConsoleEntry,
+  ConsoleTreeExtra
+>({
+  resourceName: "console",
+  endpoints: {
+    fetch: async workspaceId => {
+      const data = unwrapBody(
+        await api.GET(base, { params: { path: { workspaceId } } }),
+      ) as {
+        tree?: ConsoleEntry[];
+        myConsoles?: ConsoleEntry[];
+        sharedWithWorkspace?: ConsoleEntry[];
+      };
+      return {
+        my: data.myConsoles ?? data.tree ?? [],
+        workspace: data.sharedWithWorkspace ?? [],
+      };
+    },
+    moveItem: async (workspaceId, id, folderId, access) =>
+      ok(
+        unwrapBody(
+          await api.PATCH(`${base}/{id}/move`, {
+            params: { path: { workspaceId, id } },
+            body: { folderId, access },
+          }),
+        ) as { success: boolean },
+      ),
+    moveFolder: async (workspaceId, id, parentId, access) =>
+      ok(
+        unwrapBody(
+          await api.PATCH(`${base}/folders/{id}/move`, {
+            params: { path: { workspaceId, id } },
+            body: { parentId, access },
+          }),
+        ) as { success: boolean },
+      ),
+    createFolder: async (workspaceId, name, parentId, access) =>
+      ok(
+        unwrapBody(
+          await api.POST(`${base}/folders`, {
+            params: { path: { workspaceId } },
+            body: {
+              name,
+              parentId: parentId || undefined,
+              isPrivate: access !== "workspace",
+              access,
+            },
+          }),
+        ) as { success: boolean; data?: { id: string; name: string } },
+      ).data,
+    renameItem: async (workspaceId, id, name) =>
+      ok(
+        unwrapBody(
+          await api.PATCH(`${base}/{id}/rename`, {
+            params: { path: { workspaceId, id } },
+            body: { name },
+          }),
+        ) as { success: boolean },
+      ),
+    renameFolder: async (workspaceId, id, name) =>
+      ok(
+        unwrapBody(
+          await api.PATCH(`${base}/folders/{id}/rename`, {
+            params: { path: { workspaceId, id } },
+            body: { name },
+          }),
+        ) as { success: boolean },
+      ),
+    deleteItem: async (workspaceId, id) =>
+      ok(
+        unwrapBody(
+          await api.DELETE(`${base}/{id}`, {
+            params: { path: { workspaceId, id } },
+          }),
+        ) as { success: boolean },
+      ),
+    deleteFolder: async (workspaceId, id) =>
+      ok(
+        unwrapBody(
+          await api.DELETE(`${base}/folders/{id}`, {
+            params: { path: { workspaceId, id } },
+          }),
+        ) as { success: boolean },
+      ),
+  },
+  extend: (set, get, helpers) => ({
     searchQuery: "",
     searchResults: [],
     searchLoading: false,
@@ -210,12 +178,10 @@ export const useConsoleTreeStore = create<TreeState>()(
       });
       try {
         const data = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/consoles/search", {
+          await api.GET(`${base}/search`, {
             params: { path: { workspaceId }, query: { q: query } },
           }),
-        ) as {
-          results: ConsoleSearchResult[];
-        };
+        ) as { results: ConsoleSearchResult[] };
         set(state => {
           state.searchResults = data.results || [];
           state.searchLoading = false;
@@ -236,70 +202,13 @@ export const useConsoleTreeStore = create<TreeState>()(
       });
     },
 
-    fetchTree: async workspaceId => {
-      set(state => {
-        state.loading[workspaceId] = true;
-        state.error[workspaceId] = null;
-      });
-      try {
-        const data = unwrapBody(
-          await api.GET("/api/workspaces/{workspaceId}/consoles", {
-            params: { path: { workspaceId } },
-          }),
-        ) as {
-          success: boolean;
-          tree?: ConsoleEntry[];
-          myConsoles?: ConsoleEntry[];
-          sharedWithWorkspace?: ConsoleEntry[];
-        };
-
-        const myTree = data.myConsoles ?? data.tree ?? [];
-        const sharedWithWorkspaceTree = data.sharedWithWorkspace ?? [];
-
-        set(state => {
-          state.myConsoles[workspaceId] = myTree;
-          state.sharedWithWorkspace[workspaceId] = sharedWithWorkspaceTree;
-          state.trees[workspaceId] = myTree;
-        });
-        return myTree;
-      } catch (err: any) {
-        console.error("Failed to fetch console tree", err);
-        set(state => {
-          state.error[workspaceId] = err?.message || "Failed to fetch";
-        });
-        return [];
-      } finally {
-        set(state => {
-          delete state.loading[workspaceId];
-        });
-      }
-    },
-
-    refresh: async workspaceId => {
-      return await _get().fetchTree(workspaceId);
-    },
-
-    init: async workspaceId => {
-      if (!_get().trees[workspaceId]) {
-        await _get().fetchTree(workspaceId);
-      }
-    },
-
-    setTree: (workspaceId, tree) => {
-      set(state => {
-        state.trees[workspaceId] = tree;
-        state.myConsoles[workspaceId] = tree;
-      });
-    },
-
     addConsole: (workspaceId, path, id) => {
       set(state => {
-        const tree = state.myConsoles[workspaceId] || [];
+        const tree = state.myItems[workspaceId] || [];
         const segments = path.split("/").filter(Boolean);
         const fileName = segments[segments.length - 1];
         const folderSegments = segments.slice(0, -1);
         const existing = removeById(tree, id);
-        const targetArray = findTargetArray(tree, folderSegments);
         const newConsole: ConsoleEntry = {
           ...(existing || {}),
           name: fileName,
@@ -307,198 +216,15 @@ export const useConsoleTreeStore = create<TreeState>()(
           isDirectory: false,
           id,
         };
-        const destination = targetArray || tree;
+        const destination = findTargetArray(tree, folderSegments) || tree;
         insertAlphabetically(destination, newConsole);
-        state.myConsoles[workspaceId] = tree;
-        state.trees[workspaceId] = tree;
+        state.myItems[workspaceId] = tree;
       });
-    },
-
-    // ── Optimistic mutations ──
-
-    moveConsole: async (workspaceId, consoleId, folderId, access) => {
-      set(state => {
-        const entry = removeFromAnySection(state, workspaceId, consoleId);
-        if (!entry) return;
-        if (access) entry.access = access;
-        const targetSection = access
-          ? access === "workspace"
-            ? "workspace"
-            : "my"
-          : folderId
-            ? sectionOfFolder(state, workspaceId, folderId)
-            : "my";
-        insertIntoFolder(state, workspaceId, entry, folderId, targetSection);
-      });
-      try {
-        const body: Record<string, unknown> = { folderId };
-        if (access) body.access = access;
-        const res = unwrapBody(
-          await api.PATCH("/api/workspaces/{workspaceId}/consoles/{id}/move", {
-            params: { path: { workspaceId, id: consoleId } },
-            body,
-          }),
-        ) as { success: boolean };
-        if (!res.success) {
-          await _get().refresh(workspaceId);
-        }
-        return res.success;
-      } catch {
-        await _get().refresh(workspaceId);
-        return false;
-      }
-    },
-
-    moveFolder: async (workspaceId, folderId, parentId, access) => {
-      set(state => {
-        const entry = removeFromAnySection(state, workspaceId, folderId);
-        if (!entry) return;
-        if (access) entry.access = access;
-        const targetSection = access
-          ? access === "workspace"
-            ? "workspace"
-            : "my"
-          : parentId
-            ? sectionOfFolder(state, workspaceId, parentId)
-            : "my";
-        insertIntoFolder(state, workspaceId, entry, parentId, targetSection);
-      });
-      try {
-        const body: Record<string, unknown> = { parentId };
-        if (access) body.access = access;
-        const res = unwrapBody(
-          await api.PATCH(
-            "/api/workspaces/{workspaceId}/consoles/folders/{id}/move",
-            { params: { path: { workspaceId, id: folderId } }, body },
-          ),
-        ) as { success: boolean };
-        if (!res.success) {
-          await _get().refresh(workspaceId);
-        }
-        return res.success;
-      } catch {
-        await _get().refresh(workspaceId);
-        return false;
-      }
-    },
-
-    createFolder: async (workspaceId, name, parentId, access) => {
-      // Resolve access: if not specified, inherit from the section the parent lives in
-      let resolvedAccess = access || "private";
-      if (!access && parentId) {
-        const parentSection = sectionOfFolder(_get(), workspaceId, parentId);
-        if (parentSection === "workspace") {
-          resolvedAccess = "workspace";
-        }
-      }
-
-      const tempId = `temp-${Date.now()}`;
-      const targetSection =
-        resolvedAccess === "workspace"
-          ? "workspace"
-          : parentId
-            ? sectionOfFolder(_get(), workspaceId, parentId)
-            : "my";
-
-      set(state => {
-        const newFolder: ConsoleEntry = {
-          name,
-          path: name,
-          isDirectory: true,
-          children: [],
-          id: tempId,
-          access: resolvedAccess,
-        };
-        insertIntoFolder(
-          state,
-          workspaceId,
-          newFolder,
-          parentId ?? null,
-          targetSection,
-          "top",
-        );
-      });
-
-      try {
-        const res = unwrapBody(
-          await api.POST("/api/workspaces/{workspaceId}/consoles/folders", {
-            params: { path: { workspaceId } },
-            body: {
-              name,
-              parentId: parentId || undefined,
-              isPrivate: resolvedAccess !== "workspace",
-              access: resolvedAccess,
-            },
-          }),
-        ) as {
-          success: boolean;
-          data?: { id: string; name: string };
-        };
-        if (res.success && res.data) {
-          const newId = res.data.id;
-          set(state => {
-            const node = findInAnySectionMut(state, workspaceId, tempId);
-            if (node) node.id = newId;
-          });
-          return { id: res.data.id, name: res.data.name };
-        }
-        await _get().refresh(workspaceId);
-        return null;
-      } catch {
-        await _get().refresh(workspaceId);
-        return null;
-      }
-    },
-
-    renameItem: async (workspaceId, itemId, newName, isDirectory) => {
-      set(state => {
-        const parent = (() => {
-          for (const section of allSections(state, workspaceId)) {
-            const found = findParentArray(section, itemId);
-            if (found) return found;
-          }
-          return null;
-        })();
-        if (parent) {
-          const idx = parent.findIndex(n => n.id === itemId);
-          if (idx !== -1) {
-            const [node] = parent.splice(idx, 1);
-            node.name = newName;
-            insertAlphabetically(parent, node);
-          }
-        }
-      });
-      try {
-        const res = unwrapBody(
-          isDirectory
-            ? await api.PATCH(
-                "/api/workspaces/{workspaceId}/consoles/folders/{id}/rename",
-                {
-                  params: { path: { workspaceId, id: itemId } },
-                  body: { name: newName },
-                },
-              )
-            : await api.PATCH(
-                "/api/workspaces/{workspaceId}/consoles/{id}/rename",
-                {
-                  params: { path: { workspaceId, id: itemId } },
-                  body: { name: newName },
-                },
-              ),
-        ) as { success: boolean };
-        if (!res.success) {
-          await _get().refresh(workspaceId);
-        }
-        return res.success;
-      } catch {
-        await _get().refresh(workspaceId);
-        return false;
-      }
     },
 
     applyRemoteRename: (workspaceId, itemId, newName) => {
       set(state => {
-        for (const section of allSections(state, workspaceId)) {
+        for (const section of helpers.allSections(state, workspaceId)) {
           const parent = findParentArray(section, itemId);
           if (!parent) continue;
           const idx = parent.findIndex(n => n.id === itemId);
@@ -515,85 +241,41 @@ export const useConsoleTreeStore = create<TreeState>()(
       });
     },
 
-    deleteItem: async (workspaceId, itemId, isDirectory) => {
-      // Optimistic: remove from local tree
-      set(state => {
-        removeFromAnySection(state, workspaceId, itemId);
-      });
-      try {
-        const res = unwrapBody(
-          isDirectory
-            ? await api.DELETE(
-                "/api/workspaces/{workspaceId}/consoles/folders/{id}",
-                { params: { path: { workspaceId, id: itemId } } },
-              )
-            : await api.DELETE("/api/workspaces/{workspaceId}/consoles/{id}", {
-                params: { path: { workspaceId, id: itemId } },
-              }),
-        ) as { success: boolean };
-        if (!res.success) {
-          await _get().refresh(workspaceId);
-        }
-        return res.success;
-      } catch {
-        await _get().refresh(workspaceId);
-        return false;
-      }
-    },
-
-    resortItem: (workspaceId, itemId) => {
-      set(state => {
-        const parent = (() => {
-          for (const section of allSections(state, workspaceId)) {
-            const found = findParentArray(section, itemId);
-            if (found) return found;
-          }
-          return null;
-        })();
-        if (parent) {
-          const idx = parent.findIndex(n => n.id === itemId);
-          if (idx !== -1) {
-            const [node] = parent.splice(idx, 1);
-            insertAlphabetically(parent, node);
-          }
-        }
-      });
-    },
-
     duplicateConsole: async (workspaceId, consoleId) => {
       try {
         const res = unwrapBody(
-          await api.POST(
-            "/api/workspaces/{workspaceId}/consoles/{id}/duplicate",
-            { params: { path: { workspaceId, id: consoleId } } },
-          ),
+          await api.POST(`${base}/{id}/duplicate`, {
+            params: { path: { workspaceId, id: consoleId } },
+          }),
         ) as {
           success: boolean;
           data?: { id: string; name: string; folderId?: string };
         };
-        if (res.success && res.data) {
-          const newConsole = res.data;
-          set(state => {
-            const original = findInAnySectionMut(state, workspaceId, consoleId);
-            if (!original) return;
-            const copy: ConsoleEntry = {
-              ...original,
-              id: newConsole.id,
-              name: newConsole.name,
-              isDirectory: false,
-            };
-            // Find which section/folder the original is in
-            for (const section of allSections(state, workspaceId)) {
-              const parent = findParentArray(section, consoleId);
-              if (parent) {
-                insertAlphabetically(parent, copy);
-                return;
-              }
+        if (!res.success || !res.data) return null;
+        const created = res.data;
+        set(state => {
+          const original = helpers.findInAnySection(
+            state,
+            workspaceId,
+            consoleId,
+          );
+          if (!original) return;
+          const copy: ConsoleEntry = {
+            ...original,
+            id: created.id,
+            name: created.name,
+            isDirectory: false,
+          };
+          // The copy lands next to the original, whichever section/folder.
+          for (const section of helpers.allSections(state, workspaceId)) {
+            const parent = findParentArray(section, consoleId);
+            if (parent) {
+              insertAlphabetically(parent, copy);
+              return;
             }
-          });
-          return { id: res.data.id, name: res.data.name };
-        }
-        return null;
+          }
+        });
+        return { id: created.id, name: created.name };
       } catch {
         return null;
       }
@@ -602,46 +284,15 @@ export const useConsoleTreeStore = create<TreeState>()(
     restoreConsole: async (workspaceId, consoleId) => {
       try {
         const res = unwrapBody(
-          await api.PATCH(
-            "/api/workspaces/{workspaceId}/consoles/{id}/restore",
-            { params: { path: { workspaceId, id: consoleId } } },
-          ),
+          await api.PATCH(`${base}/{id}/restore`, {
+            params: { path: { workspaceId, id: consoleId } },
+          }),
         ) as { success: boolean };
-        if (res.success) {
-          await _get().refresh(workspaceId);
-        }
+        if (res.success) await get().refresh(workspaceId);
         return res.success;
       } catch {
         return false;
       }
     },
-
-    updateAccess: async (workspaceId, itemId, isDirectory, access) => {
-      set(state => {
-        const entry = removeFromAnySection(state, workspaceId, itemId);
-        if (!entry) return;
-        entry.access = access;
-        const sectionKey =
-          access === "workspace" ? "sharedWithWorkspace" : "myConsoles";
-        const arr = state[sectionKey][workspaceId] || [];
-        state[sectionKey][workspaceId] = arr;
-        insertAlphabetically(arr, entry);
-      });
-      try {
-        const endpoint = isDirectory
-          ? `/workspaces/${workspaceId}/consoles/folders/${itemId}/share`
-          : `/workspaces/${workspaceId}/consoles/${itemId}/share`;
-        const res = await apiClient.post<{ success: boolean }>(endpoint, {
-          access,
-        });
-        if (!res.success) {
-          await _get().refresh(workspaceId);
-        }
-        return res.success;
-      } catch {
-        await _get().refresh(workspaceId);
-        return false;
-      }
-    },
-  })),
-);
+  }),
+});

--- a/app/src/store/lib/createResourceTreeStore.ts
+++ b/app/src/store/lib/createResourceTreeStore.ts
@@ -1,5 +1,6 @@
 /**
- * ONE tree store for every foldered resource (notebooks, dashboards, …).
+ * ONE tree store for every foldered resource (notebooks, dashboards,
+ * consoles, …).
  *
  * The two-section tree ("My X" / "Workspace X"), the optimistic move /
  * rename / create-folder / delete with refresh-on-failure, the per-workspace
@@ -7,9 +8,12 @@
  * notebookTreeStore and dashboardTreeStore differed by 29 lines out of 400
  * once the noun was renamed, and consoleTreeStore forked to grow a third
  * section and then drifted 600 lines. A resource now supplies only its
- * entry type and its endpoints; the mechanics live here once.
+ * entry type and its endpoints; the mechanics live here once. Anything a
+ * resource needs beyond the shared set (consoles: search, remote rename,
+ * duplicate, restore) composes on top through `extend`, which receives the
+ * same section helpers the built-in actions use.
  */
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { toErrorMessage } from "../../api";
 import {
@@ -36,7 +40,12 @@ export interface ResourceTreeEntry {
   updatedAt?: string;
 }
 
-/** What a resource must know how to do; the store never builds a URL. */
+/**
+ * What a resource must know how to do; the store never builds a URL. An
+ * endpoint that resolves counts as success; one that throws triggers the
+ * refresh-on-failure path (so an endpoint whose envelope carries
+ * `success: false` should throw on it).
+ */
 export interface ResourceTreeEndpoints<T extends ResourceTreeEntry> {
   fetch: (workspaceId: string) => Promise<{ my: T[]; workspace: T[] }>;
   moveItem: (
@@ -79,18 +88,19 @@ export interface ResourceTreeState<T extends ResourceTreeEntry> {
 
   fetchTree: (workspaceId: string) => Promise<void>;
   refresh: (workspaceId: string) => Promise<void>;
+  /** Optimistic; resolves `false` after the tree was refetched on failure. */
   moveItem: (
     workspaceId: string,
     itemId: string,
     targetFolderId: string | null,
     access?: TreeAccessLevel,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   moveFolder: (
     workspaceId: string,
     folderId: string,
     parentId: string | null,
     access?: TreeAccessLevel,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   createFolder: (
     workspaceId: string,
     name: string,
@@ -102,30 +112,94 @@ export interface ResourceTreeState<T extends ResourceTreeEntry> {
     itemId: string,
     name: string,
     isDirectory: boolean,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   deleteItem: (
     workspaceId: string,
     itemId: string,
     isDirectory: boolean,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   resortItem: (workspaceId: string, itemId: string) => void;
 }
 
-export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
+/** The section arrays an extension mutates inside `set`. */
+export type ResourceTreeSections<T extends ResourceTreeEntry> = Pick<
+  ResourceTreeState<T>,
+  "myItems" | "workspaceItems"
+>;
+
+/** The internal section helpers, handed to `extend` so extras compose. */
+export interface ResourceTreeHelpers<T extends ResourceTreeEntry> {
+  /** Both section arrays for a workspace (missing ones read as empty). */
+  allSections: (state: ResourceTreeSections<T>, wid: string) => T[][];
+  findInAnySection: (
+    state: ResourceTreeSections<T>,
+    wid: string,
+    id: string,
+  ) => T | null;
+  removeFromAnySection: (
+    state: ResourceTreeSections<T>,
+    wid: string,
+    id: string,
+  ) => T | null;
+  /** Into a folder's children, or the section root when it is not found. */
+  insertIntoFolder: (
+    state: ResourceTreeSections<T>,
+    wid: string,
+    entry: T,
+    targetFolderId: string | null,
+    targetSection: TreeSection,
+    placement?: "alphabetical" | "top",
+  ) => void;
+  sectionOfFolder: (
+    state: ResourceTreeSections<T>,
+    wid: string,
+    folderId: string,
+  ) => TreeSection;
+  /** Re-sort one node within its parent array (after a rename). */
+  resortIn: (state: ResourceTreeSections<T>, wid: string, id: string) => void;
+}
+
+type ImmerCreator<S> = StateCreator<S, [["zustand/immer", never]], [], S>;
+export type ResourceTreeSet<S> = Parameters<ImmerCreator<S>>[0];
+export type ResourceTreeGet<S> = Parameters<ImmerCreator<S>>[1];
+
+export function createResourceTreeStore<
+  T extends ResourceTreeEntry,
+  Extra extends object = Record<never, never>,
+>(config: {
   /** Used in the fetch-error fallback message, e.g. "notebook". */
   resourceName: string;
   endpoints: ResourceTreeEndpoints<T>;
+  /** Resource-specific state and actions layered on the shared slice. */
+  extend?: (
+    set: ResourceTreeSet<ResourceTreeState<T> & Extra>,
+    get: ResourceTreeGet<ResourceTreeState<T> & Extra>,
+    helpers: ResourceTreeHelpers<T>,
+  ) => Extra;
 }) {
-  const { resourceName, endpoints } = config;
-  type State = ResourceTreeState<T>;
+  const { resourceName, endpoints, extend } = config;
+  type State = ResourceTreeState<T> & Extra;
+  type Sections = ResourceTreeSections<T>;
 
-  const allSections = (state: State, wid: string): T[][] => [
+  const allSections = (state: Sections, wid: string): T[][] => [
     state.myItems[wid] || [],
     state.workspaceItems[wid] || [],
   ];
 
+  const findInAnySection = (
+    state: Sections,
+    wid: string,
+    id: string,
+  ): T | null => {
+    for (const section of allSections(state, wid)) {
+      const found = findById(section, id);
+      if (found) return found;
+    }
+    return null;
+  };
+
   const removeFromAnySection = (
-    state: State,
+    state: Sections,
     wid: string,
     id: string,
   ): T | null => {
@@ -137,7 +211,7 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
   };
 
   const insertIntoFolder = (
-    state: State,
+    state: Sections,
     wid: string,
     entry: T,
     targetFolderId: string | null,
@@ -160,14 +234,14 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
   };
 
   const sectionOfFolder = (
-    state: State,
+    state: Sections,
     wid: string,
     folderId: string,
   ): TreeSection =>
     findById(state.workspaceItems[wid] || [], folderId) ? "workspace" : "my";
 
   const targetSectionFor = (
-    state: State,
+    state: Sections,
     wid: string,
     access: TreeAccessLevel | undefined,
     folderId: string | null | undefined,
@@ -178,7 +252,7 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
     return "my";
   };
 
-  const resortIn = (state: State, wid: string, itemId: string): void => {
+  const resortIn = (state: Sections, wid: string, itemId: string): void => {
     for (const section of allSections(state, wid)) {
       const parent = findParentArray(section, itemId);
       if (parent) {
@@ -190,6 +264,15 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
         break;
       }
     }
+  };
+
+  const helpers: ResourceTreeHelpers<T> = {
+    allSections,
+    findInAnySection,
+    removeFromAnySection,
+    insertIntoFolder,
+    sectionOfFolder,
+    resortIn,
   };
 
   return create<State>()(
@@ -231,19 +314,19 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
       moveItem: async (workspaceId, itemId, targetFolderId, access) => {
         set(state => {
           const entry = removeFromAnySection(
-            state as State,
+            state as Sections,
             workspaceId,
             itemId,
           );
           if (!entry) return;
           if (access) entry.access = access;
           insertIntoFolder(
-            state as State,
+            state as Sections,
             workspaceId,
             entry,
             targetFolderId,
             targetSectionFor(
-              state as State,
+              state as Sections,
               workspaceId,
               access,
               targetFolderId,
@@ -252,37 +335,49 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
         });
         try {
           await endpoints.moveItem(workspaceId, itemId, targetFolderId, access);
+          return true;
         } catch {
           await get().refresh(workspaceId);
+          return false;
         }
       },
 
       moveFolder: async (workspaceId, folderId, parentId, access) => {
         set(state => {
           const entry = removeFromAnySection(
-            state as State,
+            state as Sections,
             workspaceId,
             folderId,
           );
           if (!entry) return;
           if (access) entry.access = access;
           insertIntoFolder(
-            state as State,
+            state as Sections,
             workspaceId,
             entry,
             parentId,
-            targetSectionFor(state as State, workspaceId, access, parentId),
+            targetSectionFor(state as Sections, workspaceId, access, parentId),
           );
         });
         try {
           await endpoints.moveFolder(workspaceId, folderId, parentId, access);
+          return true;
         } catch {
           await get().refresh(workspaceId);
+          return false;
         }
       },
 
       createFolder: async (workspaceId, name, parentId, access) => {
-        const resolvedAccess = access || "private";
+        // No explicit access: a folder created inside another one lives in
+        // that folder's section, so it inherits that section's access.
+        const parentSection: TreeSection = parentId
+          ? sectionOfFolder(get(), workspaceId, parentId)
+          : "my";
+        const resolvedAccess: TreeAccessLevel =
+          access ?? (parentSection === "workspace" ? "workspace" : "private");
+        const targetSection: TreeSection =
+          resolvedAccess === "workspace" ? "workspace" : parentSection;
         const tempId = `temp-${Date.now()}`;
         const tempEntry = {
           id: tempId,
@@ -292,15 +387,9 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
           children: [],
           access: resolvedAccess,
         } as unknown as T;
-        const targetSection: TreeSection =
-          resolvedAccess === "workspace"
-            ? "workspace"
-            : parentId
-              ? sectionOfFolder(get(), workspaceId, parentId)
-              : "my";
         set(state => {
           insertIntoFolder(
-            state as State,
+            state as Sections,
             workspaceId,
             tempEntry,
             parentId || null,
@@ -316,15 +405,14 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
             resolvedAccess,
           );
           const realId = created?.id;
-          if (!realId) return null;
+          if (!realId) throw new Error("Folder was not created");
           set(state => {
-            for (const section of allSections(state as State, workspaceId)) {
-              const node = findById(section, tempId);
-              if (node) {
-                node.id = realId;
-                break;
-              }
-            }
+            const node = findInAnySection(
+              state as Sections,
+              workspaceId,
+              tempId,
+            );
+            if (node) node.id = realId;
           });
           return realId;
         } catch {
@@ -335,42 +423,44 @@ export function createResourceTreeStore<T extends ResourceTreeEntry>(config: {
 
       renameItem: async (workspaceId, itemId, name, isDirectory) => {
         set(state => {
-          for (const section of allSections(state as State, workspaceId)) {
-            const node = findById(section, itemId);
-            if (node) {
-              node.name = name;
-              resortIn(state as State, workspaceId, itemId);
-              break;
-            }
-          }
+          const node = findInAnySection(state as Sections, workspaceId, itemId);
+          if (!node) return;
+          node.name = name;
+          resortIn(state as Sections, workspaceId, itemId);
         });
         try {
           await (isDirectory
             ? endpoints.renameFolder(workspaceId, itemId, name)
             : endpoints.renameItem(workspaceId, itemId, name));
+          return true;
         } catch {
           await get().refresh(workspaceId);
+          return false;
         }
       },
 
       deleteItem: async (workspaceId, itemId, isDirectory) => {
         set(state => {
-          removeFromAnySection(state as State, workspaceId, itemId);
+          removeFromAnySection(state as Sections, workspaceId, itemId);
         });
         try {
           await (isDirectory
             ? endpoints.deleteFolder(workspaceId, itemId)
             : endpoints.deleteItem(workspaceId, itemId));
+          return true;
         } catch {
           await get().refresh(workspaceId);
+          return false;
         }
       },
 
       resortItem: (workspaceId, itemId) => {
         set(state => {
-          resortIn(state as State, workspaceId, itemId);
+          resortIn(state as Sections, workspaceId, itemId);
         });
       },
+
+      ...(extend ? extend(set, get, helpers) : ({} as Extra)),
     })),
   );
 }

--- a/app/src/store/lib/tree-helpers.ts
+++ b/app/src/store/lib/tree-helpers.ts
@@ -4,7 +4,7 @@
  * Every helper expects a node interface with at least:
  *   { id?: string; name: string; isDirectory: boolean; children?: T[] }
  *
- * Used by both consoleTreeStore and dashboardTreeStore.
+ * Used by createResourceTreeStore and the resource stores built on it.
  */
 
 export interface ManagedTreeNode {


### PR DESCRIPTION
## Why

`consoleTreeStore` was the fork `createResourceTreeStore`'s header already called out: the same two-section tree, optimistic move / rename / create-folder / delete and refresh-on-failure as the notebook and dashboard stores, copied and then drifted ~600 lines on its own. It also carried a dead legacy `trees` mirror, `init` / `setTree` nobody called, and an `updateAccess` on the untyped `apiClient` hitting a `/share` route the typed schema no longer has. Every fix to the shared mechanics had to land three times, and the console copy was the one that missed them.

## What

- **Factory** (`createResourceTreeStore`): new optional `extend(set, get, helpers)` so a resource layers its own state/actions on the shared slice with the same section helpers the built-ins use (`allSections`, `findInAnySection`, `removeFromAnySection`, `insertIntoFolder`, `sectionOfFolder`, `resortIn`); generic is `createResourceTreeStore<T, Extra>`. Mutating actions resolve `Promise<boolean>` (false after the refresh-on-failure path) — the console explorer keys its tab-path update and undo stack on it. `createFolder` without an explicit access inherits the parent folder's section (the console store did this; the temp node was already placed there).
- **consoleTreeStore**: 647 → ~290 lines; entry type + endpoints + the genuinely console-only extras (`searchConsoles`/`clearSearch`, `addConsole`, `applyRemoteRename`, `duplicateConsole`, `restoreConsole`). `{ success: false }` envelopes throw so the factory's failure path fires exactly as before. `ConsoleEntry.id` is now required (every producer already set it). Dropped: `trees`, `init`, `setTree`, `updateAccess` (no callers anywhere), `moveConsole` (callers use `moveItem`).
- **useResourceTreeExplorer**: takes the store structurally (selector call + `setState`) so an extended store fits; `myItems`/`workspaceItems` are typed `T[]`; new `autoFetch: false` option for consoles, whose tree is preloaded by workspace-context (and the save/move picker must not refetch on open).
- **ConsoleTree / ConsoleExplorer** sit on the hook for move / rename / create-folder / resort handlers and the delete-confirm state. Delete stays custom in `ConsoleTree` (sidebar → explorer's confirm/soft-delete+undo, picker → direct); sections stay local (no header icons, droppable only with DnD on).
- State keys are `myItems` / `workspaceItems` in `FileExplorerDialog` and the two components; the API response field `sharedWithWorkspace` is untouched.
- New `consoleTreeStore.test.ts`: fetch mapping (incl. legacy `tree` fallback and error path), optimistic rename + resort before the PATCH resolves, refetch on `success: false`, `applyRemoteRename`, `addConsole`.

Behaviour preserved: optimistic updates, refresh-on-failure, the realtime `applyRemoteRename` path, `restoreConsole` refetch-on-success, workspace-context preload. Only visible text change: the fetch-error fallback reads "Failed to fetch console tree" instead of "Failed to fetch" (the message itself still comes from the error when present).

Checks: `tsc --noEmit`, eslint on changed files, `vitest run src/store src/lib src/hooks src/utils` (35 files, 255 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5
