### PR TITLE
fix(close): subscribe to activity.call / task_completed `updated` webhook events

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -171,6 +171,38 @@ function testGroupsEntityIsAvailable() {
   );
 }
 
+function testCallWebhookEventsIncludeUpdated() {
+  const connector = createConnector();
+
+  // Regression: `activity.call updated` was missing from the subscription
+  // list, so manually-logged calls (source "External") kept duration 0 forever
+  // and recordings never attached — while created/answered/completed flowed.
+  assert.deepEqual(connector.getWebhookEventsForEntities(["activities:Call"]), [
+    "activity.call.created",
+    "activity.call.updated",
+    "activity.call.deleted",
+    "activity.call.answered",
+    "activity.call.completed",
+  ]);
+  assert.deepEqual(connector.getWebhookEventMapping("activity.call.updated"), {
+    entity: "activities:Call",
+    operation: "upsert",
+  });
+}
+
+function testTaskCompletedWebhookEventsIncludeUpdated() {
+  const connector = createConnector();
+
+  assert.deepEqual(
+    connector.getWebhookEventsForEntities(["activities:TaskCompleted"]),
+    [
+      "activity.task_completed.created",
+      "activity.task_completed.updated",
+      "activity.task_completed.deleted",
+    ],
+  );
+}
+
 function testGroupWebhookEventsAreScopedToGroups() {
   const connector = createConnector();
 
@@ -597,6 +629,8 @@ async function main() {
   testWebhookChangeIdUsesNestedEventId();
   testWebhookChangeIdFallbackIncludesSourceTs();
   testGroupsEntityIsAvailable();
+  testCallWebhookEventsIncludeUpdated();
+  testTaskCompletedWebhookEventsIncludeUpdated();
   testGroupWebhookEventsAreScopedToGroups();
   testGroupWebhookEventsAreMapped();
   await testGroupSchemaResolves();

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -94,6 +94,11 @@ const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "opportunity", action: "updated" },
   { object_type: "opportunity", action: "deleted" },
   { object_type: "activity.call", action: "created" },
+  // `updated` is how manually-logged calls (source "External") get their real
+  // duration (created with duration 0, then updated on save), and how native
+  // calls get recording_url/has_recording after the recording lands. Without
+  // this selector those fields freeze at their creation values.
+  { object_type: "activity.call", action: "updated" },
   { object_type: "activity.call", action: "deleted" },
   { object_type: "activity.call", action: "answered" },
   { object_type: "activity.call", action: "completed" },
@@ -125,6 +130,7 @@ const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "activity.opportunity_status_change", action: "updated" },
   { object_type: "activity.opportunity_status_change", action: "deleted" },
   { object_type: "activity.task_completed", action: "created" },
+  { object_type: "activity.task_completed", action: "updated" },
   { object_type: "activity.task_completed", action: "deleted" },
   { object_type: "activity.custom_activity", action: "created" },
   { object_type: "activity.custom_activity", action: "updated" },


### PR DESCRIPTION
## Motivation

Since Close flows moved to webhook-only streaming, every manually-logged call (`source: "External"`) freezes at **duration 0** in the destination: the activity is created with duration 0 and the real duration arrives in an `activity.call updated` event — which was never subscribed. Native calls kept looking healthy because their final state arrives via `completed`, which masked the gap. The same missing selector freezes `recording_url`/`has_recording` (they land via `updated` once the recording is processed).

Measured on the RealAdvisor workspace (BigQuery destinations): FR External calls with an applied update went **798/837 in June (polling era) → 3/590 in July → 5/329 in August**, and 0 across ES/IT/CH/PL — a clean simultaneous break at the webhook migration. `activity.call updated` events are confirmed present in the Close event log (checked via `GET /event/?object_type=activity.call&action=updated`), and Close delivers `updated` actions over webhooks after its consolidation delay.

Downstream impact of the bug: two months of CSM follow-up calls invisible in activity reporting (duration filters), i.e. real compensation undercounting.

## What changed

- Added `{ object_type: "activity.call", action: "updated" }` to `CLOSE_SUPPORTED_WEBHOOK_SELECTORS` — the receive path (`getWebhookEventMapping`) already maps `activity.call.updated` → `activities:Call` upsert, so only the subscription list was missing.
- Added `activity.task_completed updated` as well (same latent gap; such events exist in the Close event log).
- Tests: `getWebhookEventsForEntities` now asserts the Call and TaskCompleted selector sets, plus the `activity.call.updated` mapping.

## Deploy note

Existing Close subscriptions are updated in place on re-provision (`createWebhookSubscription` PUTs the new `events` list onto the webhook matched by URL) — flows need one re-provision after deploy to pick up the new selectors. Historical rows need a backfill or the periodic full reconcile to heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDXR6Kj4chfisSfZJghE4t