### PR TITLE
fix(editors): a pending autosave is flushed on unmount, never dropped — one debounce hook

### DIFF
--- a/app/src/components/AppFileEditor.tsx
+++ b/app/src/components/AppFileEditor.tsx
@@ -5,7 +5,7 @@
  * edits autosave with a debounce, each save flushing to the actor's private
  * WIP ref so nothing is lost if the tab or the sandbox dies.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Alert, Box, Button, Chip, Typography } from "@mui/material";
 import { Database as DatabaseIcon, Play as PlayIcon } from "lucide-react";
 import MonacoEditor from "@monaco-editor/react";
@@ -13,6 +13,7 @@ import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppsStore } from "../store/appsStore";
 import { useConsoleStore } from "../store/consoleStore";
+import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import {
   configureMonacoForJsx,
   languageForPath,
@@ -54,7 +55,9 @@ export default function AppFileEditor({
   const updateFileLocal = useAppsStore(s => s.updateFileLocal);
   const materializeAppBinding = useAppsStore(s => s.materializeAppBinding);
   const saveFile = useAppsStore(s => s.saveFile);
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const save = useDebouncedCallback(() => {
+    if (workspaceId) void saveFile(workspaceId, appId, path);
+  }, 1000);
 
   // Binding files get a console-style toolbar (Block 3 of the bindings plan;
   // connection picker + Run-through-console-engine are the next slice).
@@ -100,14 +103,9 @@ export default function AppFileEditor({
       updateFileLocal(appId, path, value ?? "");
       // First keystroke pins the tab (preview -> permanent), as for consoles.
       useConsoleStore.getState().updateDirty(_tabId, true);
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      if (workspaceId) {
-        saveTimer.current = setTimeout(() => {
-          void saveFile(workspaceId, appId, path);
-        }, 1000);
-      }
+      save.call();
     },
-    [appId, path, workspaceId, updateFileLocal, saveFile, _tabId],
+    [appId, path, updateFileLocal, save, _tabId],
   );
 
   return (

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -657,12 +657,20 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     }
   }, [initialContent]);
 
-  // Cleanup debounce timeout on unmount
+  // On unmount, FLUSH a pending content change instead of dropping it: the
+  // debounce is 500ms, and a tab switch inside that window used to lose the
+  // last keystrokes from the persisted tab state.
+  const pendingContentRef = useRef<string | null>(null);
+  const onContentChangeRef = useRef(onContentChange);
+  onContentChangeRef.current = onContentChange;
   useEffect(() => {
     return () => {
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current);
       }
+      const pending = pendingContentRef.current;
+      pendingContentRef.current = null;
+      if (pending !== null) onContentChangeRef.current?.(pending);
     };
   }, []);
 
@@ -829,7 +837,9 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           clearTimeout(debounceTimeoutRef.current);
         }
 
+        pendingContentRef.current = content;
         debounceTimeoutRef.current = setTimeout(() => {
+          pendingContentRef.current = null;
           onContentChange(content);
         }, 500);
       }

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useConsoleStore } from "../store/consoleStore";
+import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import {
   lazy,
   Suspense,
@@ -256,7 +257,12 @@ export default function DbtFileEditor({
   const previewModel = useDbtStore(s => s.previewModel);
   const setMyEnvironment = useDbtStore(s => s.setMyEnvironment);
 
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const save = useDebouncedCallback(() => {
+    if (!workspaceId) return;
+    void persistFile(workspaceId, projectId, path);
+    // Live re-compile after the edit settles (dbt Studio parity).
+    autoCompileRef.current();
+  }, 1200);
   const [environment, setEnvironment] = useState<string>("");
   const [defer, setDefer] = useState(false);
   // Run menu builds/runs with --full-refresh (rebuild incremental models
@@ -349,25 +355,15 @@ export default function DbtFileEditor({
       writeFile(projectId, path, value ?? "");
       // First keystroke pins the tab (preview -> permanent), as for consoles.
       useConsoleStore.getState().updateDirty(tabId, true);
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      if (workspaceId) {
-        saveTimer.current = setTimeout(() => {
-          void persistFile(workspaceId, projectId, path);
-          // Live re-compile after the edit settles (dbt Studio parity).
-          autoCompileRef.current();
-        }, 1200);
-      }
+      save.call();
     },
-    [projectId, path, workspaceId, writeFile, persistFile, tabId],
+    [projectId, path, writeFile, save, tabId],
   );
 
   const saveNow = useCallback(() => {
-    if (saveTimer.current) {
-      clearTimeout(saveTimer.current);
-      saveTimer.current = null;
-    }
+    save.cancel();
     if (workspaceId) void persistFile(workspaceId, projectId, path);
-  }, [workspaceId, projectId, path, persistFile]);
+  }, [save, workspaceId, projectId, path, persistFile]);
 
   // ⌘S saves, ⌘↵ previews. Both are registered once on mount, so they read the
   // live handler through a ref rather than capturing the mount-time closure.

--- a/app/src/hooks/useDebouncedCallback.test.ts
+++ b/app/src/hooks/useDebouncedCallback.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDebouncedCallback } from "./useDebouncedCallback";
+
+describe("useDebouncedCallback", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("collapses rapid calls into the last one after the delay", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 500));
+    result.current.call("a");
+    result.current.call("b");
+    vi.advanceTimersByTime(499);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("b");
+  });
+
+  it("flushes the pending call on unmount instead of dropping it", () => {
+    const fn = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedCallback(fn, 500));
+    result.current.call("typed just before switching tabs");
+    unmount();
+    expect(fn).toHaveBeenCalledWith("typed just before switching tabs");
+    vi.advanceTimersByTime(1000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel drops the pending call; flush with nothing pending is a no-op", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 500));
+    result.current.call("x");
+    result.current.cancel();
+    vi.advanceTimersByTime(1000);
+    result.current.flush();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/hooks/useDebouncedCallback.ts
+++ b/app/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,47 @@
+/**
+ * Debounce for "persist what the user just typed": the last call wins, and
+ * an unmount FLUSHES the pending call instead of dropping it. Three editors
+ * hand-rolled this with a `saveTimer` ref (1000 ms, 1200 ms, 500 ms); the
+ * console's cleanup cleared its timer, so the final keystrokes before a tab
+ * switch never reached the persisted tab state.
+ */
+import { useCallback, useEffect, useRef } from "react";
+
+export function useDebouncedCallback<A extends unknown[]>(
+  fn: (...args: A) => void,
+  delayMs: number,
+) {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending = useRef<A | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = null;
+    pending.current = null;
+  }, []);
+
+  /** Run the pending call now (no-op when nothing is pending). */
+  const flush = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = null;
+    const args = pending.current;
+    pending.current = null;
+    if (args) fnRef.current(...args);
+  }, []);
+
+  const call = useCallback(
+    (...args: A) => {
+      pending.current = args;
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, delayMs);
+    },
+    [delayMs, flush],
+  );
+
+  // Unmount = the user moved on; what they typed must still land.
+  useEffect(() => flush, [flush]);
+
+  return { call, flush, cancel };
+}


### PR DESCRIPTION
## Why
`Console.tsx`'s unmount cleanup **cleared** its 500 ms `onContentChange` debounce, so keystrokes in that window before a tab switch never reached the persisted tab state. `AppFileEditor` / `DbtFileEditor` hand-rolled the same `saveTimer` (1000/1200 ms) with no unmount handling — they worked because the store still held the content, by accident.

## What
- `hooks/useDebouncedCallback(fn, delay)` → `{ call, flush, cancel }`; unmount flushes. 3 tests (collapse, flush-on-unmount, cancel).
- App/dbt file editors on the hook (⌘S = cancel + persist, unchanged).
- Console: records the pending content and flushes it on unmount (shared timer otherwise untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5