### PR TITLE
chore(npm): scope @makoai — app-sdk + cli renamed, trusted-publishing workflow, template v4

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,77 @@
+# Publish @makoai/app-sdk and @makoai/cli to npm with TRUSTED PUBLISHING:
+# the job proves its identity to npm with a GitHub OIDC token, npm mints a
+# short-lived publish credential, and no long-lived token exists anywhere
+# (npm is retiring 2FA-bypass tokens for publishing in Jan 2027).
+#
+# One-time setup per package on npmjs.com → package → Settings → Trusted
+# publisher: GitHub Actions, repository mako-ai/mako, workflow
+# publish-npm.yml. The first version of a brand-new package has to be
+# published once by a human (`npm publish --access public` from the package
+# directory) so the settings page exists.
+#
+# Trigger: push a tag `app-sdk-vX.Y.Z` or `cli-vX.Y.Z` matching the
+# package.json version, or run manually.
+name: Publish npm packages
+
+on:
+  push:
+    tags:
+      - "app-sdk-v*"
+      - "cli-v*"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Which package"
+        required: true
+        type: choice
+        options: [app-sdk, cli]
+
+permissions:
+  contents: read
+  id-token: write # OIDC for npm trusted publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Resolve package from tag or input
+        id: pkg
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            name="${{ inputs.package }}"
+          else
+            name="${GITHUB_REF_NAME%-v*}"
+          fi
+          echo "dir=packages/$name" >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+      - name: Trusted publishing needs npm >= 11.5
+        run: npm install -g npm@latest && npm --version
+      - name: Check the tag matches package.json
+        if: github.event_name == 'push'
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: |
+          v=$(node -p "require('./package.json').version")
+          [ "${GITHUB_REF_NAME}" = "${{ steps.pkg.outputs.name }}-v$v" ] || { echo "tag $GITHUB_REF_NAME != package.json $v"; exit 1; }
+      - name: Tests
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: |
+          # The cli depends on the workspace app-sdk; resolve it for the tests
+          # without a full pnpm install.
+          if [ "${{ steps.pkg.outputs.name }}" = "cli" ]; then
+            mkdir -p node_modules/@makoai && ln -sfn ../../../app-sdk node_modules/@makoai/app-sdk
+          fi
+          node --test
+      - name: Rewrite workspace:* to the published version (cli → app-sdk)
+        if: steps.pkg.outputs.name == 'cli'
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: |
+          sdk=$(node -p "require('../app-sdk/package.json').version")
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.dependencies['@makoai/app-sdk']='^'+process.argv[1];fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" "$sdk"
+      - name: Publish
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: npm publish --provenance --access public

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -152,6 +152,12 @@ SNAPPY-compressed, so plain hyparquet works (no compressors bundle needed).
 After wiring a binding into the UI, `app_browse` is how you confirm the data
 actually loads — a failed `__data/...` fetch shows up in its failedRequests.
 
+## The SDK's name
+
+New apps depend on `@makoai/app-sdk` (npm) — vendored at `packages/app-sdk`.
+Apps created before 2026-09 import the same package as `@makoai/app-sdk`
+(older alias): keep whatever the app's `package.json` already uses.
+
 ## Charts
 
 Before adding any chart, read `references/charting.md`

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -16,7 +16,7 @@ Mako is a data platform. Its core concepts are:
 - **Connectors** — SaaS integrations (Stripe, PostHog, Close CRM, REST, GraphQL) that sync external data into a connection.
 - **Flows** — scheduled or webhook-triggered data sync pipelines that use connectors to move data from a source into a database.
 - **Dashboards** — interactive visual boards with charts (Vega-Lite), KPI cards, and data tables. Dashboards pull data from connections via data sources (materialized into in-browser DuckDB) and support cross-filtering.
-- **Apps** — full React applications (Lovable / v0 style) authored as a virtual filesystem. Apps can use any npm library and custom components, and read workspace data through named **data bindings** (\`useQuery("name")\` from \`@mako/app-sdk\`). Bindings run server-side, scoped to the workspace.
+- **Apps** — full React applications (Lovable / v0 style) authored as a virtual filesystem. Apps can use any npm library and custom components, and read workspace data through named **data bindings** (\`useQuery("name")\` from \`@makoai/app-sdk\`). Bindings run server-side, scoped to the workspace.
 
 ## Expertise Modes (read this FIRST)
 

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -11,7 +11,7 @@ Mako is a data platform. Its core concepts are:
 - **Connectors** — SaaS integrations (Stripe, PostHog, Close CRM, REST, GraphQL) that sync external data into a connection.
 - **Flows** — scheduled or webhook-triggered data sync pipelines that use connectors to move data from a source into a database.
 - **Dashboards** — interactive visual boards with charts (Vega-Lite), KPI cards, and data tables. Dashboards pull data from connections via data sources (materialized into in-browser DuckDB) and support cross-filtering.
-- **Apps** — full React applications (Lovable / v0 style) authored as a virtual filesystem. Apps can use any npm library and custom components, and read workspace data through named **data bindings** (\`useQuery("name")\` from \`@mako/app-sdk\`). Bindings run server-side, scoped to the workspace.
+- **Apps** — full React applications (Lovable / v0 style) authored as a virtual filesystem. Apps can use any npm library and custom components, and read workspace data through named **data bindings** (\`useQuery("name")\` from \`@makoai/app-sdk\`). Bindings run server-side, scoped to the workspace.
 
 ## Expertise Modes (read this FIRST)
 
@@ -105,7 +105,7 @@ For sync-flow setup, query templates, pagination, destination requirements, sche
 
 ## App Guidance
 
-For building React apps (file editing workflow, data bindings, \`@mako/app-sdk\` hooks, materialized DuckDB bindings, and runtime constraints), load the \`apps\` system skill.`;
+For building React apps (file editing workflow, data bindings, \`@makoai/app-sdk\` hooks, materialized DuckDB bindings, and runtime constraints), load the \`apps\` system skill.`;
 
 function buildConsoleContext(context: AgentContext): string[] {
   const parts: string[] = [];

--- a/api/src/apps/app-sdk-package.ts
+++ b/api/src/apps/app-sdk-package.ts
@@ -1,5 +1,5 @@
 /**
- * `@mako/app-sdk` — a REAL package committed into every workspace repo at
+ * `@makoai/app-sdk` — a REAL package committed into every workspace repo at
  * `packages/app-sdk`, consumed by apps as a `file:` dependency.
  *
  * v1 injected this module at runtime: the host resolved the import from an
@@ -23,7 +23,7 @@ export const APP_SDK_DIR = "packages/app-sdk";
 
 /** The dependency entry an app needs to import the SDK. */
 export const APP_SDK_DEPENDENCY: Record<string, string> = {
-  "@mako/app-sdk": "file:../../packages/app-sdk",
+  "@makoai/app-sdk": "file:../../packages/app-sdk",
 };
 
 /** Files of the package that ship into workspace repos (the npm `files`). */
@@ -62,7 +62,7 @@ export function appSdkSourceDir(): string {
     }
   }
   throw new Error(
-    `@mako/app-sdk package files not found (looked in ${candidateDirs().join(", ")})`,
+    `@makoai/app-sdk package files not found (looked in ${candidateDirs().join(", ")})`,
   );
 }
 

--- a/api/src/apps/scaffold.ts
+++ b/api/src/apps/scaffold.ts
@@ -42,7 +42,7 @@ export function createAppsScaffold(
           preview: "vite preview",
         },
         dependencies: {
-          "@mako/app-sdk": "file:../../packages/app-sdk",
+          "@makoai/app-sdk": "file:../../packages/app-sdk",
           react: "^18.2.0",
           "react-dom": "^18.2.0",
         },
@@ -83,7 +83,7 @@ export function createAppsScaffold(
 `,
     "vite.config.ts": `import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { makoData } from "@mako/app-sdk/vite";
+import { makoData } from "@makoai/app-sdk/vite";
 
 export default defineConfig({
   // makoData serves this app's data bindings (__data/*.parquet) during a

--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 4, fingerprint: "cc58059df561fb6d" };
+const PINNED = { version: 4, fingerprint: "7d2dbe63394371c2" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 3, fingerprint: "7c9f98503d68416e" };
+const PINNED = { version: 4, fingerprint: "cc58059df561fb6d" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.ts
+++ b/api/src/apps/workspace-template.ts
@@ -31,7 +31,7 @@ import { fetchFromCloud, queueMirrorPush } from "./cloud-repo.service";
 
 const logger = loggers.app();
 
-export const WORKSPACE_TEMPLATE_VERSION = 3;
+export const WORKSPACE_TEMPLATE_VERSION = 4;
 
 /** Where `.mcp.json` points when MAKO_API_URL is not exported. */
 export const HOSTED_MAKO_URL = "https://app.mako.ai";
@@ -56,7 +56,7 @@ of the workspace. **\`main\` is production** — a commit on \`main\` deploys.
 - \`apps/<slug>/\` — one app per folder: a real Vite + React + TypeScript
   project. \`mako.json\` (title, entry), \`bindings/<name>.sql\` (data),
   \`src/\`, \`package.json\` + \`package-lock.json\` (commit the lockfile).
-- \`packages/app-sdk/\` — \`@mako/app-sdk\` (managed by Mako, do not edit).
+- \`packages/app-sdk/\` — \`@makoai/app-sdk\` (managed by Mako, do not edit).
   Apps depend on it via \`file:../../packages/app-sdk\`.
 - \`.mako/workspace.json\` — workspace id + template version (managed).
 - \`.mcp.json\` — the \`mako\` MCP server for your agent (managed).
@@ -70,7 +70,7 @@ paste:
 1. \`claude\` (or Cursor / Codex) → the \`mako\` MCP server in \`.mcp.json\`
    opens a browser sign-in on first use: pick this workspace, approve
    (read-only). Claude Code: type \`/mcp\` if it does not prompt.
-2. \`npx @mako/cli login\` (or \`mako login\` once installed) in this checkout —
+2. \`npx @makoai/cli login\` (or \`mako login\` once installed) in this checkout —
    the same sign-in, kept in \`~/.mako/credentials.json\` for \`vite dev\`.
 
 Headless / CI instead: create a workspace API key in Mako (**Workspace
@@ -109,7 +109,7 @@ You are an ordinary developer in an ordinary checkout.
 ## Data in local dev
 
 Each app's \`vite.config.ts\` includes \`makoData()\` from
-\`@mako/app-sdk/vite\`. During \`vite dev\` it answers
+\`@makoai/app-sdk/vite\`. During \`vite dev\` it answers
 \`__data/index.json\` (the app's \`bindings/*.sql\`) and
 \`__data/<name>.parquet\` by streaming the binding's materialized artifact
 from the Mako API with your login (or the key in \`.env\`); a binding that was never
@@ -118,7 +118,7 @@ materialized is built on first request. Results are cached under
 
 No key → the app runs and every binding answers 503 with a hint. An app whose
 \`vite.config.ts\` predates the plugin: add
-\`import { makoData } from "@mako/app-sdk/vite";\` and \`makoData()\` to
+\`import { makoData } from "@makoai/app-sdk/vite";\` and \`makoData()\` to
 \`plugins\`.
 
 ## Bindings

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -641,7 +641,7 @@ export async function createProject(input: {
     if (!(await repoExists(repoDir))) {
       // README + .gitignore (seeded once), and the managed template: agent
       // instructions, MCP wiring, identity stamp, and the vendored
-      // @mako/app-sdk so `import { useQuery } from "@mako/app-sdk"` resolves
+      // @makoai/app-sdk so `import { useQuery } from "@makoai/app-sdk"` resolves
       // in vite dev, in npm run build, and in a laptop clone alike. Existing
       // repos are brought level by ensureWorkspaceTemplate (workspace-template.ts).
       await initRepo(repoDir, initialWorkspaceFiles(input.workspaceId), {

--- a/api/src/auth/scoped-key-routes.ts
+++ b/api/src/auth/scoped-key-routes.ts
@@ -4,7 +4,7 @@
  * Scoped keys (`mcp`, `query:read`, …) are MCP-only by construction so a
  * key handed to an agent can never be replayed against REST mutation routes
  * (AUTH_README, "MCP credentials are MCP-only"). A laptop checkout needs one
- * exception: `@mako/app-sdk/vite` streams an app's materialized binding
+ * exception: `@makoai/app-sdk/vite` streams an app's materialized binding
  * parquet during a local `vite dev`, and parquet does not travel well inside
  * a JSON-RPC tool result. So a key carrying `query:read` may additionally
  * call the binding READ routes below — each executes the binding's query

--- a/apps.md
+++ b/apps.md
@@ -47,7 +47,7 @@ Two RFCs were written independently against the same brief and then merged. Wher
 | **One substrate: E2B everywhere; the local provider is deleted (DECIDED)** | Three unrelated activities were all called "development", and the substrate was chosen for the wrong one. **(1) Developing Mako runs on E2B** — exercising a substrate no user runs ships untested code paths and carries a second implementation forever; every developer has an E2B key, like a database URL. Proven, not theoretical: the nested-node_modules bug (app could not build; 13-27s per command) survived from Block B until 2026-08-20 **because the local provider has no host↔sandbox sync at all** — structurally invisible there, immediate on E2B. **(2) Customer app dev on app.mako.ai runs on E2B** — N1, plus an unsandboxed shell lets a tenant exhaust the API host. **(3) Local customer dev uses NO Mako sandbox**: the user has the WORKSPACE repo checked out, a `mako` executable supplies data proxies + auth, and the user (or Claude Code) runs `vite dev` directly as themselves — Mako is not in the execution path, and **the user never checks out Mako**. This corrects §4.8(d)'s "local executor behind the provider seam". Deleted: local-provider.ts, dev-server.service.ts, dev-preview-ws-proxy.ts, the devPreviewAvailable probe + toolbar gating, and the APPS_V2_SANDBOX_PROVIDER knob; provider.ts stays as the seam for a Fly/Modal fallback. **Live preview moves INTO the sandbox** (vite on 0.0.0.0 + `sandbox.getHost(port)` + iframe), which is why it can finally exist in deployed environments at all. Detail: §12. | User (2026-08-21) |
 | **App lifecycle: view / edit / publish (§13)** | Found by this RFC's own author: *"even though I built this, I don't understand the UX"*. The cause is not labelling — **there is no publish, no deploy and no viewer**: `publishedSha` is never written by anything, there is no public-share route, the built bundle is served behind a 30-MINUTE in-memory token, and even browsing an app calls `ensureWorktree`. Apps v2 is an IDE with two developer preview modes. **Correction to an earlier claim in this session:** data is much further along — bindings already materialize into the shared artifact store (GCS when deployed) at `apps-v2/<projectId>/<name>.parquet`, so warehouse→parquet→bucket is DONE and durable; only the serving path is tied to the ephemeral preview token. Target: three states, one primary action each — Published (no sandbox at all; primary = Edit), Editing (branch + dev session; primary = Publish), Never published. Publish = merge → build from main → IMMUTABLE addressable artifact → repoint, which makes rollback a repoint. Open: an ACL'd data path for published apps (§4.7 capability tokens — the genuinely hard part), scheduled refresh, failed-build-on-main, rollback UX, concurrent editors, static-only boundary. Detail: §13. | User + analysis (2026-08-21) |
 | **What `mako` runs locally (OPEN)** | Two readings of "the full Mako app at localhost:6969": a **thin local shell** (serves the UI, owns the local checkout, runs `vite dev`, proxies control plane + data execution to the cloud — materially `packages/desktop` + `packages/local-agent` minus Electron; ships in weeks, no new deployment target) versus a **full local stack** (API + database + Inngest + kernel on the laptop; true self-host, permanent second deployment target and support surface). **Proposed default: thin shell**, full stack only if self-hosting proves to be a sales requirement. Detail: §11.6. | Raised 2026-08-19 |
-| **Sequencing: cheap half first; `mako agent` deferred indefinitely** | Order: (1) scaffold `CLAUDE.md`/`.mcp.json` + §10 Block D1 `skills/` so `git clone && claude` is Mako-capable with no CLI at all — generated from the same source as `buildMakoSystemPromptAppend` to avoid drift; (2) **deploy on merge** (`publishedSha` is currently read but never written — no pipeline exists, so §11.4 is not yet true); (3) minimal `@mako/cli` (`login` + `dev` only); then Block D2 consoles + Block C branch state; then revisit §11.6. The **`mako agent` terminal harness (§4.8c) is deferred indefinitely** — building a competing harness with our tokens contradicts the reason for the work. Detail: §11.7–11.9. | User (2026-08-19) |
+| **Sequencing: cheap half first; `mako agent` deferred indefinitely** | Order: (1) scaffold `CLAUDE.md`/`.mcp.json` + §10 Block D1 `skills/` so `git clone && claude` is Mako-capable with no CLI at all — generated from the same source as `buildMakoSystemPromptAppend` to avoid drift; (2) **deploy on merge** (`publishedSha` is currently read but never written — no pipeline exists, so §11.4 is not yet true); (3) minimal `@makoai/cli` (`login` + `dev` only); then Block D2 consoles + Block C branch state; then revisit §11.6. The **`mako agent` terminal harness (§4.8c) is deferred indefinitely** — building a competing harness with our tokens contradicts the reason for the work. Detail: §11.7–11.9. | User (2026-08-19) |
 
 ---
 
@@ -106,7 +106,7 @@ Both properties must survive — and both must extend to users editing from outs
 | App storage | `MakoApp` doc, embedded `files[]`, `dependencies` map | Migration source only |
 | App versioning | `version` counter + `entity_versions` snapshots | Replaced by git; keep publish pointer concept |
 | Agent tools | ~20 bespoke server tools + 3 client tools | Replaced by shell/file tools; binding tools evolve |
-| Rendering | Babel + esm.sh import-map iframe, `@mako/app-sdk` injected via postMessage bridge | Bridge + SDK concepts survive; transpile pipeline retired |
+| Rendering | Babel + esm.sh import-map iframe, `@makoai/app-sdk` injected via postMessage bridge | Bridge + SDK concepts survive; transpile pipeline retired |
 | Data bindings | `dataBindings[]` on the doc; live via `POST /workspaces/:id/execute`; parquet via Inngest + DuckDB-WASM | Execution + materialization services reused as-is; binding *definitions* move into files |
 | Sharing | `published` snapshot + `/api/share/:token` routes | Reused; "published" becomes a git ref + built artifact |
 | Git integration | dbt module: GitHub App, Git Data API, Mongo mirror + per-user drafts (`api/src/dbt/dbt-github-*.service.ts`) | GitHub App auth + webhook plumbing reused; the Mongo-mirror pattern is *not* carried into apps v2 |
@@ -271,7 +271,7 @@ The unified agent (`api/src/agents/unified/index.ts`, `app` mode in `modes/regis
 
 Two tiers replace the single CDN iframe:
 
-**Dev preview (editing).** The sandbox runs `vite dev`; E2B exposes it at a public per-sandbox URL; `AppRenderer` iframes that URL. HMR works natively. The `@mako/app-sdk` becomes a real npm package (dep of the scaffold) that keeps the same API (`useQuery`, `useDuckDB`, `useTheme`, `useLocation`) and the same postMessage bridge to the authenticated parent window — so live queries, parquet/DuckDB, theming, and virtual routing carry over with minimal renderer changes, and the iframe still never holds credentials. When no sandbox is running, the preview shows the last published build with a "start dev session" affordance.
+**Dev preview (editing).** The sandbox runs `vite dev`; E2B exposes it at a public per-sandbox URL; `AppRenderer` iframes that URL. HMR works natively. The `@makoai/app-sdk` becomes a real npm package (dep of the scaffold) that keeps the same API (`useQuery`, `useDuckDB`, `useTheme`, `useLocation`) and the same postMessage bridge to the authenticated parent window — so live queries, parquet/DuckDB, theming, and virtual routing carry over with minimal renderer changes, and the iframe still never holds credentials. When no sandbox is running, the preview shows the last published build with a "start dev session" affordance.
 
 **Published (deployed).** "Publish" = deploy an **immutable commit** (never a moving branch head; a dirty worktree gets an explicit "commit and publish"): run `vite build` with `--frozen-lockfile` in a fresh build sandbox, upload `dist/` to a GCS/R2 bucket under a content-addressed deployment prefix, record an `AppDeployment` (commit SHA, lockfile digest, artifact digest), and point the routing entry at it. Rollback is a pointer change, no rebuild. Serving reuses the Cloudflare pattern we already run (`cloudflare/app-router/` KV-routed Worker) — but on a **separate registrable domain, never a `mako.ai` subdomain** (e.g. `<stable-app-id>.makoapps.dev`, registered in the Public Suffix List so sibling apps are different browser *sites*). User code sharing a registrable domain with the control plane would share cookie scope and same-site trust; this was a flaw in the first draft of this RFC. The Worker enforces the existing public-share model (tokens, password unlock, `allowLiveQueries`); runtime data access continues through `api/src/routes/public-share.ts` initially, evolving to a dedicated runtime capability endpoint (opaque, short-lived, deployment-scoped tokens exchanged via one-time bootstrap codes) as the end state.
 
@@ -298,7 +298,7 @@ mako agent          # ...or vibe with the Mako agent itself, right in the termin
 - **Publish from local:** `mako deploy` = push + call Deploy API. USP #2 intact.
 - The repo scaffold includes `.mcp.json` and `AGENTS.md`/`CLAUDE.md` describing the layout and the SDK, so third-party harnesses are effective immediately after clone.
 
-**(c) The `mako` CLI — plumbing *and* a terminal agent.** The commands above imply a real CLI product (`@mako/cli`, installed via `npm i -g mako` or a curl script), not just glue. Beyond `login` / `clone` / `dev` / `deploy` / `run <job>`, it ships **`mako agent`: the Mako agent as a terminal harness**, so users can vibe-code an app from their shell the way they would with Claude Code — except this agent natively knows their workspace.
+**(c) The `mako` CLI — plumbing *and* a terminal agent.** The commands above imply a real CLI product (`@makoai/cli`, installed via `npm i -g mako` or a curl script), not just glue. Beyond `login` / `clone` / `dev` / `deploy` / `run <job>`, it ships **`mako agent`: the Mako agent as a terminal harness**, so users can vibe-code an app from their shell the way they would with Claude Code — except this agent natively knows their workspace.
 
 - **It is a thin client, not a second agent.** `POST /api/agent/chat` already accepts `revops_*` API keys through `unifiedAuthMiddleware`, so streaming, chat persistence, model selection, skills, modes, and MCP tools all come from the existing server for free. The CLI renders the stream and handles tool round-trips.
 - **Tool execution split reuses the existing client/server pattern.** The codebase already splits tools into server-executed and client-executed (`app/src/agent-runtime/client-tool-manifest.ts` + `useClientToolDispatch`); the CLI simply becomes an alternative "client" surface. Data tools (`sql_*`, `mongo_*`, bindings, materialization, publish) keep running server-side; the v2 `bash`/`read_file`/`write_file`/`edit_file`/`glob`/`grep` tools execute **locally against the user's checkout** instead of an E2B sandbox. Same tool contract, two interchangeable executors: cloud sandbox when driven from the web app, local filesystem when driven from the terminal. One brain, two pairs of hands.
@@ -330,7 +330,7 @@ An Inngest function (same pattern as `dbt-run.ts` / `app-binding-materialize.ts`
 - **Migration tool:** for each `MakoApp`, write `files[]` into `apps/<slug>/`, synthesize `package.json` from `dependencies` (+ scaffold `vite.config.ts`, `index.html`), convert `dataBindings[]` to `bindings/` files + `mako.json`, and commit as the app's initial history. `entity_versions` snapshots are optionally replayed as historical commits (nice-to-have).
 - **Dual runtime window:** unmigrated apps keep rendering via the CDN iframe path; migrated apps use v2. The `runtime` field ("cdn" | "webcontainer") is repurposed/extended to gate this. Migration is per-app, user- or admin-triggered, with a bulk path once stable.
 - **Retired after migration:** embedded `files[]`, the ~15 bespoke file/dependency/version tools, Babel/esm.sh preview, `entity_versions` for apps.
-- **Kept:** `MakoApp` doc slims down to metadata + sharing + publish pointer (`repoPath`, `publishedSha`, `publicShare`, ACLs) — sharing and ACLs are workspace concerns and stay in Mongo; execute/materialization/public-share services; `@mako/app-sdk` API surface.
+- **Kept:** `MakoApp` doc slims down to metadata + sharing + publish pointer (`repoPath`, `publishedSha`, `publicShare`, ACLs) — sharing and ACLs are workspace concerns and stay in Mongo; execute/materialization/public-share services; `@makoai/app-sdk` API surface.
 
 ## 6. Phasing
 
@@ -340,7 +340,7 @@ Everything lands as a **parallel v2 module**: `api/src/apps-v2/**`, new Mongo co
 
 1. **Phase 1 — Git substrate.** Mako-hosted bare repos (per app) + repository service with CAS ref updates and hidden WIP refs; Files API (tree/read from a ref); worktree service. Smart-HTTP clone endpoint. *De-risks: git hosting, the read model.* **(Foundation implemented in this PR.)**
 2. **Phase 2 — Sandbox sessions + agent v2.** `SandboxProvider` abstraction (E2B for production; a flag-gated local subprocess provider for dev VMs), session service materializing accessible apps into a workspace-shaped directory, scoped tokens, `app2_bash`/file tools, WIP flush loop, `app2_commit`. Chat can build an app end-to-end. *De-risks: sandbox integration, flush durability, tool ergonomics.* **(Foundation implemented in this PR: provider seam + local provider + session/exec/flush + tools; E2B adapter next.)**
-3. **Phase 3 — Preview & hosting.** `@mako/app-sdk` as real package + Vite scaffold; dev-preview iframe via sandbox URL; publish pipeline (build sandbox → bucket → apps-router Worker); binding-as-files reconciliation + materialization rewire.
+3. **Phase 3 — Preview & hosting.** `@makoai/app-sdk` as real package + Vite scaffold; dev-preview iframe via sandbox URL; publish pipeline (build sandbox → bucket → apps-router Worker); binding-as-files reconciliation + materialization rewire.
 4. **Phase 4 — Open editing.** MCP server, `mako` CLI (`login`/`dev`/`deploy`, then `mako agent` reusing the Phase 2 tool contract with a local executor), PATs with scopes, repo scaffold docs for third-party harnesses.
 5. **Phase 5 — Desktop local-first + extension slot + jobs.** Local-agent PTY/file capabilities; desktop-managed workspace checkout with local executor sessions (Mako chat with zero cloud sandbox); right-panel harness hosting (with `mako agent` as first-party occupant); `mako.json` scheduled jobs; bulk v1 migration + CDN runtime deprecation.
 
@@ -773,7 +773,7 @@ The substrate is largely built. The local developer surface is close to zero.
 | **Repo-resident agent instructions** (`CLAUDE.md`, `AGENTS.md`, `.mcp.json`)                                                                     | ❌ `api/src/apps-v2/scaffold.ts` writes only `package.json`, `mako.json`, `index.html`, `vite.config.ts`, `tsconfig.json`. A fresh clone tells `claude` nothing about Mako |
 | **Skills in the repo** (§10 Block D1)                                                                                                            | ❌ system skills live in the API image (`api/src/agent-skills/`)                                                                                                           |
 | **`mako` CLI / npm package**                                                                                                                     | ❌ does not exist. The `mako-agent` bin in `packages/local-agent` is the local-database daemon + ACP bridge — a different product                                          |
-| **App SDK for data access from a local checkout**                                                                                                | ❌ no `@mako/app-sdk` package exists, though §5 and §6 Phase 3 both assume one                                                                                             |
+| **App SDK for data access from a local checkout**                                                                                                | ❌ no `@makoai/app-sdk` package exists, though §5 and §6 Phase 3 both assume one                                                                                             |
 | Consoles in the repo (§10 Block D2)                                                                                                              | ❌ still Mongo `SavedConsole`                                                                                                                                              |
 | Per-session branch state (§10 Block C)                                                                                                           | ❌ not started                                                                                                                                                             |
 | **Human (builder) access to workspace repos**                                                                                                     | ❌ cloud repos are touched only by Mako's installation token — no human has any access. The builder tier of §11.5 is net-new: collaborator management or a git proxy, plus revocation wired to workspace membership |
@@ -807,7 +807,7 @@ Write `publishedSha`, build from it, serve it durably. Without this, §11.4 is
 aspirational and the monorepo model does not actually exist. PR preview deploys
 remain deferred.
 
-**Step 3 — minimal `@mako/cli`: `login` + `dev`.**
+**Step 3 — minimal `@makoai/cli`: `login` + `dev`.**
 Auth (device flow or pasted API key) and a dev server that proxies bindings and
 queries to the cloud execute API, so a local checkout renders with real data.
 This is what makes local editing _useful_ rather than merely possible. Not the
@@ -2203,7 +2203,7 @@ one-line by-hand path for older ones.
 A test pins a fingerprint of the managed
 content so changing it without bumping the version fails CI.
 
-**`@mako/app-sdk/vite`** — `makoData()`, a dependency-free Vite plugin in the
+**`@makoai/app-sdk/vite`** — `makoData()`, a dependency-free Vite plugin in the
 vendored package (`exports: { ".", "./vite" }`). During `vite dev` it answers
 `__data/index.json` from `bindings/*.sql` on disk and streams each binding's
 materialized artifact from `GET …/bindings/<name>/artifact`, materializing on
@@ -2282,7 +2282,7 @@ Three follow-ups from the review of the first pass, plus one correction.
 
 - **The refresh writes nothing under `apps/`.** See §15.2; the correction
   that keeps a template bump from fanning rebuilds out to prod.
-- **`@mako/app-sdk` is a real workspace package** (`packages/app-sdk`, plain
+- **`@makoai/app-sdk` is a real workspace package** (`packages/app-sdk`, plain
   ESM + `.d.ts`, `node --test`, publishable) instead of a 600-line template
   literal. `app-sdk-package.ts` vendors its files from disk — the API build
   copies them to `dist/app-sdk`, the same trick system skills use — so the
@@ -2290,12 +2290,12 @@ Three follow-ups from the review of the first pass, plus one correction.
   `pnpm publish` away once we own the `@mako` scope (nothing is under it
   today; `mako` and `mako-cli` unscoped are taken by strangers, and the
   Python SDK's `mako` collides with the Mako templating engine on PyPI).
-- **`mako login` / `mako dev`** (`packages/cli`, `@mako/cli`, dependency-free
+- **`mako login` / `mako dev`** (`packages/cli`, `@makoai/cli`, dependency-free
   beyond the SDK). `login` is the OAuth 2.1 sign-in every MCP client already
   performs against Mako — PKCE, loopback redirect (RFC 8252, which the
   authorization server already allowed), dynamic client registration —
   stored in `~/.mako/credentials.json` keyed by host and workspace, refreshed
-  on demand by the shared `@mako/app-sdk/credentials` module. The Vite plugin
+  on demand by the shared `@makoai/app-sdk/credentials` module. The Vite plugin
   reads it when there is no API key. So the template is now **OAuth-first**
   (v2): `.mcp.json` carries no `Authorization` header and the agent signs in
   through its own browser prompt; the API key path remains for CI. To make

--- a/docs/mako-apps-platform-prd.md
+++ b/docs/mako-apps-platform-prd.md
@@ -62,10 +62,10 @@ Almost everything needed already exists inside the product; what's missing is th
 | **Git → Mako sync precedent** | dbt: `IDbtRepoBinding` + GitHub App webhooks (`api/src/routes/github.routes.ts` → `dbt-ci.service.ts`) | ✅ Proven pattern, dbt-only |
 | **Public data serving for published apps** | `api/src/services/public-live-query.service.ts` (serves `app.published` snapshot bindings via share token) | ✅ Token-gated, read-only |
 | **MCP infrastructure** | `api/src/services/mcp-client.service.ts`, risk tiers (`read`/`write_safe`/`write_destructive`), tool restriction model | ✅ **Client only** — Mako does not expose an MCP *server* |
-| **App runtime** | `app/src/app-runtime/preview.ts` (esm.sh import map, sandboxed iframe, injected `@mako/app-sdk`: `useQuery`, `useDuckDB`, `useTheme`, `useLocation`, `navigate`) | ✅ But embedded in the frontend; `@mako/app-sdk` is a synthetic module, **not a real npm package** |
+| **App runtime** | `app/src/app-runtime/preview.ts` (esm.sh import map, sandboxed iframe, injected `@makoai/app-sdk`: `useQuery`, `useDuckDB`, `useTheme`, `useLocation`, `navigate`) | ✅ But embedded in the frontend; `@makoai/app-sdk` is a synthetic module, **not a real npm package** |
 | **Machine-readable API** | `GET /api/openapi.json`, Consoles API, `/api/workspaces/:id/execute` | ✅ |
 
-**Gaps** (the actual work): Mako-as-MCP-server, an on-disk repo format + CLI, a published `@mako/app-sdk` package, GitHub repo binding for apps, API-key scopes, and a standalone runtime + app-scoped data endpoint.
+**Gaps** (the actual work): Mako-as-MCP-server, an on-disk repo format + CLI, a published `@makoai/app-sdk` package, GitHub repo binding for apps, API-key scopes, and a standalone runtime + app-scoped data endpoint.
 
 ---
 
@@ -151,8 +151,8 @@ my-app/
 Key design points:
 
 - **Connection aliasing:** `dataBindings[].connectionId` is workspace-specific and must never be hardcoded in a repo. The manifest references connections by **alias** (e.g. `"warehouse"`); `mako push` / repo-binding sync resolves aliases → connection ids per workspace (interactive on first push, stored in `.mako/`). Same trick as the existing `{{ dbt_schema }}` token.
-- **Publish `@mako/app-sdk` as a real npm package:** types + a dev implementation of `useQuery`/`useDuckDB`/`useTheme`/`useLocation` that calls the Mako API with an API key. In-product, the injected synthetic module keeps winning (import-map override), so runtime behavior is unchanged; the package exists so repos type-check and run locally.
-- **`mako` CLI** (`packages/cli`, `npx @mako/cli`), auth via `MAKO_API_KEY` env or `mako login`:
+- **Publish `@makoai/app-sdk` as a real npm package:** types + a dev implementation of `useQuery`/`useDuckDB`/`useTheme`/`useLocation` that calls the Mako API with an API key. In-product, the injected synthetic module keeps winning (import-map override), so runtime behavior is unchanged; the package exists so repos type-check and run locally.
+- **`mako` CLI** (`packages/cli`, `npx @makoai/cli`), auth via `MAKO_API_KEY` env or `mako login`:
   - `mako init` — scaffold from `createAppScaffold` + CLAUDE.md + SDK types
   - `mako pull` / `mako push` — bidirectional sync between repo ⇄ app draft (REST, `apps:write`)
   - `mako dev` — local Vite dev server with the dev SDK hitting real bindings (`bindings:execute`)
@@ -213,8 +213,8 @@ Prerequisite for every other phase; nothing external ships until this lands.
 
 **Deliverables**
 - Repo format spec (`mako.app.json`, `src/`, `bindings/*`) + zod validation shared with the server; connection **aliases** resolved at push.
-- `@mako/app-sdk` on npm — types + dev implementation, **generated from the same source** as the synthetic module in `preview.ts` (single source of truth, see L19).
-- `@mako/cli`: `init`, `pull`, `push`, `dev`, `publish`, `check` (headless validation against the real cdn/import-map runtime), generated `CLAUDE.md`.
+- `@makoai/app-sdk` on npm — types + dev implementation, **generated from the same source** as the synthetic module in `preview.ts` (single source of truth, see L19).
+- `@makoai/cli`: `init`, `pull`, `push`, `dev`, `publish`, `check` (headless validation against the real cdn/import-map runtime), generated `CLAUDE.md`.
 
 **Exit criteria:** `pull → edit → push` round-trips losslessly; `mako dev` renders with real workspace data; `mako check` catches an esm.sh-incompatible import before push.
 
@@ -262,7 +262,7 @@ The developer keeps a Mako browser tab open next to the Claude Code terminal; Ma
 
 Everything Claude Code already does well — local files, local server, local browser — with real workspace data behind it.
 
-1. `mako init` (or `mako pull`) → repo with `CLAUDE.md`, typed `@mako/app-sdk`, binding files.
+1. `mako init` (or `mako pull`) → repo with `CLAUDE.md`, typed `@makoai/app-sdk`, binding files.
 2. `mako dev` → local Vite server on `localhost` with HMR. The dev SDK implements `useQuery` by executing the **local** binding code through the workspace API (requires `query:execute` scope on the dev key — bindings in the repo aren't on the server yet). Published/standalone apps never do this; only dev mode runs ad-hoc binding code.
 3. Claude Code edits `src/` and `bindings/` directly — errors appear in the Vite terminal output (which Claude Code reads natively), HMR refreshes instantly, and Claude Code can screenshot `localhost` with Playwright. No Mako-side round-trip per edit.
 4. `mako push` → syncs to the Mako draft to verify in the real (sandboxed, esm.sh) renderer — the fidelity check, since local Vite is a simulation of the cdn runtime.
@@ -330,7 +330,7 @@ Numbered so phases and reviews can reference them. **Bold** = changes the design
 
 - **L15 — Concurrent-edit clobbering.** An MCP agent and a human editing the same app race; today's server tools are effectively last-write-wins on the draft. *Mitigation:* optimistic concurrency — write tools take the expected `version` and fail with a fresh snapshot on mismatch (the `app.updated` version counter already exists to build on).
 - **L16 — Local dev ≠ cdn runtime.** Vite dev with node-resolved deps will happily run code the esm.sh import-map runtime rejects (or resolves differently). *Mitigation:* `mako check` validates against the real import-map resolution headlessly; `mako push` runs it automatically; treat the Mako draft preview as CI, not as the first time the real runtime sees the code.
-- **L17 — SDK/docs drift.** Three copies of truth threaten to diverge: the synthetic `@mako/app-sdk` module in `preview.ts`, the npm package, and the generated `CLAUDE.md` (distilled from `agent-skills/apps/SKILL.md`). *Mitigation:* generate the synthetic module and the npm package from one source; serve authoring guidance to external agents dynamically as an MCP resource instead of freezing it into scaffolds.
+- **L17 — SDK/docs drift.** Three copies of truth threaten to diverge: the synthetic `@makoai/app-sdk` module in `preview.ts`, the npm package, and the generated `CLAUDE.md` (distilled from `agent-skills/apps/SKILL.md`). *Mitigation:* generate the synthetic module and the npm package from one source; serve authoring guidance to external agents dynamically as an MCP resource instead of freezing it into scaffolds.
 - **L18 — Metering & billing.** Key-authenticated traffic (MCP tool calls, binding executions from standalone apps) bypasses today's in-product usage accounting; a popular standalone app is unmetered load. *Mitigation:* per-key usage log (Phase 0) feeds the existing `usage`/`billing` routes; publishable-key executions counted against the owning workspace with configurable caps.
 - **L19 — Version/publish semantics across three authoring paths.** In-product agent, MCP, and git sync all mutate the same draft; without a convention, `app_save_version` checkpoints and git history tell conflicting stories. *Mitigation:* record `origin` (`agent` / `mcp:<keyId>` / `git:<sha>`) on every version snapshot — cheap now, painful to retrofit.
 
@@ -344,12 +344,12 @@ Keep this list current: it is the hand-off.
 
 - Workspace repos carry a Mako-managed template: `AGENTS.md` (+ `CLAUDE.md`
   → `@AGENTS.md`), OAuth-first `.mcp.json`, `.envrc`, `.mako/workspace.json`,
-  vendored `@mako/app-sdk`. Refreshed monotonically, never touches `apps/`.
-- `@mako/app-sdk` is a real package (`packages/app-sdk`): hooks, `./vite`
+  vendored `@makoai/app-sdk`. Refreshed monotonically, never touches `apps/`.
+- `@makoai/app-sdk` is a real package (`packages/app-sdk`): hooks, `./vite`
   (`makoData()` — local `vite dev` gets real parquet from the API), and
   `./credentials` (`~/.mako/credentials.json`). SDK 2.2 decodes DATE →
   `YYYY-MM-DD`, TIMESTAMP → ISO, BigInt → Number.
-- `@mako/cli` (`packages/cli`): `mako login` (OAuth PKCE loopback against the
+- `@makoai/cli` (`packages/cli`): `mako login` (OAuth PKCE loopback against the
   MCP auth server), `mako dev [app]`, `whoami`, `logout`.
 - Auth: OAuth tokens and `query:read` keys may call the three read-only
   binding routes besides `/api/mcp` (`auth/scoped-key-routes.ts`).
@@ -368,8 +368,8 @@ Keep this list current: it is the hand-off.
       claim it. Fallback names if not: `@mako-ai/app-sdk`, `@mako-ai/cli`
       (update `packages/*/package.json`, `APP_SDK_DEPENDENCY`, AGENTS.md,
       docs). Unscoped `mako` / `mako-cli` are taken by strangers.
-- [ ] **Publish** `@mako/app-sdk` 2.2.0 and `@mako/cli` 0.1.0
-      (`pnpm --filter @mako/app-sdk publish`, then cli). Add a release
+- [ ] **Publish** `@makoai/app-sdk` 2.2.0 and `@makoai/cli` 0.1.0
+      (`pnpm --filter @makoai/app-sdk publish`, then cli). Add a release
       workflow so a version bump publishes from CI (`NPM_TOKEN` secret).
 - [ ] **Publish `mako-ai` to PyPI** (`packages/mako-sdk-py`; pyproject is
       ready; needs a PyPI token). Its suite has 4 PRE-EXISTING failures in

--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -35,7 +35,7 @@ SELECT category, amount, created_at FROM orders
 Queries execute server-side through Mako's scoped execute API — **the app code never sees credentials or connection strings**. The query is materialized into a Parquet artifact (same pipeline as dashboards); at runtime the preview serves each artifact at the app-relative URL `__data/<name>.parquet`, ready for hyparquet or DuckDB-WASM. In app code, read bindings through `@mako/app-sdk` — a real package committed into the workspace repo:
 
 ```tsx
-import { useQuery, useDuckDB } from "@mako/app-sdk";
+import { useQuery, useDuckDB } from "@makoai/app-sdk"; // apps created before 2026-09: "@mako/app-sdk" (older alias, same package)
 
 const { data, loading, error } = useQuery("recent_orders");
 
@@ -51,7 +51,7 @@ A binding can pin a workspace [dbt project](/transforms/) via `-- dbt_project: <
 Apps can keep view state — the active tab, applied filters, a selected record, a sub-page — in the URL, so a reload restores it and the link is shareable. Reach for the `@mako/app-sdk` hooks rather than `window.history` directly, and they work both embedded in Mako (`/a/:app`) and in the public share view (`/share/:token`):
 
 ```tsx
-import { useLocation, useSearchParams, navigate } from "@mako/app-sdk";
+import { useLocation, useSearchParams, navigate } from "@makoai/app-sdk";
 
 const loc = useLocation();
 const [params, setParams] = useSearchParams();

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -131,17 +131,17 @@ To keep agent context lean, agents can pass `includeScreenshot: false` to `app_b
 Every workspace repo carries a small template Mako keeps current: `AGENTS.md`
 (imported by `CLAUDE.md`) telling your agent what the repo is and how to work
 in it, `.mcp.json` wiring the `mako` MCP server, `.envrc` for direnv, and the
-vendored `@mako/app-sdk`. The whole setup, no key to paste:
+vendored `@makoai/app-sdk`. The whole setup, no key to paste:
 
 ```bash
 git clone <your workspace repo> && cd <repo>
 claude                 # the mako MCP server prompts a browser sign-in (read-only)
-npx @mako/cli login    # same sign-in for the app dev server, kept in ~/.mako/credentials.json
-npx @mako/cli dev <app>   # or: cd apps/<app> && npm install && npm run dev
+npx @makoai/cli login    # same sign-in for the app dev server, kept in ~/.mako/credentials.json
+npx @makoai/cli dev <app>   # or: cd apps/<app> && npm install && npm run dev
 ```
 
 The app renders with **real data**: the scaffold's `vite.config.ts` includes
-`makoData()` from `@mako/app-sdk/vite`, which serves `__data/<binding>.parquet`
+`makoData()` from `@makoai/app-sdk/vite`, which serves `__data/<binding>.parquet`
 by streaming the binding's materialized artifact from your Mako host with that
 login (a binding that was never materialized is built on first request;
 results are cached for five minutes under `node_modules/.mako-data/`,

--- a/packages/app-sdk/README.md
+++ b/packages/app-sdk/README.md
@@ -1,17 +1,17 @@
-# @mako/app-sdk
+# @makoai/app-sdk
 
 The runtime SDK for [Mako](https://mako.ai) data apps — React hooks over an
 app's data bindings, plus a Vite plugin that serves those bindings during a
 local `vite dev`.
 
 Every Mako workspace repository carries this package at `packages/app-sdk`;
-apps depend on it with `"@mako/app-sdk": "file:../../packages/app-sdk"`. Mako
+apps depend on it with `"@makoai/app-sdk": "file:../../packages/app-sdk"`. Mako
 keeps the vendored copy current — do not edit it in a workspace repo.
 
 ## In the app
 
 ```tsx
-import { useQuery, useDuckDB, useSearchParams, useTheme } from "@mako/app-sdk";
+import { useQuery, useDuckDB, useSearchParams, useTheme } from "@makoai/app-sdk";
 
 // Rows of bindings/<name>.sql, materialized to parquet by Mako.
 const { data, loading, error } = useQuery("latest_sales");
@@ -31,7 +31,7 @@ path in Mako's sandbox, in a published app, and on a laptop.
 ## In `vite.config.ts`
 
 ```ts
-import { makoData } from "@mako/app-sdk/vite";
+import { makoData } from "@makoai/app-sdk/vite";
 
 export default defineConfig({ plugins: [react(), makoData()] });
 ```

--- a/packages/app-sdk/credentials.js
+++ b/packages/app-sdk/credentials.js
@@ -1,4 +1,4 @@
-// @mako/app-sdk/credentials — the laptop credential store shared by the
+// @makoai/app-sdk/credentials — the laptop credential store shared by the
 // `mako` CLI (which writes it) and the Vite plugin (which reads it).
 //
 // `mako login` runs the same OAuth 2.1 sign-in Claude Code uses against the

--- a/packages/app-sdk/index.js
+++ b/packages/app-sdk/index.js
@@ -1,4 +1,4 @@
-// @mako/app-sdk — see package.json. Plain ESM on purpose: no build step.
+// @makoai/app-sdk — see package.json. Plain ESM on purpose: no build step.
 import * as React from "react";
 
 const DEFAULT_ROW_LIMIT = 500000;

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mako/app-sdk",
+  "name": "@makoai/app-sdk",
   "version": "2.2.0",
   "description": "Mako app SDK: data bindings (useQuery/useDuckDB), URL state, theme.",
   "license": "ISC",

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mako-ai/mako.git",
+    "url": "git+https://github.com/mako-ai/mako.git",
     "directory": "packages/app-sdk"
   },
   "homepage": "https://docs.mako.ai/mcp-server/",

--- a/packages/app-sdk/vite.js
+++ b/packages/app-sdk/vite.js
@@ -1,4 +1,4 @@
-// @mako/app-sdk/vite — data bindings for a LOCAL `vite dev`.
+// @makoai/app-sdk/vite — data bindings for a LOCAL `vite dev`.
 //
 // Inside Mako's sandbox the dev server is launched by Mako, which answers
 // `__data/<name>.parquet` itself. On a laptop nothing does, so Vite's SPA

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,10 +1,10 @@
-# @mako/cli
+# @makoai/cli
 
 Mako from your terminal. Two commands matter:
 
 ```bash
-npx @mako/cli login      # sign in once (browser, OAuth) — kept in ~/.mako/credentials.json
-npx @mako/cli dev <app>  # run apps/<app> locally with real workspace data
+npx @makoai/cli login      # sign in once (browser, OAuth) — kept in ~/.mako/credentials.json
+npx @makoai/cli dev <app>  # run apps/<app> locally with real workspace data
 ```
 
 Run inside a clone of your Mako workspace repository. `login` is the same
@@ -12,7 +12,7 @@ read-only OAuth sign-in every MCP client does against Mako (PKCE, loopback
 redirect, no key to paste); the credential is tied to the workspace of the
 checkout you ran it in and refreshed automatically. `dev` installs the app if
 needed and starts its Vite dev server; the app's `makoData()` plugin
-(`@mako/app-sdk/vite`) streams each binding's parquet from Mako using that
+(`@makoai/app-sdk/vite`) streams each binding's parquet from Mako using that
 login.
 
 Also: `mako whoami`, `mako logout`, `--api-url <host>` for self-hosted Mako
@@ -20,4 +20,4 @@ Also: `mako whoami`, `mako logout`, `--api-url <host>` for self-hosted Mako
 (`MAKO_API_KEY`) is used instead of the login when present — that is the path
 for CI.
 
-Node 20+. No dependencies beyond `@mako/app-sdk`.
+Node 20+. No dependencies beyond `@makoai/app-sdk`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,16 +5,24 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mako-ai/mako.git",
+    "url": "git+https://github.com/mako-ai/mako.git",
     "directory": "packages/cli"
   },
   "homepage": "https://docs.mako.ai/mcp-server/",
-  "keywords": ["mako", "cli", "data-apps"],
+  "keywords": [
+    "mako",
+    "cli",
+    "data-apps"
+  ],
   "type": "module",
   "bin": {
-    "mako": "./bin/mako.js"
+    "mako": "bin/mako.js"
   },
-  "files": ["bin", "src", "README.md"],
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
   "engines": {
     "node": ">=20"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mako/cli",
+  "name": "@makoai/cli",
   "version": "0.1.0",
   "description": "Mako from your terminal: sign in once (mako login), run a workspace app locally with real data (mako dev).",
   "license": "ISC",
@@ -19,7 +19,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@mako/app-sdk": "workspace:*"
+    "@makoai/app-sdk": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/context.js
+++ b/packages/cli/src/context.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveMakoContext } from "@mako/app-sdk/vite";
+import { resolveMakoContext } from "@makoai/app-sdk/vite";
 
 export const HOSTED_API_URL = "https://app.mako.ai";
 

--- a/packages/cli/src/dev.js
+++ b/packages/cli/src/dev.js
@@ -4,7 +4,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { findCredential } from "@mako/app-sdk/credentials";
+import { findCredential } from "@makoai/app-sdk/credentials";
 import { resolveAppDir } from "./context.js";
 
 function run(cmd, args, opts) {

--- a/packages/cli/src/login.js
+++ b/packages/cli/src/login.js
@@ -4,7 +4,7 @@
 // 127.0.0.1, dynamic client registration, no client secret.
 import crypto from "node:crypto";
 import http from "node:http";
-import { saveCredential, normalizeApiUrl } from "@mako/app-sdk/credentials";
+import { saveCredential, normalizeApiUrl } from "@makoai/app-sdk/credentials";
 import { openInBrowser } from "./browser.js";
 
 const CLIENT_NAME = "Mako CLI";

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -1,4 +1,4 @@
-import { findCredential, removeCredential } from "@mako/app-sdk/credentials";
+import { findCredential, removeCredential } from "@makoai/app-sdk/credentials";
 import { parseArgs } from "./args.js";
 import { loadContext } from "./context.js";
 import { login } from "./login.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,7 +627,7 @@ importers:
 
   packages/cli:
     dependencies:
-      '@mako/app-sdk':
+      '@makoai/app-sdk':
         specifier: workspace:*
         version: link:../app-sdk
 


### PR DESCRIPTION
- \`@mako\` / \`@mako-ai\` are squatted on npm; org **makoai** created. Packages renamed to \`@makoai/app-sdk\` (2.2.0) and \`@makoai/cli\` (0.1.0).
- Existing apps are untouched: their \`file:\` dependency key stays \`@mako/app-sdk\` and npm links the vendored folder under that key regardless of the package's own name (verified). New apps get \`@makoai/app-sdk\`; AGENTS.md / apps skill / docs explain the older alias.
- \`.github/workflows/publish-npm.yml\`: trusted publishing (OIDC + provenance) from \`app-sdk-vX.Y.Z\` / \`cli-vX.Y.Z\` tags; no long-lived npm token.
- Workspace template v4 (root files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171ohtXgzkZ6duCx9pVC6DK