### PR TITLE
test(hooks): run useDebouncedCallback tests under jsdom

### DIFF
--- a/app/src/hooks/useDebouncedCallback.test.ts
+++ b/app/src/hooks/useDebouncedCallback.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useDebouncedCallback } from "./useDebouncedCallback";


### PR DESCRIPTION
The new hook test used `renderHook` without a DOM environment and failed with `document is not defined` (I merged #857 without gating on it). Adds the `@vitest-environment jsdom` directive the other component tests use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5