### PR TITLE
feat(apps): History shows where "Live" is when the published sha is not in the app's history

### DIFF
--- a/app/src/components/AppHistoryPopover.tsx
+++ b/app/src/components/AppHistoryPopover.tsx
@@ -126,6 +126,11 @@ export default function AppHistoryPopover({
 
   const commits = history ?? [];
   const headOid = commits[0]?.oid;
+  // The published sha is often a repo-wide commit (a publish merges main),
+  // which does not touch this app's folder and so is absent from the
+  // app-scoped list. Say where "live" is rather than showing no chip at all.
+  const liveInHistory =
+    !!publishedSha && commits.some(c => c.oid === publishedSha);
 
   return (
     <>
@@ -177,6 +182,36 @@ export default function AppHistoryPopover({
           </Alert>
         )}
         <Box sx={{ overflowY: "auto", minHeight: 0 }}>
+          {publishedSha && history !== undefined && !liveInHistory && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 2,
+                py: 0.75,
+                borderBottom: 1,
+                borderColor: "divider",
+                bgcolor: "action.hover",
+              }}
+            >
+              <CommitChip
+                label="Live"
+                color="success"
+                icon={<LiveIcon size={12} />}
+              />
+              <Typography
+                variant="caption"
+                sx={{ fontFamily: "monospace", color: "text.secondary" }}
+              >
+                {publishedSha.slice(0, 7)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                — published from a repo-wide commit that did not change this
+                app&apos;s files
+              </Typography>
+            </Box>
+          )}
           {history !== undefined && commits.length === 0 && (
             <Typography
               variant="body2"


### PR DESCRIPTION
The published sha is usually a repo-wide publish commit that didn't touch the app's folder, so it's absent from the app-scoped history and no **Live** chip appeared (seen on CSM Activity). A header row now names the live sha and explains why it isn't in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SLEvhU3Sg45x3Pswv2RH5