### PR TITLE
chore(pypi): trusted-publishing workflow for mako-ai; fix sources test fake

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,63 @@
+# Publish the Python SDK (packages/mako-sdk-py → PyPI project `mako-ai`) with
+# TRUSTED PUBLISHING: PyPI trusts this repository + workflow + environment
+# through GitHub's OIDC token, so no API token exists anywhere.
+#
+# One-time setup on pypi.org → Account settings → Publishing → "Add a new
+# pending publisher": project mako-ai, owner mako-ai, repository mako,
+# workflow publish-pypi.yml, environment pypi. (A pending publisher lets the
+# very first release come from CI.)
+#
+# Trigger: push a tag `py-vX.Y.Z` matching pyproject.toml's version, or run
+# manually.
+name: Publish Python SDK
+
+on:
+  push:
+    tags:
+      - "py-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mako-sdk-py
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check the tag matches pyproject.toml
+        if: github.event_name == 'push'
+        run: |
+          v=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          [ "${GITHUB_REF_NAME}" = "py-v$v" ] || { echo "tag $GITHUB_REF_NAME != pyproject version $v"; exit 1; }
+      - name: Install (runtime deps + build tool)
+        run: python -m pip install --quiet build -e .
+      - name: Tests
+        run: python -m unittest discover -s tests
+      - name: Build sdist + wheel
+        run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/mako-sdk-py/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/packages/mako-sdk-py/tests/test_sources.py
+++ b/packages/mako-sdk-py/tests/test_sources.py
@@ -88,7 +88,9 @@ class SourcesTest(unittest.TestCase):
 class ReadTest(unittest.TestCase):
     def _handler_factory(self, read_response):
         def handler(method, url, body):
-            if url.endswith("/databases"):
+            # Source discovery moved from /databases to /notebook/sources; the
+            # fake answers both so the test pins the contract, not the path.
+            if url.endswith("/databases") or url.endswith("/notebook/sources"):
                 return _json_response(200, DATABASES)
             if url.endswith("/notebook/read"):
                 self.last_read_body = json.loads(body.decode("utf-8"))


### PR DESCRIPTION
- `.github/workflows/publish-pypi.yml`: on tag `py-vX.Y.Z` (must match pyproject version) → tests → build → publish to PyPI via OIDC trusted publishing (environment `pypi`, created). No token anywhere.
- `tests/test_sources.py`: the fake transport answered `/databases` but the SDK lists sources at `/notebook/sources` since the kernel-token change — 4 tests failed on master for that reason; now it answers both.

PyPI side (pending publisher for `mako-ai`) is being registered from the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171ohtXgzkZ6duCx9pVC6DK