### PR TITLE
feat(chat): close button in the chat pane header

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -25,6 +25,7 @@ import {
   History,
   Menu as MenuIcon,
   Plus,
+  X,
 } from "lucide-react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import { useChat } from "@ai-sdk/react";
@@ -1341,6 +1342,19 @@ const Chat: React.FC<ChatProps> = ({
                 <History size={20} />
               </IconButton>
             </Tooltip>
+            {/* Desktop only: on mobile the chat is a tab, not a pane. The
+                sidebar shows an "Open Chat" button while the pane is closed. */}
+            {!isMobile && (
+              <Tooltip title="Close chat">
+                <IconButton
+                  size="small"
+                  aria-label="Close chat"
+                  onClick={() => useUIStore.getState().closeRightPane()}
+                >
+                  <X size={20} />
+                </IconButton>
+              </Tooltip>
+            )}
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- Adds a **Close chat** (✕) button to the chat pane header, after the history button, wired to the existing `closeRightPane` store action.
- Desktop only — on mobile the chat is a tab, not a pane, so there is nothing to close.
- Drag-to-collapse on the divider already worked and is unchanged; both paths now flip the same `rightPaneOpen` flag, so the sidebar's "Open Chat" bubble reopens the pane at its remembered width either way.

## Test plan
- [x] `tsc --noEmit` + `eslint` on the app package pass
- [x] Browser: click ✕ → pane collapses to 0, sidebar shows "Open Chat"; click it → pane restored at previous width
- [x] Browser: drag the divider off the right edge → same collapse; reopen restores the pre-drag width (not the minimum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhELkwHEsP3xdexTYq67SB