### PR TITLE
feat(mcp): title annotation on every tool (directory listing requirement)

### DIFF
--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -336,8 +336,9 @@ export function toolTitle(name: string): string {
     .split("_")
     .filter(Boolean)
     .map((part, i) => {
-      if (TITLE_ACRONYMS.has(part))
+      if (TITLE_ACRONYMS.has(part)) {
         return part === "dbt" ? "dbt" : part.toUpperCase();
+      }
       return i === 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part;
     })
     .join(" ");

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -310,10 +310,37 @@ function toolAnnotations(
 ): Record<string, unknown> {
   const readOnly = mcpReadOnlyHint(name, queryAccess);
   return {
+    // Directories (Anthropic's in particular) require a human-readable title
+    // next to the hints; derive it from the name so it can never drift.
+    title: toolTitle(name),
     readOnlyHint: readOnly,
     destructiveHint: !readOnly && mcpDestructiveHint(name),
     openWorldHint: mcpOpenWorldHint(name),
   };
+}
+
+const TITLE_ACRONYMS = new Set([
+  "sql",
+  "dbt",
+  "mcp",
+  "api",
+  "url",
+  "id",
+  "csv",
+  "json",
+]);
+
+/** `app_list_apps` → "App list apps"; `dbt_run_model` → "dbt run model". */
+export function toolTitle(name: string): string {
+  return name
+    .split("_")
+    .filter(Boolean)
+    .map((part, i) => {
+      if (TITLE_ACRONYMS.has(part))
+        return part === "dbt" ? "dbt" : part.toUpperCase();
+      return i === 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part;
+    })
+    .join(" ");
 }
 
 function isZodSchema(value: unknown): value is z.ZodType {


### PR DESCRIPTION
Anthropic's Software Directory policy requires `readOnlyHint`, `destructiveHint` and `title` annotations; we emitted the hints but no title. Derived from the tool name (`app_list_apps` → "App list apps", `sql_execute_query` → "SQL execute query").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171ohtXgzkZ6duCx9pVC6DK