### PR TITLE
fix(migrations): v1 parquet purge records a backlog and never blocks the rip-out

### DIFF
--- a/api/src/apps/purge-v1-artifacts.cli.ts
+++ b/api/src/apps/purge-v1-artifacts.cli.ts
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+/**
+ * Sweep `v1_artifact_purge_backlog` (apps.md §17): delete the v1 binding
+ * parquet prefixes the rip-out migration recorded before dropping
+ * `makoapps`. Exists because the first prod run was denied
+ * storage.objects.list — run this with a credential that can list/delete on
+ * GCS_DASHBOARD_BUCKET.
+ *
+ *   GCS_DASHBOARD_BUCKET=<bucket> pnpm apps:purge-v1-artifacts [--execute]
+ */
+import path from "node:path";
+import { config as loadEnv } from "dotenv";
+loadEnv({ path: path.resolve(process.cwd(), ".env") });
+loadEnv({ path: path.resolve(process.cwd(), "..", ".env") });
+import { MongoClient } from "mongodb";
+import { Storage } from "@google-cloud/storage";
+
+async function main(): Promise<void> {
+  const execute = process.argv.includes("--execute");
+  const uri = process.env.DATABASE_URL;
+  const bucketName = process.env.GCS_DASHBOARD_BUCKET;
+  if (!uri) throw new Error("DATABASE_URL is not set");
+  if (!bucketName) throw new Error("GCS_DASHBOARD_BUCKET is not set");
+  const client = new MongoClient(uri);
+  await client.connect();
+  try {
+    const backlog = client.db().collection("v1_artifact_purge_backlog");
+    const entries = await backlog
+      .find({ purgedAt: { $exists: false } })
+      .toArray();
+    const prefixes = entries.flatMap(e => (e.prefixes as string[]) ?? []);
+    console.log(
+      `${entries.length} backlog entr${entries.length === 1 ? "y" : "ies"}, ${prefixes.length} prefixes`,
+    );
+    if (prefixes.length === 0) return;
+    const bucket = new Storage().bucket(bucketName);
+    let deleted = 0;
+    for (const p of prefixes) {
+      const [files] = await bucket.getFiles({ prefix: p });
+      if (files.length === 0) continue;
+      console.log(
+        `${execute ? "deleting" : "would delete"} ${files.length} object(s) under ${p}`,
+      );
+      if (execute) await bucket.deleteFiles({ prefix: p, force: true });
+      deleted += files.length;
+    }
+    console.log(
+      `${execute ? "deleted" : "would delete"} ${deleted} object(s) total`,
+    );
+    if (execute) {
+      await backlog.updateMany(
+        { purgedAt: { $exists: false } },
+        { $set: { purgedAt: new Date() } },
+      );
+    } else {
+      console.log("dry run — pass --execute to delete");
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().then(
+  // eslint-disable-next-line no-process-exit -- operator CLI, not server code
+  () => process.exit(0),
+  error => {
+    console.error(error instanceof Error ? error.message : error);
+    // eslint-disable-next-line no-process-exit -- operator CLI, not server code
+    process.exit(1);
+  },
+);

--- a/api/src/migrations/2026-08-31-180000_rip_out_v1_apps_and_mako_cloud.ts
+++ b/api/src/migrations/2026-08-31-180000_rip_out_v1_apps_and_mako_cloud.ts
@@ -16,6 +16,13 @@
  * DASHBOARD_ARTIFACT_PREFIX) and GCP credentials (the deploy job
  * authenticates before `pnpm run migrate`). Re-runnable: a second run finds
  * nothing to delete. Filesystem stores (dev) prune the same paths on disk.
+ *
+ * The doomed prefixes are persisted to `v1_artifact_purge_backlog` BEFORE
+ * anything is dropped, and the entry is marked purged only after the bucket
+ * delete succeeds. A denied bucket (the deployer SA lacked
+ * storage.objects.list on the first prod run) therefore cannot orphan the
+ * parquet untracked: the migration completes, and
+ * `pnpm apps:purge-v1-artifacts` sweeps the backlog once access exists.
  */
 import fs from "node:fs/promises";
 import { Db, ObjectId } from "mongodb";
@@ -43,12 +50,8 @@ const LEGACY_COLLECTIONS = [
 ];
 
 async function purgeArtifacts(
-  apps: Array<{ _id: ObjectId; workspaceId?: ObjectId }>,
+  prefixes: string[],
 ): Promise<{ prefixes: number; deleted: number; skipped: string | null }> {
-  const prefix = getArtifactPrefix();
-  const prefixes = apps
-    .filter(a => a.workspaceId)
-    .map(a => `${prefix}/workspaces/${a.workspaceId}/apps/${a._id}/`);
   if (prefixes.length === 0) return { prefixes: 0, deleted: 0, skipped: null };
 
   // A configured bucket wins over store-type detection: this runs on the
@@ -103,14 +106,36 @@ export async function up(db: Db): Promise<void> {
     ),
   );
 
-  // 1. Bucket first — it needs the app ids that step 2 drops.
+  // 1. Bucket first — it needs the app ids that step 2 drops. The prefix
+  // list is persisted before any attempt so a denied bucket loses nothing.
   if (collections.has("makoapps")) {
     const apps = (await db
       .collection("makoapps")
       .find({}, { projection: { _id: 1, workspaceId: 1 } })
       .toArray()) as Array<{ _id: ObjectId; workspaceId?: ObjectId }>;
-    const purge = await purgeArtifacts(apps);
-    log.info("v1 app artifacts purged", { apps: apps.length, ...purge });
+    const prefix = getArtifactPrefix();
+    const prefixes = apps
+      .filter(a => a.workspaceId)
+      .map(a => `${prefix}/workspaces/${a.workspaceId}/apps/${a._id}/`);
+    const backlog = db.collection("v1_artifact_purge_backlog");
+    if (prefixes.length > 0) {
+      await backlog.insertOne({ prefixes, createdAt: new Date() });
+    }
+    try {
+      const purge = await purgeArtifacts(prefixes);
+      log.info("v1 app artifacts purged", { apps: apps.length, ...purge });
+      if (!purge.skipped) {
+        await backlog.updateMany(
+          { purgedAt: { $exists: false } },
+          { $set: { purgedAt: new Date() } },
+        );
+      }
+    } catch (error) {
+      log.error(
+        "v1 artifact purge failed; prefixes are in v1_artifact_purge_backlog — run `pnpm apps:purge-v1-artifacts` once the credential can list the bucket",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    }
 
     // 2. The documents (and with them every v1 public link).
     await db.collection("makoapps").drop();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "sandbox:tunnel": "./scripts/sandbox-tunnel.sh",
     "consoles:migrate": "pnpm --filter api exec tsx src/apps/migrate-consoles.cli.ts",
     "artifacts:cors": "pnpm --filter api exec tsx src/services/artifact-bucket-cors.cli.ts",
+    "apps:purge-v1-artifacts": "pnpm --filter api exec tsx src/apps/purge-v1-artifacts.cli.ts",
     "dev:tunnel": "concurrently \"pnpm dev\" \"cloudflared tunnel --url http://localhost:5173 --no-tls-verify\"",
     "build": "pnpm run lint:fix:all && pnpm run build:ci",
     "build:ci": "pnpm --filter @mako/schemas run build && pnpm --filter @mako/agent-tools run build && pnpm run app:build && pnpm run api:build && node scripts/check-connector-agnosticism.js",


### PR DESCRIPTION
The first prod run failed at the bucket purge (deployer SA lacks `storage.objects.list`); the migration failed closed before dropping `makoapps`, so nothing was lost. This makes the purge fail-safe: prefixes persist to `v1_artifact_purge_backlog` before any drop, marked purged only on success; `pnpm apps:purge-v1-artifacts` sweeps the backlog once the credential can list the bucket. Alternatively grant the SA access and the next deploy purges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat