### PR TITLE
fix(apps): deploy-on-push builds the commit it deploys

### DIFF
--- a/api/src/apps/deploy-on-push.ts
+++ b/api/src/apps/deploy-on-push.ts
@@ -16,6 +16,7 @@ import { loggers } from "../logging";
 import { runGit } from "./git";
 import {
   PUBLISH_ACTOR,
+  checkoutInBox,
   ensureWorktree,
   execInWorktree,
   listAppFolders,
@@ -123,6 +124,14 @@ export async function deployOneApp(
     await setPublishedSha(project as IAppProject, sha);
     return { slug, sha, outcome: "already-built" };
   }
+  // Build THIS commit. The publish route pins the box the same way, and for
+  // the same reason: ensureBox catches a box up with a throttled pull
+  // (60s), so a push soon after another one rebuilt the PREVIOUS state and
+  // stored it under this sha — the app then served a build nobody made,
+  // while the UI reported the new commit as live. Observed on three
+  // consecutive pushes to one app, each deployment holding the content of
+  // the push before it.
+  await checkoutInBox(handle, sha);
   const build = await buildApp(handle, execInWorktree);
   if (!build.ok) throw new Error(build.output);
   await deployBuild(project as IAppProject, sha, handle);


### PR DESCRIPTION
## Why

A push to `main` deploys a build of the **previous** push. The live app then serves code that was never written at that sha, while the UI reports the new commit as published. Observed on three consecutive pushes to one app, each deployment holding the content of the push before it:

```
badge: published · fef8c90   →  served df8600d4's bundle
badge: published · cb989aa   →  served 0032a159's bundle (index-BX-GGT8a.js, 343,623 bytes)
```

Verified from the browser: the preview token pins `s = cb989aa3…`, and the asset it serves is the older build byte-for-byte — the new source strings are simply absent from it.

## What

`deployAppForSha` builds in the publish actor's box and never puts that box at the sha it is about to deploy:

```ts
const handle = await ensureWorktree(project, PUBLISH_ACTOR, { branch: … });
const build  = await buildApp(handle, execInWorktree);   // ← builds whatever is on disk
await deployBuild(project, sha, handle);                 // ← stored under `sha` regardless
```

`ensureBox` catches a box up with a **throttled** pull (`PULL_INTERVAL_MS`, 60s). That is right for an interactive session and wrong for a build: a push inside the window skips the pull entirely, `npm run build` compiles the previous checkout, and `deployBuild` stores it under the new sha.

It is then permanent for that sha: a later publish hits `deploymentExists(sha)` and short-circuits to `reused: true`, moving the pointer without rebuilding. The only escape is a new commit — which lands one behind again.

The fix is one line, and not a new idea. The publish route already does it (`apps.ts`, just before its `buildApp`), for exactly this reason:

```ts
await checkoutInBox(handle, sha);   // fetch the commit by sha, hard reset, clean
```

The webhook path just never did.

## Verified

`tsc -p tsconfig.build.json`, `eslint`, and the apps suite (9 files, 109 tests) all green.

Not reproducible in the suite: the throttle plus a real sandbox make this a timing property of the deployed service, which is why it survived — every green test builds a box that had just been hydrated.

Same serving path as #872 and #874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
