### PR TITLE
feat(skills): workspace skills live in the workspace repo; console snapshots retired

### DIFF
--- a/api/src/agent-lib/tools/skill-tools.ts
+++ b/api/src/agent-lib/tools/skill-tools.ts
@@ -141,7 +141,7 @@ export function createSkillTools(workspaceId: string, userId?: string) {
         "Delete a workspace skill by name. Use this to retract a skill that turned out to be wrong — without deletion, bad skills poison every future query. Deletion is permanent.",
       inputSchema: deleteSkillSchema,
       execute: async ({ name }) => {
-        return deleteSkill(workspaceId, name);
+        return deleteSkill(workspaceId, name, authorId);
       },
     }),
     list_skills: tool({

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -25,7 +25,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { runGit } from "./git";
 import { appsConnectedRepoPushEnv, appsRequireConnectedRepo } from "./config";
-import { DEFAULT_BRANCH, repoDirFor, repoExists } from "./repository.service";
+import {
+  DEFAULT_BRANCH,
+  initRepo,
+  repoDirFor,
+  repoExists,
+  type GitAuthor,
+} from "./repository.service";
+import { initialWorkspaceFiles } from "./workspace-template";
 import { loggers } from "../logging";
 
 const logger = loggers.api("apps");
@@ -466,4 +473,25 @@ export async function adoptConnectedRepo(
     return "seeded";
   }
   return "fresh";
+}
+
+/**
+ * The workspace repo, restored from its mirror or initialized with the
+ * starter template. Repos are provisioned lazily by whichever content type
+ * arrives first — app creation, console saves and skill writes all converge
+ * here (§10 monorepo).
+ */
+export async function ensureWorkspaceRepo(
+  workspaceId: string,
+  author?: GitAuthor,
+): Promise<string> {
+  await ensureLocalRepo(workspaceId);
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) {
+    await initRepo(repoDir, initialWorkspaceFiles(workspaceId), {
+      message: "Initialize workspace repository",
+      author,
+    });
+  }
+  return repoDir;
 }

--- a/api/src/apps/skill-files.ts
+++ b/api/src/apps/skill-files.ts
@@ -1,0 +1,133 @@
+/**
+ * Workspace skills as repo content (apps.md §10 Block D1).
+ *
+ * A workspace skill is `skills/<name>/SKILL.md` in the workspace repo — the
+ * same package shape as the git-versioned system skills under
+ * api/src/agent-skills/, so one format serves both kinds:
+ *
+ *   ---
+ *   name: mrr_walkthrough_fr
+ *   description: <the retrieval trigger — Mongo's `loadWhen`>
+ *   entities: [mrr, france]        # optional author-declared triggers
+ *   suppressed: true               # optional soft-disable, omitted when false
+ *   ---
+ *   <body — the playbook>
+ *
+ * The folder name is the identity (discovery = glob, like bindings/*.sql);
+ * the frontmatter `name` is carried for human readers and system-skill
+ * parity, but a mismatch resolves in the folder's favor.
+ *
+ * This module is pure format — serialize/parse only. Reading and writing the
+ * repo lives in workspace-skills.service.ts.
+ */
+import yaml from "js-yaml";
+
+export const SKILLS_DIR = "skills";
+export const SKILL_FILE_GLOB = `${SKILLS_DIR}/*/SKILL.md`;
+/**
+ * Marker that a workspace's skills have been adopted into git. While absent,
+ * Mongo rows may exist that git has never seen, so the push-driven index sync
+ * must not treat "not in git" as "deleted".
+ */
+export const SKILLS_README_PATH = `${SKILLS_DIR}/README.md`;
+
+export const SKILLS_README = `# Workspace skills
+
+Workspace-taught agent skills, one folder per skill (\`skills/<name>/SKILL.md\`).
+Managed by Mako: the agent's \`save_skill\` writes here, and anything committed
+here (from a clone, a terminal) is in the agent's retrieval index by its next
+turn.
+
+Format (same as Mako's system skills): YAML frontmatter with \`name\`,
+\`description\` (the retrieval trigger), optional \`entities\` and
+\`suppressed\`, then the playbook body. The folder name is the identity.
+`;
+
+/** Same contract as skills.service validation: lowercase snake_case. */
+export const SKILL_NAME_RE = /^[a-z0-9_]+$/;
+
+export interface WorkspaceSkillFile {
+  name: string;
+  /** The retrieval trigger — `description` in frontmatter, `loadWhen` in Mongo. */
+  loadWhen: string;
+  entities: string[];
+  suppressed: boolean;
+  body: string;
+}
+
+export function skillFilePath(name: string): string {
+  if (!SKILL_NAME_RE.test(name)) {
+    throw new Error(`Invalid skill name: ${JSON.stringify(name)}`);
+  }
+  return `${SKILLS_DIR}/${name}/SKILL.md`;
+}
+
+/** `skills/<name>/SKILL.md` → `<name>`, or null for any other path. */
+export function skillNameFromPath(path: string): string | null {
+  const m = /^skills\/([^/]+)\/SKILL\.md$/.exec(path);
+  if (!m || !SKILL_NAME_RE.test(m[1])) return null;
+  return m[1];
+}
+
+export function serializeSkillFile(skill: WorkspaceSkillFile): string {
+  const frontmatter: Record<string, unknown> = {
+    name: skill.name,
+    description: skill.loadWhen,
+  };
+  if (skill.entities.length > 0) frontmatter.entities = skill.entities;
+  if (skill.suppressed) frontmatter.suppressed = true;
+  const head = yaml.dump(frontmatter, { lineWidth: 100 }).trimEnd();
+  return `---\n${head}\n---\n\n${skill.body.trim()}\n`;
+}
+
+/**
+ * Parse a SKILL.md. `name` comes from the caller (the folder), which is
+ * authoritative; frontmatter `description` (alias: `loadWhen`) is required —
+ * a file without one returns null rather than entering the index with an
+ * empty trigger.
+ */
+export function parseSkillFile(
+  name: string,
+  content: string,
+): WorkspaceSkillFile | null {
+  const normalized = content.replace(/^\uFEFF/, "");
+  const match = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n?([\s\S]*)$/.exec(
+    normalized,
+  );
+  if (!match) return null;
+
+  let data: Record<string, unknown>;
+  try {
+    const parsed = yaml.load(match[1]);
+    if (!parsed || typeof parsed !== "object") return null;
+    data = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const loadWhen =
+    typeof data.description === "string"
+      ? data.description.trim()
+      : typeof data.loadWhen === "string"
+        ? data.loadWhen.trim()
+        : "";
+  if (!loadWhen) return null;
+
+  const entities = Array.isArray(data.entities)
+    ? data.entities
+        .filter((e): e is string => typeof e === "string")
+        .map(e => e.toLowerCase().trim())
+        .filter(e => e.length > 0)
+    : [];
+
+  const body = (match[2] ?? "").trim();
+  if (!body) return null;
+
+  return {
+    name,
+    loadWhen,
+    entities,
+    suppressed: data.suppressed === true,
+    body,
+  };
+}

--- a/api/src/apps/workspace-consoles.service.ts
+++ b/api/src/apps/workspace-consoles.service.ts
@@ -54,7 +54,7 @@ import {
   validateScheduledConsoleSchedule,
 } from "../services/scheduled-query-schedule.service";
 import {
-  ensureLocalRepo,
+  ensureWorkspaceRepo,
   mirrorPushNow,
   queueMirrorPush,
   resolveMirrorTarget,
@@ -78,7 +78,6 @@ import {
   blobOid,
   commitBlobsOnBranch,
   diffNameStatus,
-  initRepo,
   listTree,
   log as repoLog,
   readBlob,
@@ -92,7 +91,6 @@ import {
   type TreeEntry,
 } from "./repository.service";
 import { EMPTY_TREE } from "./git";
-import { initialWorkspaceFiles } from "./workspace-template";
 
 const logger = loggers.api("consoles-git");
 
@@ -337,14 +335,7 @@ function filesFor(
 
 /** The workspace bare repo, restored from its mirror or initialized. */
 export async function ensureConsolesRepo(workspaceId: string): Promise<string> {
-  await ensureLocalRepo(workspaceId);
-  const repoDir = repoDirFor(workspaceId);
-  if (!(await repoExists(repoDir))) {
-    await initRepo(repoDir, initialWorkspaceFiles(workspaceId), {
-      message: "Initialize workspace repository",
-    });
-  }
-  return repoDir;
+  return ensureWorkspaceRepo(workspaceId);
 }
 
 async function readAt(
@@ -1498,4 +1489,32 @@ export async function restoreConsoleTo(
   row.lastDraftOrigin = "user";
   await row.save();
   return { commitOid: committed.commitOid, unchanged: committed.unchanged };
+}
+
+/**
+ * The last explicitly saved state of a console — its file at HEAD. Git is
+ * the history now; snapshot rows are no longer written (§16.6).
+ */
+export async function savedConsoleStateFromRepo(
+  row: Pick<ISavedConsole, "workspaceId" | "path">,
+): Promise<{
+  code: string;
+  connectionId?: string;
+  databaseId?: string;
+  databaseName?: string;
+} | null> {
+  if (!row.path) return null;
+  const location = parseConsoleRepoPath(row.path);
+  if (!location) return null;
+  const repoDir = repoDirFor(row.workspaceId.toString());
+  if (!(await repoExists(repoDir))) return null;
+  const contents = await readAt(repoDir, row.path);
+  if (contents === null) return null;
+  const parsed = parseConsoleFile(contents, location.language);
+  return {
+    code: parsed.code,
+    connectionId: parsed.meta.connectionId,
+    databaseId: parsed.meta.databaseId,
+    databaseName: parsed.meta.databaseName,
+  };
 }

--- a/api/src/apps/workspace-skills.service.test.ts
+++ b/api/src/apps/workspace-skills.service.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Skills in git (apps.md §10 Block D1): real bare repos under a temp
+ * APPS_GIT_ROOT, mongodb-memory-server for the derived index, no network —
+ * the same rig the consoles suite uses.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { Skill } from "../database/workspace-schema";
+import {
+  SKILLS_README_PATH,
+  parseSkillFile,
+  serializeSkillFile,
+  skillFilePath,
+} from "./skill-files";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  log,
+  readBlob,
+  repoDirFor,
+  resolveCommit,
+} from "./repository.service";
+import {
+  adoptWorkspaceSkills,
+  commitSkillDelete,
+  commitSkillSave,
+  commitSkillSuppressed,
+  listSkillFilesFromRepo,
+  syncSkillsIndexFromRepo,
+} from "./workspace-skills.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "apps-skills-test-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SESSIONS_ROOT = path.join(tmpRoot, "sessions");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.AI_GATEWAY_API_KEY;
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+const WS = new Types.ObjectId().toString();
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+beforeEach(async () => {
+  await Skill.deleteMany({});
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+});
+
+async function fileAt(rel: string): Promise<string | null> {
+  try {
+    const blob = await readBlob(repoDirFor(WS), MAIN, rel);
+    return blob.isBinary ? null : blob.contents;
+  } catch {
+    return null;
+  }
+}
+
+const skill = (name: string, body = "Do the thing.") => ({
+  name,
+  loadWhen: `when asked about ${name}`,
+  entities: [name],
+  suppressed: false,
+  body,
+});
+
+describe("format round-trip", () => {
+  it("serializes and parses the SKILL.md package shape", () => {
+    const file = serializeSkillFile(skill("mrr_walkthrough"));
+    expect(file).toContain("description: when asked about mrr_walkthrough");
+    const parsed = parseSkillFile("mrr_walkthrough", file);
+    expect(parsed).toMatchObject({
+      name: "mrr_walkthrough",
+      loadWhen: "when asked about mrr_walkthrough",
+      entities: ["mrr_walkthrough"],
+      suppressed: false,
+      body: "Do the thing.",
+    });
+  });
+});
+
+describe("write-through", () => {
+  it("the first save adopts existing Mongo skills plus the marker", async () => {
+    await Skill.create({
+      workspaceId: new Types.ObjectId(WS),
+      name: "legacy_skill",
+      loadWhen: "legacy trigger",
+      body: "Old knowledge.",
+      entities: [],
+      scopeType: "workspace",
+      createdBy: "agent",
+      suppressed: false,
+      useCount: 3,
+    });
+    await commitSkillSave(WS, skill("fresh_skill"), {
+      loadAdoptable: async () => [
+        {
+          name: "legacy_skill",
+          loadWhen: "legacy trigger",
+          entities: [],
+          suppressed: false,
+          body: "Old knowledge.",
+        },
+      ],
+    });
+    expect(await fileAt(SKILLS_README_PATH)).not.toBeNull();
+    expect(await fileAt(skillFilePath("fresh_skill"))).toContain(
+      "Do the thing.",
+    );
+    expect(await fileAt(skillFilePath("legacy_skill"))).toContain(
+      "Old knowledge.",
+    );
+  });
+
+  it("delete and suppress commit; a Mongo-only skill is a git no-op", async () => {
+    await commitSkillSave(WS, skill("keeper"));
+    expect(await commitSkillSuppressed(WS, "keeper", true)).toBe(true);
+    expect(await fileAt(skillFilePath("keeper"))).toContain("suppressed: true");
+    expect(await commitSkillDelete(WS, "keeper")).toBe(true);
+    expect(await fileAt(skillFilePath("keeper"))).toBeNull();
+    expect(await commitSkillDelete(WS, "never_committed")).toBe(false);
+  });
+});
+
+describe("sync from repo", () => {
+  it("an external skill edit reaches the index; removal deletes the row", async () => {
+    await commitSkillSave(WS, skill("synced"));
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    let row = await Skill.findOne({ name: "synced" });
+    expect(row?.body).toBe("Do the thing.");
+
+    // Laptop edit: change the body, keep telemetry.
+    await Skill.updateOne({ _id: row!._id }, { $set: { useCount: 9 } });
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      {
+        writes: {
+          [skillFilePath("synced")]: serializeSkillFile(
+            skill("synced", "Do the BETTER thing."),
+          ),
+        },
+      },
+      { message: "laptop edit" },
+    );
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    row = await Skill.findOne({ name: "synced" });
+    expect(row?.body).toBe("Do the BETTER thing.");
+    expect(row?.previousBody).toBe("Do the thing.");
+    expect(row?.useCount).toBe(9);
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { deletes: [skillFilePath("synced")] },
+      { message: "laptop delete" },
+    );
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    expect(await Skill.findOne({ name: "synced" })).toBeNull();
+  });
+
+  it("never touches a workspace that has not adopted", async () => {
+    await Skill.create({
+      workspaceId: new Types.ObjectId(WS),
+      name: "mongo_only",
+      loadWhen: "trigger",
+      body: "body",
+      entities: [],
+      scopeType: "workspace",
+      createdBy: "agent",
+      suppressed: false,
+      useCount: 0,
+    });
+    const { initRepo } = await import("./repository.service");
+    await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+    await syncSkillsIndexFromRepo(WS);
+    expect(await Skill.findOne({ name: "mongo_only" })).not.toBeNull();
+  });
+});
+
+describe("adoption (migration path)", () => {
+  it("writes missing files + marker once, is re-runnable", async () => {
+    for (const name of ["a_skill", "b_skill"]) {
+      await Skill.create({
+        workspaceId: new Types.ObjectId(WS),
+        name,
+        loadWhen: `use ${name}`,
+        body: `${name} body`,
+        entities: [],
+        scopeType: "workspace",
+        createdBy: "agent",
+        suppressed: false,
+        useCount: 0,
+      });
+    }
+    const first = await adoptWorkspaceSkills(WS);
+    expect(first).toMatchObject({ skills: 2, written: 3, adopted: true });
+    expect((await listSkillFilesFromRepo(WS)).map(f => f.name).sort()).toEqual([
+      "a_skill",
+      "b_skill",
+    ]);
+    const head = await resolveCommit(repoDirFor(WS), MAIN);
+    const again = await adoptWorkspaceSkills(WS);
+    expect(again.written).toBe(0);
+    expect(await resolveCommit(repoDirFor(WS), MAIN)).toBe(head);
+    expect((await log(repoDirFor(WS), MAIN, 5))[0].subject).toContain(
+      "Adopt workspace skills",
+    );
+  });
+});

--- a/api/src/apps/workspace-skills.service.ts
+++ b/api/src/apps/workspace-skills.service.ts
@@ -1,0 +1,404 @@
+/**
+ * Workspace skills in the workspace repo — git is the source of truth,
+ * Mongo's `skills` collection is the DERIVED retrieval index (embeddings,
+ * $text, useCount telemetry), the same doctrine consoles follow (apps.md
+ * §10 Block D1, §16).
+ *
+ * Adoption: workspaces predate this layout, so `skills/README.md` on main is
+ * the marker that git owns skills. Until it exists, Mongo may hold skills
+ * git has never seen — the first skill save on a pre-existing workspace
+ * adopts them all in one commit, and the sync never deletes index rows for
+ * a repo that has not adopted. The workspace_skills_to_git migration
+ * performs the same adoption for every workspace that already has a repo.
+ *
+ * Must not import worktree.service (it imports this module for the push
+ * hook).
+ */
+import { Types } from "mongoose";
+import { Skill, type ISkill } from "../database/workspace-schema";
+import {
+  embedText,
+  getEmbeddingModelName,
+  isEmbeddingAvailable,
+} from "../services/embedding.service";
+import { extractEntities } from "../agent-lib/entity-extraction";
+import { loggers } from "../logging";
+import {
+  ensureWorkspaceRepo,
+  queueMirrorPush,
+  resolveMirrorTarget,
+} from "./cloud-repo.service";
+import { RepoRequiredError, appsRequireConnectedRepo } from "./config";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  globTree,
+  listTree,
+  readBlob,
+  repoDirFor,
+  repoExists,
+  resolveCommit,
+  type GitAuthor,
+} from "./repository.service";
+import {
+  SKILLS_README,
+  SKILLS_README_PATH,
+  SKILL_FILE_GLOB,
+  SKILL_NAME_RE,
+  parseSkillFile,
+  serializeSkillFile,
+  skillFilePath,
+  skillNameFromPath,
+  type WorkspaceSkillFile,
+} from "./skill-files";
+
+const logger = loggers.api("skills-git");
+
+/** Mirrors skills.service's MAX_SKILLS_PER_WORKSPACE — bounds the index. */
+const MAX_SYNCED_SKILLS = 200;
+
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+async function readRepoFile(
+  repoDir: string,
+  relPath: string,
+): Promise<string | null> {
+  try {
+    const blob = await readBlob(repoDir, MAIN, relPath);
+    return blob.isBinary ? null : blob.contents;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether this repo's skills folder has been adopted (see module doc). */
+export async function skillsAdopted(repoDir: string): Promise<boolean> {
+  return (await readRepoFile(repoDir, SKILLS_README_PATH)) !== null;
+}
+
+/** Every parseable skill file on main. Missing repo/branch → empty. */
+export async function listSkillFilesFromRepo(
+  workspaceId: string,
+): Promise<WorkspaceSkillFile[]> {
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return [];
+  if (!(await resolveCommit(repoDir, MAIN))) return [];
+  const paths = await globTree(repoDir, MAIN, SKILL_FILE_GLOB, 1000);
+  const out: WorkspaceSkillFile[] = [];
+  for (const path of paths.sort()) {
+    const name = skillNameFromPath(path);
+    if (!name) {
+      logger.warn("Skipping skill file with invalid name", {
+        workspaceId,
+        path,
+      });
+      continue;
+    }
+    const raw = await readRepoFile(repoDir, path);
+    const parsed = raw === null ? null : parseSkillFile(name, raw);
+    if (!parsed) {
+      logger.warn("Skipping unparseable skill file", { workspaceId, path });
+      continue;
+    }
+    out.push(parsed);
+  }
+  return out;
+}
+
+/** Production gate (apps.md §17): no connected repo, no durable skill save. */
+async function assertDurableWritable(workspaceId: string): Promise<void> {
+  if (appsRequireConnectedRepo() && !(await resolveMirrorTarget(workspaceId))) {
+    throw new RepoRequiredError();
+  }
+}
+
+/**
+ * Commit one skill save onto main. On a repo that has not adopted yet, the
+ * same commit adopts: the caller's snapshot of the workspace's Mongo skills
+ * (`loadAdoptable`, called lazily — only that first commit needs the bodies)
+ * and the `skills/README.md` marker ride along, so no Mongo-only skill can
+ * be orphaned by the sync afterwards.
+ */
+export async function commitSkillSave(
+  workspaceId: string,
+  skill: WorkspaceSkillFile,
+  options: {
+    author?: GitAuthor;
+    loadAdoptable?: () => Promise<WorkspaceSkillFile[]>;
+  } = {},
+): Promise<void> {
+  await assertDurableWritable(workspaceId);
+  const repoDir = await ensureWorkspaceRepo(workspaceId, options.author);
+  const writes: Record<string, string> = {};
+  let message = `Save skill "${skill.name}"`;
+  if (!(await skillsAdopted(repoDir))) {
+    writes[SKILLS_README_PATH] = SKILLS_README;
+    for (const existing of (await options.loadAdoptable?.()) ?? []) {
+      if (existing.name === skill.name) continue;
+      const path = skillFilePath(existing.name);
+      if ((await readRepoFile(repoDir, path)) === null) {
+        writes[path] = serializeSkillFile(existing);
+      }
+    }
+    message = `Adopt workspace skills into git; save skill "${skill.name}"`;
+  }
+  writes[skillFilePath(skill.name)] = serializeSkillFile(skill);
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    { writes },
+    { message, author: options.author },
+  );
+  queueMirrorPush(workspaceId);
+}
+
+/** Every path under a skill's folder (a laptop may have added extras). */
+async function skillFolderPaths(
+  repoDir: string,
+  name: string,
+): Promise<string[]> {
+  const head = await resolveCommit(repoDir, MAIN);
+  if (!head) return [];
+  const prefix = `skills/${name}/`;
+  return (await listTree(repoDir, head))
+    .map(e => e.path)
+    .filter(p => p.startsWith(prefix));
+}
+
+/**
+ * Commit a skill deletion. No-op (returns false) when the repo or the file
+ * does not exist — a Mongo-only skill on an unadopted workspace has nothing
+ * to delete in git.
+ */
+export async function commitSkillDelete(
+  workspaceId: string,
+  name: string,
+  author?: GitAuthor,
+): Promise<boolean> {
+  if (!SKILL_NAME_RE.test(name)) return false;
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return false;
+  const deletes = await skillFolderPaths(repoDir, name);
+  if (deletes.length === 0) return false;
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    { deletes },
+    { message: `Delete skill "${name}"`, author },
+  );
+  queueMirrorPush(workspaceId);
+  return true;
+}
+
+/**
+ * Commit a suppressed-flag flip by rewriting the file's frontmatter. No-op
+ * when the file is not in git yet (unadopted workspace).
+ */
+export async function commitSkillSuppressed(
+  workspaceId: string,
+  name: string,
+  suppressed: boolean,
+  author?: GitAuthor,
+): Promise<boolean> {
+  if (!SKILL_NAME_RE.test(name)) return false;
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return false;
+  const path = skillFilePath(name);
+  const raw = await readRepoFile(repoDir, path);
+  const parsed = raw === null ? null : parseSkillFile(name, raw);
+  if (!parsed) return false;
+  if (parsed.suppressed === suppressed) return true;
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    { writes: { [path]: serializeSkillFile({ ...parsed, suppressed }) } },
+    {
+      message: `${suppressed ? "Suppress" : "Unsuppress"} skill "${name}"`,
+      author,
+    },
+  );
+  queueMirrorPush(workspaceId);
+  return true;
+}
+
+function sameEntities(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const bs = new Set(b);
+  return a.every(e => bs.has(e));
+}
+
+/** Declared (file) entities ∪ extracted — same union saveSkill computes. */
+function indexEntities(skill: WorkspaceSkillFile): string[] {
+  const extracted = extractEntities(`${skill.loadWhen}\n${skill.body}`);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of [...skill.entities, ...extracted]) {
+    const norm = raw.toLowerCase().trim();
+    if (norm.length < 2 || seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+  }
+  return out;
+}
+
+async function embeddingFor(
+  loadWhen: string,
+): Promise<{ embedding?: number[]; model?: string }> {
+  if (!isEmbeddingAvailable()) return {};
+  try {
+    const embedding = await embedText(loadWhen);
+    if (!embedding) return {};
+    return { embedding, model: getEmbeddingModelName() ?? undefined };
+  } catch (error) {
+    logger.warn("Skill embedding failed during index sync", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {};
+  }
+}
+
+/**
+ * Reconcile the Mongo retrieval index with the repo's skills/ folder —
+ * called after every push to the git endpoint (worktree.service
+ * notifyRepoPushed) so a skill edited in a terminal or a laptop clone is in
+ * the agent's index by its next turn.
+ *
+ * Deliberately conservative: it never touches an unadopted repo (Mongo may
+ * hold skills git has never seen), it preserves telemetry (useCount,
+ * lastUsedAt) and createdBy on update, and it re-embeds only when the
+ * trigger text actually changed.
+ */
+export async function syncSkillsIndexFromRepo(
+  workspaceId: string,
+  userId?: string,
+): Promise<void> {
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return;
+  if (!(await skillsAdopted(repoDir))) return;
+
+  let files = await listSkillFilesFromRepo(workspaceId);
+  if (files.length > MAX_SYNCED_SKILLS) {
+    logger.warn(
+      "Workspace has more skill files than the index cap; truncating",
+      {
+        workspaceId,
+        fileCount: files.length,
+        cap: MAX_SYNCED_SKILLS,
+      },
+    );
+    files = files.slice(0, MAX_SYNCED_SKILLS);
+  }
+
+  const wsObjectId = new Types.ObjectId(workspaceId);
+  const rows = (await Skill.find({ workspaceId: wsObjectId })) as ISkill[];
+  const rowByName = new Map(rows.map(r => [r.name, r]));
+  const fileNames = new Set(files.map(f => f.name));
+
+  for (const file of files) {
+    const entities = indexEntities(file);
+    const row = rowByName.get(file.name);
+    if (!row) {
+      const { embedding, model } = await embeddingFor(file.loadWhen);
+      await Skill.create({
+        workspaceId: wsObjectId,
+        name: file.name,
+        loadWhen: file.loadWhen,
+        body: file.body,
+        entities,
+        loadWhenEmbedding: embedding,
+        embeddingModel: model,
+        scopeType: "workspace",
+        createdBy: userId && userId.length > 0 ? userId : "agent",
+        suppressed: file.suppressed,
+        useCount: 0,
+      });
+      continue;
+    }
+    const unchanged =
+      row.loadWhen === file.loadWhen &&
+      row.body === file.body &&
+      row.suppressed === file.suppressed &&
+      sameEntities(row.entities ?? [], entities);
+    if (unchanged) continue;
+    if (row.body !== file.body) {
+      row.previousBody = row.body;
+      row.previousUpdatedAt = row.updatedAt;
+    }
+    if (row.loadWhen !== file.loadWhen) {
+      const { embedding, model } = await embeddingFor(file.loadWhen);
+      if (embedding) {
+        row.loadWhenEmbedding = embedding;
+        row.embeddingModel = model;
+      }
+    }
+    row.loadWhen = file.loadWhen;
+    row.body = file.body;
+    row.entities = entities;
+    row.suppressed = file.suppressed;
+    await row.save();
+  }
+
+  const stale = rows.filter(r => !fileNames.has(r.name));
+  if (stale.length > 0) {
+    await Skill.deleteMany({
+      workspaceId: wsObjectId,
+      _id: { $in: stale.map(r => r._id) },
+    });
+  }
+}
+
+/**
+ * Adopt a workspace's Mongo skills into its repo: write every skill file
+ * that is missing plus the `skills/README.md` marker, in one commit. Used
+ * by the workspace_skills_to_git migration (repos that already exist) —
+ * the first skill save adopts lazily everywhere else. Re-runnable.
+ */
+export async function adoptWorkspaceSkills(workspaceId: string): Promise<{
+  workspaceId: string;
+  skills: number;
+  written: number;
+  adopted: boolean;
+}> {
+  const rows = (await Skill.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select("name loadWhen body entities suppressed")
+    .lean()) as Array<
+    Pick<ISkill, "name" | "loadWhen" | "body" | "entities" | "suppressed">
+  >;
+  const repoDir = await ensureWorkspaceRepo(workspaceId);
+  const alreadyAdopted = await skillsAdopted(repoDir);
+  const writes: Record<string, string> = {};
+  for (const row of rows) {
+    if (!SKILL_NAME_RE.test(row.name)) {
+      logger.warn("Skipping skill with a name git cannot hold", {
+        workspaceId,
+        name: row.name,
+      });
+      continue;
+    }
+    const path = skillFilePath(row.name);
+    if ((await readRepoFile(repoDir, path)) !== null) continue;
+    writes[path] = serializeSkillFile({
+      name: row.name,
+      loadWhen: row.loadWhen,
+      entities: row.entities ?? [],
+      suppressed: !!row.suppressed,
+      body: row.body,
+    });
+  }
+  if (!alreadyAdopted) writes[SKILLS_README_PATH] = SKILLS_README;
+  const written = Object.keys(writes).length;
+  if (written > 0) {
+    await commitBlobsOnBranch(
+      repoDir,
+      DEFAULT_BRANCH,
+      { writes },
+      {
+        message: `Adopt workspace skills into git (${rows.length} skill${rows.length === 1 ? "" : "s"})`,
+      },
+    );
+    queueMirrorPush(workspaceId);
+  }
+  return { workspaceId, skills: rows.length, written, adopted: true };
+}

--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 6, fingerprint: "73f6f03ba5ae958b" };
+const PINNED = { version: 7, fingerprint: "72a17f59c954e646" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.ts
+++ b/api/src/apps/workspace-template.ts
@@ -31,7 +31,7 @@ import { fetchFromCloud, queueMirrorPush } from "./cloud-repo.service";
 
 const logger = loggers.app();
 
-export const WORKSPACE_TEMPLATE_VERSION = 6;
+export const WORKSPACE_TEMPLATE_VERSION = 7;
 
 /** Where `.mcp.json` points when MAKO_API_URL is not exported. */
 export const HOSTED_MAKO_URL = "https://app.mako.ai";
@@ -62,6 +62,9 @@ of the workspace. **\`main\` is production** — a commit on \`main\` deploys.
   for the other languages); \`users/<userId>/consoles/…\` are private ones.
   Leading \`-- key: value\` lines are metadata (\`connection\`, \`database\`,
   \`description\`, \`schedule\`); a commit here shows up in the app on push.
+- \`skills/<name>/SKILL.md\` — workspace-taught agent skills (YAML
+  frontmatter: \`description\` is the retrieval trigger; then the playbook).
+  A commit here is in the agent's retrieval index by its next turn.
 - \`.mako/workspace.json\` — workspace id + template version (managed).
 - \`.mcp.json\` — the \`mako\` MCP server for your agent (managed).
 

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -98,6 +98,7 @@ import {
 } from "./repository.service";
 import { initialWorkspaceFiles } from "./workspace-template";
 import { syncConsolesIndexFromRepo } from "./workspace-consoles.service";
+import { syncSkillsIndexFromRepo } from "./workspace-skills.service";
 import { createAppsScaffold } from "./scaffold";
 import {
   ensureCommitLocally,
@@ -176,6 +177,13 @@ export function notifyRepoPushed(workspaceId: string, userId: string): void {
   // agent's search) by the next turn (apps.md §16.3).
   void syncConsolesIndexFromRepo(workspaceId, userId).catch(error => {
     logger.warn("Console index sync after push failed", {
+      workspaceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  // Same doctrine for skills/ (apps.md §10 Block D1).
+  void syncSkillsIndexFromRepo(workspaceId, userId).catch(error => {
+    logger.warn("Skills index sync after push failed", {
       workspaceId,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/api/src/migrations/2026-08-31-190000_workspace_skills_to_git.ts
+++ b/api/src/migrations/2026-08-31-190000_workspace_skills_to_git.ts
@@ -1,0 +1,69 @@
+/**
+ * Workspace skills into the workspace repo (apps.md §10 Block D1).
+ *
+ * For every workspace that has skills AND already has a repo — a local bare
+ * repo or a connected mirror — write each Mongo skill as
+ * `skills/<name>/SKILL.md` (only missing files) plus the `skills/README.md`
+ * adoption marker, in one commit, and push the mirror. Mongo rows stay as
+ * the derived retrieval index (embeddings, $text, useCount); the push-driven
+ * sync keeps them level from here on.
+ *
+ * Workspaces without a repo are left alone (no Mako-hosted tier, apps.md
+ * §17): their first skill save adopts lazily after they connect GitHub.
+ * Re-runnable: only missing paths are written.
+ */
+import { Db } from "mongodb";
+import mongoose from "mongoose";
+import { loggers } from "../logging";
+import { adoptWorkspaceSkills } from "../apps/workspace-skills.service";
+import { resolveMirrorTarget } from "../apps/cloud-repo.service";
+import { repoDirFor, repoExists } from "../apps/repository.service";
+
+const log = loggers.migration();
+
+export const description =
+  "Adopt workspace skills into each workspace repo (skills/<name>/SKILL.md; Mongo stays the derived retrieval index)";
+
+export async function up(db: Db): Promise<void> {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      (db as unknown as { client: { s: { url: string } } }).client.s.url,
+      { dbName: db.databaseName },
+    );
+  }
+  const workspaceIds = (await db
+    .collection("skills")
+    .distinct("workspaceId")) as Array<{ toString(): string }>;
+
+  let adopted = 0;
+  let skippedNoRepo = 0;
+  let failed = 0;
+  for (const raw of workspaceIds) {
+    const workspaceId = raw.toString();
+    try {
+      const hasLocal = await repoExists(repoDirFor(workspaceId));
+      const hasMirror = hasLocal
+        ? true
+        : Boolean(await resolveMirrorTarget(workspaceId).catch(() => null));
+      if (!hasLocal && !hasMirror) {
+        skippedNoRepo++;
+        continue;
+      }
+      const report = await adoptWorkspaceSkills(workspaceId);
+      adopted++;
+      log.info("Skills adopted", { ...report });
+    } catch (error) {
+      failed++;
+      log.error("Skills adoption failed for workspace", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  log.info("workspace_skills_to_git done", {
+    workspaces: workspaceIds.length,
+    adopted,
+    skippedNoRepo,
+    failed,
+  });
+}

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -12,7 +12,6 @@ import {
   SavedConsole,
   ConsoleFolder,
   IDatabaseConnection,
-  EntityVersion,
   type ISavedConsole,
   ScheduledQueryRun,
 } from "../database/workspace-schema";
@@ -35,12 +34,6 @@ import {
   checkPreviewQuerySafety,
 } from "../services/query-pagination.service";
 import { createStreamingExportResponse } from "../utils/query-export-stream";
-import {
-  createVersion,
-  listVersions,
-  getVersion,
-  getUserDisplayName,
-} from "../services/entity-version.service";
 import { inngest } from "../inngest";
 import { requireWorkspaceAdmin } from "../middleware/workspace-admin.middleware";
 import {
@@ -53,6 +46,7 @@ import { RepoRequiredError } from "../apps/config";
 import {
   commitConsoleState,
   consoleCommitChanges,
+  savedConsoleStateFromRepo,
   consoleFileVersions,
   consoleHistory,
   projectSavedConsole,
@@ -85,23 +79,6 @@ function repoRequired(c: Context, error: RepoRequiredError) {
   );
 }
 
-function buildConsoleSnapshot(doc: ISavedConsole): Record<string, unknown> {
-  return {
-    name: doc.name,
-    description: doc.description,
-    code: doc.code,
-    language: doc.language,
-    connectionId: doc.connectionId?.toString(),
-    databaseName: doc.databaseName,
-    databaseId: doc.databaseId,
-    chartSpec: doc.chartSpec,
-    resultsViewMode: doc.resultsViewMode,
-    mongoOptions: doc.mongoOptions,
-    folderId: doc.folderId?.toString(),
-    access: doc.access,
-  };
-}
-
 // IMPORTANT: this MUST stay byte-for-byte compatible with the client hash so
 // the server-computed baseline equals what the client would compute for the
 // same snapshot. Mirror of `hashContent` in `app/src/utils/hash.ts` and
@@ -132,35 +109,20 @@ function computeConsoleStateHash(
   );
 }
 
-function computeConsoleStateHashFromSnapshot(
-  snapshot: Record<string, unknown> | undefined,
-): string | undefined {
-  if (!snapshot || typeof snapshot.code !== "string") return undefined;
-  return computeConsoleStateHash(
-    snapshot.code,
-    typeof snapshot.connectionId === "string"
-      ? snapshot.connectionId
-      : undefined,
-    typeof snapshot.databaseId === "string" ? snapshot.databaseId : undefined,
-    typeof snapshot.databaseName === "string"
-      ? snapshot.databaseName
-      : undefined,
-  );
-}
-
+/**
+ * Hash of the last explicitly saved state — read from the console's file at
+ * HEAD (git is the history; snapshot rows are no longer written).
+ */
 async function getLatestConsoleSavedStateHash(
-  entityId: Types.ObjectId,
-  workspaceId: Types.ObjectId,
+  row: Pick<ISavedConsole, "workspaceId" | "path">,
 ): Promise<string | undefined> {
-  const latestVersion = await EntityVersion.findOne(
-    { entityId, entityType: "console", workspaceId },
-    { snapshot: 1 },
-  )
-    .sort({ version: -1 })
-    .lean();
-
-  return computeConsoleStateHashFromSnapshot(
-    latestVersion?.snapshot as Record<string, unknown> | undefined,
+  const saved = await savedConsoleStateFromRepo(row);
+  if (!saved) return undefined;
+  return computeConsoleStateHash(
+    saved.code,
+    saved.connectionId,
+    saved.databaseId,
+    saved.databaseName,
   );
 }
 
@@ -386,10 +348,7 @@ consoleRoutes.openapi(
 
       const savedStateHash =
         fullConsole && (consoleData.isSaved ?? true)
-          ? await getLatestConsoleSavedStateHash(
-              fullConsole._id,
-              new Types.ObjectId(workspaceId),
-            )
+          ? await getLatestConsoleSavedStateHash(fullConsole)
           : undefined;
 
       return c.json({
@@ -511,7 +470,6 @@ consoleRoutes.openapi(
         workspaceId: new Types.ObjectId(workspaceId),
       });
       const docsById = new Map(docs.map(d => [d._id.toString(), d]));
-      const workspaceObjectId = new Types.ObjectId(workspaceId);
 
       const changed: Array<Record<string, unknown>> = [];
       const deleted: string[] = [];
@@ -530,7 +488,7 @@ consoleRoutes.openapi(
         if (serverRevision === clientRevision) continue;
         const isSaved = doc.isSaved ?? true;
         const savedStateHash = isSaved
-          ? await getLatestConsoleSavedStateHash(doc._id, workspaceObjectId)
+          ? await getLatestConsoleSavedStateHash(doc)
           : undefined;
         changed.push({
           id,
@@ -1120,16 +1078,6 @@ consoleRoutes.openapi(
       // Create version 1 for this new console
       const freshDoc = await SavedConsole.findById(savedConsole._id).lean();
       if (freshDoc) {
-        const displayName = await getUserDisplayName(user.id);
-        await createVersion({
-          entityType: "console",
-          entityId: savedConsole._id,
-          workspaceId: new Types.ObjectId(workspaceId),
-          snapshot: buildConsoleSnapshot(freshDoc as ISavedConsole),
-          savedBy: user.id,
-          savedByName: displayName,
-          comment: body.comment ?? "",
-        });
         await SavedConsole.updateOne(
           { _id: savedConsole._id },
           { $set: { version: 1 } },
@@ -1351,8 +1299,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           );
         }
 
-        const displayName = await getUserDisplayName(user.id);
-
         // Update with path information (use upsert in case console hasn't been auto-saved yet)
         const setFields: Record<string, any> = {
           code: body.content,
@@ -1416,17 +1362,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           await projected.revert();
           return versionConflictResponse();
         }
-
-        // Create version record for the new state
-        await createVersion({
-          entityType: "console",
-          entityId: result._id,
-          workspaceId: new Types.ObjectId(workspaceId),
-          snapshot: buildConsoleSnapshot(result as ISavedConsole),
-          savedBy: user.id,
-          savedByName: displayName,
-          comment: body.comment ?? "",
-        });
 
         publishConsoleUpdated(result as ISavedConsole, "save");
         requestConsoleDescription({
@@ -1525,18 +1460,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         }
 
         publishConsoleUpdated(result as ISavedConsole, "save");
-
-        // Create version record for the new state
-        const displayNameExplicit = await getUserDisplayName(user.id);
-        await createVersion({
-          entityType: "console",
-          entityId: result._id,
-          workspaceId: new Types.ObjectId(workspaceId),
-          snapshot: buildConsoleSnapshot(result as ISavedConsole),
-          savedBy: user.id,
-          savedByName: displayNameExplicit,
-          comment: body.comment ?? "",
-        });
 
         requestConsoleDescription({
           workspaceId,
@@ -1662,16 +1585,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
     // Create version 1 for this new console
     const freshDocPath = await SavedConsole.findById(savedConsole._id).lean();
     if (freshDocPath) {
-      const displayNamePath = await getUserDisplayName(user.id);
-      await createVersion({
-        entityType: "console",
-        entityId: savedConsole._id,
-        workspaceId: new Types.ObjectId(workspaceId),
-        snapshot: buildConsoleSnapshot(freshDocPath as ISavedConsole),
-        savedBy: user.id,
-        savedByName: displayNamePath,
-        comment: body.comment ?? "",
-      });
       await SavedConsole.updateOne(
         { _id: savedConsole._id },
         { $set: { version: 1 } },
@@ -2608,28 +2521,18 @@ consoleRoutes.openapi(
       let previousContent = "";
       let versionFound = false;
       if (Types.ObjectId.isValid(consoleId)) {
-        const latestSnapshot = await EntityVersion.findOne(
-          {
-            entityId: new Types.ObjectId(consoleId),
-            entityType: "console",
-          },
-          { snapshot: 1, version: 1 },
-        )
-          .sort({ version: -1 })
-          .lean();
-
-        if (latestSnapshot?.snapshot?.code) {
-          previousContent = latestSnapshot.snapshot.code as string;
+        const row = await SavedConsole.findOne({
+          _id: new Types.ObjectId(consoleId),
+          workspaceId: new Types.ObjectId(workspaceId),
+        }).select("workspaceId path");
+        const saved = row ? await savedConsoleStateFromRepo(row) : null;
+        if (saved?.code) {
+          previousContent = saved.code;
           versionFound = true;
         }
-
         logger.debug("Version comment baseline lookup", {
           consoleId,
           versionFound,
-          latestVersion: latestSnapshot?.version ?? null,
-          snapshotKeys: latestSnapshot?.snapshot
-            ? Object.keys(latestSnapshot.snapshot)
-            : null,
           previousContentLength: previousContent.length,
           newContentLength: newContent.length,
         });
@@ -3762,319 +3665,6 @@ consoleRoutes.openapi(
           success: false,
           error: error instanceof Error ? error.message : "Restore failed",
         },
-        500,
-      );
-    }
-  },
-);
-
-// GET /api/workspaces/:workspaceId/consoles/:id/versions
-consoleRoutes.openapi(
-  createRoute({
-    method: "get",
-    path: "/{id}/versions",
-    tags: ["Consoles"],
-    summary: "List console versions",
-    security: AUTH_SECURITY,
-    request: {
-      params: z.object({
-        workspaceId: z
-          .string()
-          .openapi({ param: { name: "workspaceId", in: "path" } }),
-        id: z.string().openapi({ param: { name: "id", in: "path" } }),
-      }),
-      query: z.object({
-        limit: z
-          .string()
-          .optional()
-          .openapi({ param: { name: "limit", in: "query" } }),
-        offset: z
-          .string()
-          .optional()
-          .openapi({ param: { name: "offset", in: "query" } }),
-      }),
-    },
-    responses: { ...OPEN_RESPONSES },
-  }),
-  async c => {
-    try {
-      const workspaceId = c.req.param("workspaceId") as string;
-      const consoleId = c.req.param("id");
-      const user = c.get("user");
-
-      // Workspace access itself is the router middleware's job (it ran and
-      // set memberRole); this only keeps the route session-only.
-      if (!user) {
-        return c.json(
-          { success: false, error: "Access denied to workspace" },
-          403,
-        );
-      }
-
-      if (!Types.ObjectId.isValid(consoleId)) {
-        return c.json({ success: false, error: "Invalid console ID" }, 400);
-      }
-
-      const consoleDoc = await SavedConsole.findOne({
-        _id: new Types.ObjectId(consoleId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
-      if (!consoleDoc) {
-        return c.json({ success: false, error: "Console not found" }, 404);
-      }
-      // A version IS the console's content at a point in time: the same
-      // read gate as the console itself (owner / collaborator / workspace
-      // access), not just workspace membership — otherwise a private
-      // console's history was readable by any member. 404, not 403, so a
-      // private console's existence is not revealed (as the list does).
-      if (!ConsoleManager.canRead(consoleDoc, user.id, c.get("memberRole"))) {
-        return c.json({ success: false, error: "Console not found" }, 404);
-      }
-
-      const limit = Math.min(
-        parseInt(c.req.query("limit") ?? "50", 10) || 50,
-        100,
-      );
-      const offset = parseInt(c.req.query("offset") ?? "0", 10) || 0;
-
-      const result = await listVersions(
-        new Types.ObjectId(consoleId),
-        "console",
-        { limit, offset },
-      );
-
-      return c.json({ success: true, ...result });
-    } catch (error) {
-      if (error instanceof RepoRequiredError) return repoRequired(c, error);
-      logger.error("Error listing console versions", { error });
-      return c.json({ success: false, error: "Failed to list versions" }, 500);
-    }
-  },
-);
-
-// GET /api/workspaces/:workspaceId/consoles/:id/versions/:version
-consoleRoutes.openapi(
-  createRoute({
-    method: "get",
-    path: "/{id}/versions/{version}",
-    tags: ["Consoles"],
-    summary: "GET /{id}/versions/{version}",
-    security: AUTH_SECURITY,
-    request: {
-      params: z.object({
-        workspaceId: z
-          .string()
-          .openapi({ param: { name: "workspaceId", in: "path" } }),
-        id: z.string().openapi({ param: { name: "id", in: "path" } }),
-        version: z.string().openapi({ param: { name: "version", in: "path" } }),
-      }),
-    },
-    responses: { ...OPEN_RESPONSES },
-  }),
-  async c => {
-    try {
-      const workspaceId = c.req.param("workspaceId") as string;
-      const consoleId = c.req.param("id");
-      const versionNum = parseInt(c.req.param("version"), 10);
-      const user = c.get("user");
-
-      // Workspace access itself is the router middleware's job (it ran and
-      // set memberRole); this only keeps the route session-only.
-      if (!user) {
-        return c.json(
-          { success: false, error: "Access denied to workspace" },
-          403,
-        );
-      }
-
-      if (!Types.ObjectId.isValid(consoleId) || isNaN(versionNum)) {
-        return c.json(
-          { success: false, error: "Invalid console ID or version" },
-          400,
-        );
-      }
-
-      const consoleDoc = await SavedConsole.findOne({
-        _id: new Types.ObjectId(consoleId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
-      if (!consoleDoc) {
-        return c.json({ success: false, error: "Console not found" }, 404);
-      }
-      // A version IS the console's content at a point in time: the same
-      // read gate as the console itself (owner / collaborator / workspace
-      // access), not just workspace membership — otherwise a private
-      // console's history was readable by any member. 404, not 403, so a
-      // private console's existence is not revealed (as the list does).
-      if (!ConsoleManager.canRead(consoleDoc, user.id, c.get("memberRole"))) {
-        return c.json({ success: false, error: "Console not found" }, 404);
-      }
-
-      const version = await getVersion(consoleId, "console", versionNum);
-      if (!version) {
-        return c.json({ success: false, error: "Version not found" }, 404);
-      }
-
-      return c.json({ success: true, version });
-    } catch (error) {
-      if (error instanceof RepoRequiredError) return repoRequired(c, error);
-      logger.error("Error getting console version", { error });
-      return c.json({ success: false, error: "Failed to get version" }, 500);
-    }
-  },
-);
-
-// POST /api/workspaces/:workspaceId/consoles/:id/versions/:version/restore
-consoleRoutes.openapi(
-  createRoute({
-    method: "post",
-    path: "/{id}/versions/{version}/restore",
-    tags: ["Consoles"],
-    summary: "POST /{id}/versions/{version}/restore",
-    security: AUTH_SECURITY,
-    request: {
-      params: z.object({
-        workspaceId: z
-          .string()
-          .openapi({ param: { name: "workspaceId", in: "path" } }),
-        id: z.string().openapi({ param: { name: "id", in: "path" } }),
-        version: z.string().openapi({ param: { name: "version", in: "path" } }),
-      }),
-      body: {
-        required: false,
-        content: {
-          "application/json": { schema: z.record(z.string(), z.any()) },
-        },
-      },
-    },
-    responses: { ...OPEN_RESPONSES },
-  }),
-  async c => {
-    try {
-      const workspaceId = c.req.param("workspaceId") as string;
-      const consoleId = c.req.param("id");
-      const versionNum = parseInt(c.req.param("version"), 10);
-      const body = await c.req.json().catch(() => ({}));
-      const user = c.get("user");
-
-      // Workspace access itself is the router middleware's job (it ran and
-      // set memberRole); this only keeps the route session-only.
-      if (!user) {
-        return c.json(
-          { success: false, error: "Access denied to workspace" },
-          403,
-        );
-      }
-
-      if (!Types.ObjectId.isValid(consoleId) || isNaN(versionNum)) {
-        return c.json(
-          { success: false, error: "Invalid console ID or version" },
-          400,
-        );
-      }
-
-      const consoleDoc = await SavedConsole.findOne({
-        _id: new Types.ObjectId(consoleId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      });
-      if (!consoleDoc) {
-        return c.json({ success: false, error: "Console not found" }, 404);
-      }
-
-      const member = await workspaceService.getMember(workspaceId, user.id);
-      const isAdmin = member?.role === "owner" || member?.role === "admin";
-      if (
-        !ConsoleManager.canWrite(consoleDoc, user.id, isAdmin, member?.role)
-      ) {
-        return c.json(
-          { success: false, error: "You do not have write access" },
-          403,
-        );
-      }
-
-      const oldVersion = await getVersion(consoleId, "console", versionNum);
-      if (!oldVersion) {
-        return c.json({ success: false, error: "Version not found" }, 404);
-      }
-
-      const snap = oldVersion.snapshot as Record<string, any>;
-
-      // Apply the snapshot to the console document. Includes every field
-      // captured in buildConsoleSnapshot so restore is a true revert.
-      const restoreFields: Record<string, any> = {
-        code: snap.code,
-        name: snap.name,
-        language: snap.language,
-        description: snap.description,
-        chartSpec: snap.chartSpec,
-        resultsViewMode: snap.resultsViewMode,
-        mongoOptions: snap.mongoOptions,
-        connectionId: snap.connectionId
-          ? new Types.ObjectId(snap.connectionId)
-          : undefined,
-        databaseName: snap.databaseName,
-        databaseId: snap.databaseId,
-        folderId: snap.folderId ? new Types.ObjectId(snap.folderId) : null,
-        access: snap.access,
-      };
-
-      if (consoleDoc.isSaved) {
-        const projected = await projectSavedConsole({
-          workspaceId,
-          current: consoleDoc,
-          set: restoreFields,
-          actorUserId: user.id,
-          message: body.comment ?? `Restored from version ${versionNum}`,
-        });
-        restoreFields.path = projected.path;
-        restoreFields.sourceBlobSha = projected.sourceBlobSha;
-      }
-
-      const restored = await SavedConsole.findOneAndUpdate(
-        {
-          _id: new Types.ObjectId(consoleId),
-          workspaceId: new Types.ObjectId(workspaceId),
-        },
-        { $set: restoreFields, $inc: { version: 1 } },
-        { new: true },
-      ).lean();
-
-      if (!restored) {
-        return c.json({ success: false, error: "Restore failed" }, 500);
-      }
-      requestConsoleDescription({
-        workspaceId,
-        consoleId,
-        tracking: { userId: user.id, userEmail: user.email },
-      });
-
-      const displayName = await getUserDisplayName(user.id);
-      const comment = body.comment ?? `Restored from version ${versionNum}`;
-      await createVersion({
-        entityType: "console",
-        entityId: new Types.ObjectId(consoleId),
-        workspaceId: new Types.ObjectId(workspaceId),
-        snapshot: buildConsoleSnapshot(restored as ISavedConsole),
-        savedBy: user.id,
-        savedByName: displayName,
-        comment,
-        restoredFrom: versionNum,
-      });
-
-      return c.json({
-        success: true,
-        message: `Restored to version ${versionNum}`,
-        console: {
-          id: restored._id.toString(),
-          name: restored.name,
-          version: restored.version,
-        },
-      });
-    } catch (error) {
-      if (error instanceof RepoRequiredError) return repoRequired(c, error);
-      logger.error("Error restoring console version", { error });
-      return c.json(
-        { success: false, error: "Failed to restore version" },
         500,
       );
     }

--- a/api/src/routes/github.routes.ts
+++ b/api/src/routes/github.routes.ts
@@ -40,6 +40,7 @@ import { ensureLocalRepo, fetchFromCloud } from "../apps/cloud-repo.service";
 import { findWorkspaceIdByRepoBinding } from "../services/workspace-repos.service";
 import { repoDirFor } from "../apps/repository.service";
 import { syncConsolesIndexFromRepo } from "../apps/workspace-consoles.service";
+import { syncSkillsIndexFromRepo } from "../apps/workspace-skills.service";
 
 const logger = loggers.api("github");
 
@@ -164,6 +165,12 @@ async function handleAppsPush(input: {
   // before anyone opens the app (apps.md §16.3).
   void syncConsolesIndexFromRepo(workspaceId).catch(error => {
     logger.warn("Console index sync after GitHub push failed", {
+      workspaceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  void syncSkillsIndexFromRepo(workspaceId).catch(error => {
+    logger.warn("Skills index sync after GitHub push failed", {
       workspaceId,
       error: error instanceof Error ? error.message : String(error),
     });

--- a/api/src/routes/skills.ts
+++ b/api/src/routes/skills.ts
@@ -283,7 +283,12 @@ skillsRoutes.openapi(
       };
       const suppressed =
         typeof body.suppressed === "boolean" ? body.suppressed : true;
-      const ok = await toggleSkillSuppressed(workspaceId, id, suppressed);
+      const ok = await toggleSkillSuppressed(
+        workspaceId,
+        id,
+        suppressed,
+        c.get("user")?.id,
+      );
       if (!ok) {
         return c.json({ success: false, error: "Skill not found" }, 404);
       }
@@ -324,7 +329,7 @@ skillsRoutes.openapi(
           400,
         );
       }
-      const ok = await deleteSkillById(workspaceId, id);
+      const ok = await deleteSkillById(workspaceId, id, c.get("user")?.id);
       if (!ok) {
         return c.json({ success: false, error: "Skill not found" }, 404);
       }

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -12,6 +12,13 @@
 import { Types } from "mongoose";
 import { Skill, type ISkill } from "../database/workspace-schema";
 import {
+  commitSkillDelete,
+  commitSkillSave,
+  commitSkillSuppressed,
+} from "../apps/workspace-skills.service";
+import { authorForUser } from "../apps/workspace-consoles.service";
+import type { GitAuthor } from "../apps/repository.service";
+import {
   embedText,
   getEmbeddingModelName,
   isEmbeddingAvailable,
@@ -125,6 +132,18 @@ function unionEntities(
   return out;
 }
 
+/**
+ * Git author for a skill commit. `actorId` is a user id or the literal
+ * "agent"; a lookup miss (agent, deleted user) falls back to the Mako bot
+ * identity inside the git layer.
+ */
+async function skillCommitAuthor(
+  actorId: string | undefined,
+): Promise<GitAuthor | undefined> {
+  if (!actorId || actorId === "agent") return undefined;
+  return authorForUser(actorId);
+}
+
 async function computeEmbedding(text: string): Promise<{
   embedding: number[] | null;
   model: string | null;
@@ -180,7 +199,49 @@ export async function saveSkill(
         error: `Workspace has hit the ${MAX_SKILLS_PER_WORKSPACE} skill limit. Delete or merge skills before adding more.`,
       };
     }
+  }
 
+  // Git first — skills/<name>/SKILL.md on main is the source of truth; the
+  // Mongo write below is the derived index (apps.md §10 Block D1). On a
+  // workspace whose skills have not been adopted into git yet, this commit
+  // adopts every existing row too.
+  try {
+    const loadAdoptable = async () =>
+      (
+        (await Skill.find({ workspaceId: new Types.ObjectId(workspaceId) })
+          .select("name loadWhen body entities suppressed")
+          .lean()) as Array<
+          Pick<ISkill, "name" | "loadWhen" | "body" | "entities" | "suppressed">
+        >
+      ).map(s => ({
+        name: s.name,
+        loadWhen: s.loadWhen,
+        entities: s.entities ?? [],
+        suppressed: !!s.suppressed,
+        body: s.body,
+      }));
+    await commitSkillSave(
+      workspaceId,
+      {
+        name,
+        loadWhen,
+        // The file carries the author-DECLARED entities; the Mongo row below
+        // carries the declared ∪ extracted union the retrieval uses.
+        entities: unionEntities(input.entities, []),
+        suppressed: !!existing?.suppressed,
+        body,
+      },
+      { author: await skillCommitAuthor(createdBy), loadAdoptable },
+    );
+  } catch (error) {
+    logger.error("Skill save: git commit failed", { workspaceId, error });
+    return {
+      success: false,
+      error: `Could not commit the skill to the workspace repository: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (!existing) {
     const created = await Skill.create({
       workspaceId: new Types.ObjectId(workspaceId),
       name,
@@ -236,15 +297,30 @@ export async function skillExists(
 export async function deleteSkill(
   workspaceId: string,
   name: string,
+  actorId?: string,
 ): Promise<
   { success: true; deleted: boolean } | { success: false; error: string }
 > {
   if (!name || name.trim().length === 0) {
     return { success: false, error: "name is required" };
   }
+  const trimmed = name.trim();
+  try {
+    await commitSkillDelete(
+      workspaceId,
+      trimmed,
+      await skillCommitAuthor(actorId),
+    );
+  } catch (error) {
+    logger.error("Skill delete: git commit failed", { workspaceId, error });
+    return {
+      success: false,
+      error: `Could not commit the deletion to the workspace repository: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
   const res = await Skill.deleteOne({
     workspaceId: new Types.ObjectId(workspaceId),
-    name: name.trim(),
+    name: trimmed,
   });
   return { success: true, deleted: res.deletedCount > 0 };
 }
@@ -773,26 +849,42 @@ export async function toggleSkillSuppressed(
   workspaceId: string,
   id: string,
   suppressed: boolean,
+  actorId?: string,
 ): Promise<boolean> {
   if (!Types.ObjectId.isValid(id)) return false;
-  const res = await Skill.updateOne(
-    {
-      _id: new Types.ObjectId(id),
-      workspaceId: new Types.ObjectId(workspaceId),
-    },
-    { $set: { suppressed } },
+  const doc = await Skill.findOne({
+    _id: new Types.ObjectId(id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  }).select("name");
+  if (!doc) return false;
+  // Suppression is frontmatter, so it commits like any other skill edit; a
+  // skill not adopted into git yet flips only its Mongo row (no-op there).
+  await commitSkillSuppressed(
+    workspaceId,
+    doc.name,
+    suppressed,
+    await skillCommitAuthor(actorId),
   );
+  const res = await Skill.updateOne({ _id: doc._id }, { $set: { suppressed } });
   return res.matchedCount > 0;
 }
 
 export async function deleteSkillById(
   workspaceId: string,
   id: string,
+  actorId?: string,
 ): Promise<boolean> {
   if (!Types.ObjectId.isValid(id)) return false;
-  const res = await Skill.deleteOne({
+  const doc = await Skill.findOne({
     _id: new Types.ObjectId(id),
     workspaceId: new Types.ObjectId(workspaceId),
-  });
+  }).select("name");
+  if (!doc) return false;
+  await commitSkillDelete(
+    workspaceId,
+    doc.name,
+    await skillCommitAuthor(actorId),
+  );
+  const res = await Skill.deleteOne({ _id: doc._id });
   return res.deletedCount > 0;
 }

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       "src/apps/adversarial.test.ts",
       "src/apps/git-endpoint.test.ts",
       "src/apps/workspace-consoles.service.test.ts",
+      "src/apps/workspace-skills.service.test.ts",
       "src/apps/box-state.service.test.ts",
       "src/apps/preview.service.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -498,10 +498,7 @@ function Editor({
   const shareConsoleTab = useConsoleStore(s =>
     shareConsoleTabId ? s.tabs[shareConsoleTabId] : undefined,
   );
-  // Only dashboards still use the snapshot-based panel; consoles read git.
-  const [versionHistoryEntityType] = useState<"console" | "dashboard">(
-    "dashboard",
-  );
+
   const [scheduleModalTabId, setScheduleModalTabId] = useState<string | null>(
     null,
   );
@@ -1484,6 +1481,28 @@ function Editor({
           setScheduleModalTabId(tabId);
           setScheduleModalMode("create");
         }
+      } else if (result.code === "github_required") {
+        // Production gate (apps.md §17): saves live in the workspace's own
+        // GitHub repo. Take the user straight to the connect screen.
+        const state = useConsoleStore.getState();
+        const existing = Object.values(state.tabs).find(
+          t => t.kind === "settings" && t.settingsSection === "github",
+        );
+        if (existing) {
+          state.setActiveTab(existing.id);
+        } else {
+          const id = state.openTab({
+            title: "GitHub",
+            content: "",
+            kind: "settings",
+            settingsSection: "github",
+          });
+          state.setActiveTab(id);
+        }
+        setSnackbarMessage(
+          "Connect a GitHub repository to save consoles — Mako keeps your work in your own repo.",
+        );
+        setSnackbarOpen(true);
       } else {
         setErrorMessage(JSON.stringify(result.error, null, 2));
         setErrorModalOpen(true);
@@ -3168,7 +3187,7 @@ function Editor({
             setVersionHistoryOpen(false);
             setVersionHistoryTabId(null);
           }}
-          entityType={versionHistoryEntityType}
+          entityType="dashboard"
           entityId={versionHistoryTabId}
           onRestore={() => {
             if (currentWorkspace && versionHistoryTabId) {

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -106,10 +106,7 @@ export function VersionHistoryPanel({
       if (!workspaceId) return;
       setSelectedVersion({
         ...item,
-        snapshot:
-          entityType === "console"
-            ? { code: "" }
-            : ({} as Record<string, unknown>),
+        snapshot: {} as Record<string, unknown>,
       });
       setLoadingDetail(true);
       const detail = await fetchVersion(
@@ -150,15 +147,9 @@ export function VersionHistoryPanel({
   };
 
   let snapshotValue = "";
-  let previewLanguage = "json";
+  const previewLanguage = "json";
   if (selectedVersion != null) {
-    if (entityType === "console") {
-      snapshotValue = (selectedVersion.snapshot.code as string) ?? "";
-      previewLanguage = "sql";
-    } else {
-      snapshotValue = JSON.stringify(selectedVersion.snapshot ?? {}, null, 2);
-      previewLanguage = "json";
-    }
+    snapshotValue = JSON.stringify(selectedVersion.snapshot ?? {}, null, 2);
   }
 
   return (

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -83,6 +83,8 @@ export interface ConsoleSaveResponse {
   success: boolean;
   path?: string;
   error?: string;
+  /** Machine-readable failure code (e.g. "github_required", apps.md §17). */
+  code?: string;
   /** New document version after a successful save. */
   version?: number;
   /** New draft revision after a successful save (realtime sync base). */

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -1663,7 +1663,11 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
 
           if (!response.ok) {
-            return { success: false, error: res.error || "Save failed" };
+            return {
+              success: false,
+              error: res.error || "Save failed",
+              code: (res as { code?: string }).code,
+            };
           }
 
           if (res.success) {
@@ -1680,7 +1684,11 @@ export const useConsoleStore = create<ConsoleStore>()(
             });
             return { success: true, path: cleanPath, version: newVersion };
           }
-          return { success: false, error: res.error || "Save failed" };
+          return {
+            success: false,
+            error: res.error || "Save failed",
+            code: (res as { code?: string }).code,
+          };
         } catch (e) {
           return {
             success: false,

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -3,7 +3,8 @@ import { api, unwrap } from "../api";
 
 /** Typed versions base path per entity type. */
 const VERSION_BASE = {
-  console: "/api/workspaces/{workspaceId}/consoles/{id}/versions",
+  // Consoles read git history now (apps.md §16); only dashboards keep
+  // snapshot-based versions.
   dashboard: "/api/workspaces/{workspaceId}/dashboards/{id}/versions",
 } as const;
 

--- a/apps.md
+++ b/apps.md
@@ -2617,3 +2617,19 @@ artifacts deliberately keep streaming: their `rev`-addressed responses are
 repeat views. Signing failures degrade to streaming per-response (GCS
 signing needs a private key or `iam signBlob`), so a misconfigured service
 account costs latency, never availability.
+
+### 17.1 Skills followed consoles the same day (2026-08-31, late)
+
+Block D1, at last: the never-merged skills branch was re-ported onto the
+consoles primitive rather than rebased — `skills/<name>/SKILL.md` (system-
+skill package shape), `commitBlobsOnBranch` write-through with lazy adoption
+on the first save (plus the 412 gate in production), `skills/README.md` as
+the adoption marker, push-driven `syncSkillsIndexFromRepo` beside the
+consoles sync, Mongo `skills` kept as the derived retrieval index. The
+`workspace_skills_to_git` migration adopts repo-holding workspaces
+(rehearsed: RealAdvisor's 200 skills in one commit; three repo-less
+workspaces skip until they connect). Console `entity_versions` are fully
+retired the same evening: no dual-writes, no legacy `/versions` routes —
+save baselines and the version-comment diff read the file at HEAD. The 412
+now lands as UX: a failed save opens Settings → GitHub with a plain
+explanation. Template v7 documents `skills/` in AGENTS.md.


### PR DESCRIPTION
Block D1 re-ported onto the consoles primitive: `skills/<name>/SKILL.md` write-through with lazy adoption + the prod 412 gate, push-driven index sync, Mongo `skills` as the derived retrieval index, and the `workspace_skills_to_git` migration (rehearsed on dev: RealAdvisor's 200 skills, one commit). Console `entity_versions` fully retired — no dual-writes, no legacy `/versions` routes; baselines read the file at HEAD. 412 `github_required` now opens Settings → GitHub. Template v7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat