### PR TITLE
refactor(apps): workspace-scoped repo + branch policy module (pre-dbt Block D3)

### DIFF
--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -47,6 +47,7 @@ import {
   readSessionFile,
   worktreeStatus,
   writeFile,
+  scopeOf,
 } from "../../apps/worktree.service";
 import { materializeAppBinding } from "../../apps/bindings.service";
 import {
@@ -475,7 +476,7 @@ export function createAppsTools({
         const loaded = await loadProject(appId, { write: false });
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
-          const status = await worktreeStatus(loaded.project, actorId);
+          const status = await worktreeStatus(scopeOf(loaded.project), actorId);
           return { success: true, status };
         } catch (error) {
           return { success: false, error: errorMessage(error) };
@@ -747,7 +748,7 @@ export function createAppsTools({
         const loaded = await loadProject(appId, { write: false });
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
-          const branches = await listBranches(loaded.project);
+          const branches = await listBranches(scopeOf(loaded.project));
           return {
             success: true,
             branches,
@@ -781,7 +782,10 @@ export function createAppsTools({
           };
         }
         try {
-          const result = await mergeBranchToMain(loaded.project, target);
+          const result = await mergeBranchToMain(
+            scopeOf(loaded.project),
+            target,
+          );
           return { success: result.merged, ...result, branch: target };
         } catch (error) {
           logger.error("app_merge_to_main failed", { error, appId });

--- a/api/src/apps/adversarial.test.ts
+++ b/api/src/apps/adversarial.test.ts
@@ -15,6 +15,7 @@ import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 import { startTestGitServer, type TestGitServer } from "./test-git-server";
+import { scopeOf } from "./worktree.service";
 
 let mongo: MongoMemoryServer;
 let tmpRoot: string;
@@ -143,7 +144,9 @@ describe("hostile branch names", () => {
     // nothing executed.
     const after = await ensureWorktree(project, USER);
     expect(after.doc.branch).toBe(hostile);
-    expect((await listBranches(project)).map(b => b.name)).toContain(hostile);
+    expect((await listBranches(scopeOf(project))).map(b => b.name)).toContain(
+      hostile,
+    );
     await expect(fs.stat("/tmp/mako-pwned")).rejects.toThrow();
   }, 120_000);
 });
@@ -240,12 +243,12 @@ describe("losing the machine", () => {
     // server-side gets to hold a different opinion about what is in the tree,
     // because nothing server-side holds an opinion at all.
     await writeFile(await ensureWorktree(project, USER), "tracked.txt", "v2\n");
-    const dirty = await worktreeStatus(project, USER);
+    const dirty = await worktreeStatus(scopeOf(project), USER);
     expect(dirty?.changes.map(c => c.path)).toContain("tracked.txt");
 
     await execInWorktree(handle, "git reset -q --hard HEAD", {});
 
-    const status = await worktreeStatus(project, USER);
+    const status = await worktreeStatus(scopeOf(project), USER);
     expect(status?.changes.map(c => c.path) ?? []).not.toContain("tracked.txt");
   }, 120_000);
 });
@@ -524,7 +527,7 @@ describe("uncommitted work you cannot see", () => {
       "written by a build\n",
     );
 
-    const status = await worktreeStatus(mine, USER);
+    const status = await worktreeStatus(scopeOf(mine), USER);
     expect(status?.changes.map(c => c.path)).not.toContain("generated.lock");
     expect(status?.repoChanges.map(c => c.path).join("\n")).toMatch(
       /generated\.lock/,
@@ -634,7 +637,7 @@ describe("publishing", () => {
     );
     await commitWorktree(await ensureWorktree(project, USER), "theirs 2");
 
-    const before = (await projectHistory(project)).length;
+    const before = (await projectHistory(scopeOf(project))).length;
     const publishHandle = await ensureWorktree(project, PUBLISH_ACTOR, {
       branch: project.defaultBranch || "main",
     });
@@ -642,7 +645,7 @@ describe("publishing", () => {
     expect(trial.ok, "a conflicting merge must be refused").toBe(false);
     expect(trial.reason).toMatch(/conflict/i);
     // Refusing must not have advanced main.
-    expect((await projectHistory(project)).length).toBe(before);
+    expect((await projectHistory(scopeOf(project))).length).toBe(before);
   }, 180_000);
 });
 
@@ -658,9 +661,9 @@ describe("repeated operations are idempotent", () => {
     // Reading used to WRITE: every read snapshotted the working copy into a
     // new commit, so asking what had changed changed something. A read is a
     // read now, and this is the case that says so.
-    const first = await worktreeStatus(project, USER);
-    const second = await worktreeStatus(project, USER);
-    const third = await worktreeStatus(project, USER);
+    const first = await worktreeStatus(scopeOf(project), USER);
+    const second = await worktreeStatus(scopeOf(project), USER);
+    const third = await worktreeStatus(scopeOf(project), USER);
     expect(second?.baseSha).toBe(first?.baseSha);
     expect(third?.baseSha).toBe(first?.baseSha);
     expect(third?.changes.map(c => c.path)).toEqual(

--- a/api/src/apps/branch-policy.ts
+++ b/api/src/apps/branch-policy.ts
@@ -1,0 +1,93 @@
+/**
+ * Branch policy — the one place that answers "which branch does this commit
+ * land on?" for content written through Mako.
+ *
+ * The doctrine this module encodes (apps.md §18) is three separate rules that
+ * used to travel under one slogan ("every save is a commit"):
+ *
+ * 1. DURABILITY — an ephemeral working copy (the sandbox, a Monaco buffer)
+ *    never holds work the server is responsible for: agent turns and manual
+ *    saves commit AND push. A laptop clone is exempt — uncommitted work there
+ *    is the owner's, exactly as on any machine. This rule is not negotiable
+ *    and is enforced where the writes happen (worktree.service, the per-kind
+ *    commit services), not here.
+ *
+ * 2. REF POLICY (this module) — which branch those commits advance. It is
+ *    per-actor session state (`AppWorktree.branch`, the same pointer a
+ *    `git checkout` in the terminal moves), defaulting per content kind:
+ *    - Apps and (later) dbt follow the actor's session branch. Main is not
+ *      production for apps — publish deploys a PINNED sha — so main is an
+ *      acceptable default; anyone can work on a branch by switching in the
+ *      Source Control panel or the terminal, and protection belongs to the
+ *      remote (the git endpoint's pre-receive hook), not to a forced-branch
+ *      ceremony.
+ *    - Consoles and skills commit to the DEFAULT branch regardless of the
+ *      actor's session branch, because their Mongo rows are a derived index
+ *      of main: a save committed to a feature branch would be visually
+ *      reverted by the next index sync. Branch-scoped indexes are the
+ *      prerequisite for lifting this (apps.md §18), not a policy toggle.
+ *
+ * 3. GRANULARITY — whether a save amends, squashes, or stands alone is a
+ *    per-surface choice (see autoCommitFileEdit's history in
+ *    worktree.service); it is deliberately NOT policy here.
+ */
+import { Types } from "mongoose";
+import { AppWorktree } from "../database/workspace-schema";
+import { DEFAULT_BRANCH } from "./repository.service";
+
+/** Content kinds that commit through Mako (dbt joins with Block D3). */
+export type RepoContentKind = "app" | "console" | "skill" | "dbt";
+
+/**
+ * Which branch an actor starts on when the caller does not name one: the
+ * default branch, like a fresh clone on a laptop.
+ *
+ * Actors used to be forced onto a personal `user/<id>` branch ("you do not
+ * edit production"). That guarded the wrong thing: publish deploys a PINNED
+ * sha, so a commit on `main` moves the branch but ships nothing — exactly
+ * like committing to main of a repo whose releases are tagged. Meanwhile the
+ * forced branch made the everyday experience alien: everyone lived on a
+ * branch named after their user id, and "just commit it" needed a merge
+ * ceremony. Now the working copy is unrestricted, git-native; whoever wants
+ * main protected does it at the remote (the git endpoint's pre-receive hook
+ * carries GitHub's defaults — no force-push, no delete — and a mirrored
+ * GitHub repo can layer its own rules).
+ */
+export function defaultBranchForActor(_actorId: string): string {
+  return DEFAULT_BRANCH;
+}
+
+/**
+ * The branch this actor's session is on — the same pointer `git checkout`
+ * moves and the Source Control panel displays. An actor with no session yet
+ * is on the default branch, like a fresh clone.
+ */
+export async function sessionBranchFor(
+  workspaceId: string,
+  actorId: string,
+): Promise<string> {
+  const doc = await AppWorktree.findOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+    userId: actorId,
+  });
+  return doc?.branch || defaultBranchForActor(actorId);
+}
+
+/**
+ * Where a commit of this content kind lands (rule 2 above). Indexed kinds
+ * pin to the default branch until their indexes are branch-scoped.
+ */
+export async function commitBranchFor(
+  kind: RepoContentKind,
+  workspaceId: string,
+  actorId: string,
+): Promise<string> {
+  switch (kind) {
+    case "console":
+    case "skill":
+      return DEFAULT_BRANCH;
+    case "app":
+    case "dbt":
+      return sessionBranchFor(workspaceId, actorId);
+  }
+}

--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -26,7 +26,7 @@ import { serveParquetArtifact } from "../services/artifact-delivery.service";
 import { bindingArtifactKeyByName, readBindings } from "./bindings.service";
 import { AppProject, type IAppProject } from "../database/workspace-schema";
 import { loggers } from "../logging";
-import { boxCtx, type WorktreeHandle } from "./worktree.service";
+import { boxCtx, handleProject, type WorktreeHandle } from "./worktree.service";
 import { readBoxDir } from "./box";
 
 const logger = loggers.api("apps-deployment");
@@ -251,7 +251,8 @@ export async function readDeploymentAsset(
  * boot log uses.
  */
 export function buildLogPath(handle: WorktreeHandle): string {
-  const slug = handle.project.slug || handle.project._id.toString();
+  const project = handleProject(handle);
+  const slug = project.slug || project._id.toString();
   return `/tmp/mako-build-${slug.replace(/[^A-Za-z0-9_-]/g, "-")}.log`;
 }
 

--- a/api/src/apps/dev-server.service.ts
+++ b/api/src/apps/dev-server.service.ts
@@ -34,6 +34,7 @@ import {
   rehydrateBox,
   type WorktreeHandle,
   sessionKeyFor,
+  handleProject,
 } from "./worktree.service";
 import { loggers } from "../logging";
 import { boxEnvPath, sh } from "./box";
@@ -523,10 +524,11 @@ async function stageBindingData(
   provider: ReturnType<typeof getSandboxProvider>,
   ctx: SandboxExecContext,
 ): Promise<string[]> {
-  const projectId = handle.project._id.toString();
+  const project = handleProject(handle);
+  const projectId = project._id.toString();
   let bindings: Awaited<ReturnType<typeof readBindings>>;
   try {
-    bindings = await readBindings(handle.project, handle.doc.userId);
+    bindings = await readBindings(project, handle.doc.userId);
   } catch {
     return [];
   }
@@ -891,7 +893,7 @@ async function ensureDevServerLaunch(
       { timeoutMs: 30_000 },
     );
     logger.warn("Apps dev server orphan reaped", {
-      projectId: handle.project._id.toString(),
+      projectId: handleProject(handle)._id.toString(),
       appRoot: handle.appRoot,
     });
   }
@@ -1003,7 +1005,7 @@ async function ensureDevServerLaunch(
   if (wasListening) {
     void stageBindingData(handle, provider, ctx).catch(error => {
       logger.warn("Apps background binding restage failed", {
-        projectId: handle.project._id.toString(),
+        projectId: handleProject(handle)._id.toString(),
         error: error instanceof Error ? error.message : String(error),
       });
     });
@@ -1013,7 +1015,7 @@ async function ensureDevServerLaunch(
 
   const url = await provider.publicUrlForPort(ctx, port);
   logger.info("Apps dev preview ready", {
-    projectId: handle.project._id.toString(),
+    projectId: handleProject(handle)._id.toString(),
     appRoot: handle.appRoot,
     stagedBindings,
     ...(evicted.length ? { evicted } : {}),

--- a/api/src/apps/sandbox/e2b-provider.integration.test.ts
+++ b/api/src/apps/sandbox/e2b-provider.integration.test.ts
@@ -20,6 +20,7 @@ import {
   listFiles,
   projectHistory,
   readFile,
+  scopeOf,
 } from "../worktree.service";
 
 const HAS_KEY = Boolean(process.env.E2B_API_KEY);
@@ -110,7 +111,7 @@ suite("e2b sandbox provider (live)", () => {
     // 4. Commit through the broker (never from inside the sandbox).
     const commit = await commitWorktree(handle, "E2B live change");
     expect(commit.committed).toBe(true);
-    const history = await projectHistory(project);
+    const history = await projectHistory(scopeOf(project));
     expect(history.map(c => c.subject)).toEqual([
       "E2B live change",
       "Initial scaffold",

--- a/api/src/apps/workspace-consoles.service.ts
+++ b/api/src/apps/workspace-consoles.service.ts
@@ -90,6 +90,7 @@ import {
   type GitAuthor,
   type TreeEntry,
 } from "./repository.service";
+import { commitBranchFor } from "./branch-policy";
 import { EMPTY_TREE } from "./git";
 
 const logger = loggers.api("consoles-git");
@@ -394,12 +395,17 @@ export async function commitConsoleBatch(input: {
     });
   }
   const author = await authorForUser(input.actorUserId);
-  const result = await commitBlobsOnBranch(
-    repoDir,
-    DEFAULT_BRANCH,
-    input.mutation,
-    { message: input.message, author },
+  // Ref policy: consoles pin to the default branch while their Mongo index
+  // is main-scoped — see branch-policy.ts for the doctrine.
+  const branch = await commitBranchFor(
+    "console",
+    input.workspaceId,
+    input.actorUserId ?? "api-key",
   );
+  const result = await commitBlobsOnBranch(repoDir, branch, input.mutation, {
+    message: input.message,
+    author,
+  });
   if (!result.unchanged) queueMirrorPush(input.workspaceId);
   return { commitOid: result.commitOid, unchanged: result.unchanged };
 }

--- a/api/src/apps/workspace-repo.test.ts
+++ b/api/src/apps/workspace-repo.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The workspace-scoped repo surface (RepoScope + ensureWorkspaceWorktree +
+ * branch-policy): the repo reachable with NO app handle. Real bare repos
+ * under a temp APPS_GIT_ROOT and mongodb-memory-server — the same rig the
+ * consoles suite uses; nothing here needs a sandbox (status is exercised on
+ * its offline path).
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { AppWorktree } from "../database/workspace-schema";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  initRepo,
+  repoDirFor,
+  resolveCommit,
+  updateRefCas,
+} from "./repository.service";
+import { ZERO_OID } from "./git";
+import {
+  commitBranchFor,
+  defaultBranchForActor,
+  sessionBranchFor,
+} from "./branch-policy";
+import {
+  commitChanges,
+  commitFileVersions,
+  ensureWorkspaceWorktree,
+  listBranches,
+  mergeBranchToMain,
+  projectHistory,
+  worktreeStatus,
+  workspaceScope,
+} from "./worktree.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "apps-repo-test-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SESSIONS_ROOT = path.join(tmpRoot, "sessions");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+const WS = new Types.ObjectId().toString();
+const USER = "user-1";
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+async function seedRepo(): Promise<string> {
+  const repoDir = repoDirFor(WS);
+  await initRepo(repoDir, { "README.md": "workspace\n" });
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    {
+      writes: {
+        "apps/dash/mako.json": "{}\n",
+        "consoles/revenue.sql": "-- connection: c1\n\nselect 1\n",
+      },
+    },
+    { message: "seed content" },
+  );
+  return repoDir;
+}
+
+beforeEach(async () => {
+  await AppWorktree.deleteMany({});
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+});
+
+describe("ensureWorkspaceWorktree", () => {
+  it("creates the per-(workspace, actor) session on the default branch, no app lens", async () => {
+    await seedRepo();
+    const handle = await ensureWorkspaceWorktree(WS, USER);
+    expect(handle.project).toBeUndefined();
+    expect(handle.appRoot).toBe("");
+    expect(handle.doc.branch).toBe(DEFAULT_BRANCH);
+    // Same session doc an app-scoped handle would use: keyed by workspace.
+    const doc = await AppWorktree.findOne({
+      workspaceId: new Types.ObjectId(WS),
+      userId: USER,
+    });
+    expect(doc?._id.toString()).toBe(handle.doc._id.toString());
+  });
+});
+
+describe("workspace-scoped reads", () => {
+  it("status works offline with no app at all", async () => {
+    const repoDir = await seedRepo();
+    await ensureWorkspaceWorktree(WS, USER);
+    const status = await worktreeStatus(workspaceScope(WS), USER);
+    expect(status).not.toBeNull();
+    expect(status?.branch).toBe(DEFAULT_BRANCH);
+    expect(status?.offline).toBe(true);
+    expect(status?.branchHead).toBe(await resolveCommit(repoDir, MAIN));
+    // Repo scope: changes === repoChanges (no prefix narrowing).
+    expect(status?.changes).toEqual(status?.repoChanges);
+  });
+
+  it("history at repo scope sees commits from every content kind", async () => {
+    const repoDir = await seedRepo();
+    await commitBlobsOnBranch(
+      repoDir,
+      DEFAULT_BRANCH,
+      { writes: { "consoles/churn.sql": "select 2\n" } },
+      { message: "add churn console" },
+    );
+    const commits = await projectHistory(
+      workspaceScope(WS),
+      20,
+      undefined,
+      "repo",
+    );
+    expect(commits.map(c => c.subject)).toContain("add churn console");
+    expect(commits.map(c => c.subject)).toContain("seed content");
+  });
+
+  it("commitChanges and commitFileVersions read repo-relative paths", async () => {
+    const repoDir = await seedRepo();
+    const { commitOid } = await commitBlobsOnBranch(
+      repoDir,
+      DEFAULT_BRANCH,
+      { writes: { "consoles/revenue.sql": "select 42\n" } },
+      { message: "tweak revenue" },
+    );
+    const changes = await commitChanges(workspaceScope(WS), commitOid!, "repo");
+    expect(changes.files.map(f => f.path)).toEqual(["consoles/revenue.sql"]);
+    const versions = await commitFileVersions(
+      workspaceScope(WS),
+      commitOid!,
+      "consoles/revenue.sql",
+    );
+    expect(versions.after).toBe("select 42\n");
+    expect(versions.before).toContain("select 1");
+  });
+
+  it("branches and merge work through the workspace scope", async () => {
+    const repoDir = await seedRepo();
+    const mainHead = await resolveCommit(repoDir, MAIN);
+    await updateRefCas(repoDir, "refs/heads/feature", mainHead!, ZERO_OID);
+    await commitBlobsOnBranch(
+      repoDir,
+      "feature",
+      { writes: { "apps/dash/index.html": "<html/>\n" } },
+      { message: "feature work" },
+    );
+    const branches = await listBranches(workspaceScope(WS));
+    const feature = branches.find(b => b.name === "feature");
+    expect(feature?.aheadOfMain).toBe(1);
+    expect(branches.find(b => b.isDefault)?.name).toBe(DEFAULT_BRANCH);
+
+    const result = await mergeBranchToMain(workspaceScope(WS), "feature");
+    expect(result.merged).toBe(true);
+    expect(result.fastForward).toBe(true);
+    expect(await resolveCommit(repoDir, MAIN)).toBe(result.commitOid);
+  });
+});
+
+describe("branch policy", () => {
+  it("an actor with no session is on the default branch", async () => {
+    expect(defaultBranchForActor(USER)).toBe(DEFAULT_BRANCH);
+    expect(await sessionBranchFor(WS, USER)).toBe(DEFAULT_BRANCH);
+  });
+
+  it("apps follow the session branch; indexed kinds pin to the default branch", async () => {
+    await AppWorktree.create({
+      workspaceId: new Types.ObjectId(WS),
+      userId: USER,
+      branch: "feature/reports",
+    });
+    expect(await sessionBranchFor(WS, USER)).toBe("feature/reports");
+    expect(await commitBranchFor("app", WS, USER)).toBe("feature/reports");
+    // Consoles/skills are derived-index kinds: their Mongo rows mirror main,
+    // so a save must not land on a branch the index never reads.
+    expect(await commitBranchFor("console", WS, USER)).toBe(DEFAULT_BRANCH);
+    expect(await commitBranchFor("skill", WS, USER)).toBe(DEFAULT_BRANCH);
+  });
+});

--- a/api/src/apps/workspace-skills.service.ts
+++ b/api/src/apps/workspace-skills.service.ts
@@ -57,6 +57,8 @@ const logger = loggers.api("skills-git");
 /** Mirrors skills.service's MAX_SKILLS_PER_WORKSPACE — bounds the index. */
 const MAX_SYNCED_SKILLS = 200;
 
+// Ref policy: skills pin to the default branch while their Mongo index is
+// main-scoped — see branch-policy.ts (commitBranchFor "skill") for why.
 const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
 
 async function readRepoFile(

--- a/api/src/apps/worktree.service.test.ts
+++ b/api/src/apps/worktree.service.test.ts
@@ -35,6 +35,7 @@ import {
   readFile,
   worktreeStatus,
   writeFile,
+  scopeOf,
 } from "./worktree.service";
 import { AppWorktree } from "../database/workspace-schema";
 import { getSandboxProvider } from "./sandbox/provider";
@@ -106,7 +107,7 @@ describe("project lifecycle", () => {
     const file = await readFile(project, "src/App.tsx", USER);
     expect(file.contents).toContain("Apps");
 
-    const history = await projectHistory(project);
+    const history = await projectHistory(scopeOf(project));
     expect(history).toHaveLength(1);
     expect(history[0].subject).toContain('Create app "Test App"');
 
@@ -133,7 +134,7 @@ describe("the working copy", () => {
     expect(file.contents).toBe("export const n = 1;\n");
 
     // Uncommitted, and reported as such — no shadow commit stands in for it.
-    const status = await worktreeStatus(project, USER);
+    const status = await worktreeStatus(scopeOf(project), USER);
     expect(status?.offline).toBe(false);
     expect(status?.changes.map(ch => ch.path)).toContain("src/note.ts");
   });
@@ -171,7 +172,7 @@ describe("the working copy", () => {
     expect(entries.map(e => e.path)).not.toContain("src/scratch.ts");
 
     // And with no machine running, status says so rather than claiming clean.
-    const status = await worktreeStatus(project, USER);
+    const status = await worktreeStatus(scopeOf(project), USER);
     expect(status?.offline).toBe(true);
   });
 
@@ -325,12 +326,11 @@ describe("commits", () => {
     // A fresh actor starts on main, like a fresh clone — the commit is on
     // main's history. Publish deploys a PINNED sha, so main moving ships
     // nothing by itself.
-    expect((await projectHistory(project)).map(c => c.subject)).toEqual([
-      "Add feature module",
-      'Create app "Test App" (apps/test-app)',
-    ]);
+    expect(
+      (await projectHistory(scopeOf(project))).map(c => c.subject),
+    ).toEqual(["Add feature module", 'Create app "Test App" (apps/test-app)']);
 
-    const status = await worktreeStatus(project, USER);
+    const status = await worktreeStatus(scopeOf(project), USER);
     expect(status?.changes).toEqual([]);
     expect(status?.baseSha).toBe(result.commitOid);
     // Committed AND pushed: nothing is waiting to reach the server.
@@ -349,10 +349,10 @@ describe("commits", () => {
       "On a branch",
     );
     expect(onBranch.committed).toBe(true);
-    expect((await projectHistory(project)).map(c => c.subject)[0]).toBe(
-      "Add feature module",
-    );
-    const branch = (await listBranches(project)).find(
+    expect(
+      (await projectHistory(scopeOf(project))).map(c => c.subject)[0],
+    ).toBe("Add feature module");
+    const branch = (await listBranches(scopeOf(project))).find(
       b => b.name === "feature",
     );
     expect(branch?.aheadOfMain).toBe(1);
@@ -422,7 +422,7 @@ describe("branches are explicit", () => {
     expect(results[0].commitOid).toBeTruthy();
 
     // The commit is on the branch Alice created, NOT on main.
-    const branches = await listBranches(project);
+    const branches = await listBranches(scopeOf(project));
     const branch = branches.find(b => b.name === "alice-feature");
     expect(branch?.aheadOfMain).toBe(1);
     expect(branch?.lastCommit?.subject).toContain("add feature module");
@@ -435,12 +435,13 @@ describe("branches are explicit", () => {
     await writeFile(handle2, "src/feature2.ts", "export const g = 2;\n");
     await commitAgentTurn(WS, ALICE, "second turn");
     expect(
-      (await listBranches(project)).find(b => b.name === "alice-feature")
-        ?.aheadOfMain,
+      (await listBranches(scopeOf(project))).find(
+        b => b.name === "alice-feature",
+      )?.aheadOfMain,
     ).toBe(2);
 
     // Merge to main (fast-forward — main did not move).
-    const merge = await mergeBranchToMain(project, "alice-feature");
+    const merge = await mergeBranchToMain(scopeOf(project), "alice-feature");
     expect(merge.merged).toBe(true);
     expect(merge.fastForward).toBe(true);
     const mainAfter = (await listFiles(project)).entries.map(e => e.path);
@@ -476,7 +477,7 @@ describe("branches are explicit", () => {
     await checkoutBranch(h, "bob-work", { create: true });
     await writeFile(h, "merged.txt", "hello\n");
     await commitAgentTurn(WS, BOB);
-    await mergeBranchToMain(project, "bob-work");
+    await mergeBranchToMain(scopeOf(project), "bob-work");
 
     // The sandbox pulls on next touch — ordinary `git pull` on main.
     const resumed = await ensureWorktree(project, USER);
@@ -501,7 +502,7 @@ describe("branches are explicit", () => {
     await writeFile(userHandle, "b.txt", "from user\n");
     await commitWorktree(userHandle, "user change");
 
-    const merge = await mergeBranchToMain(project, "bob-a");
+    const merge = await mergeBranchToMain(scopeOf(project), "bob-a");
     expect(merge.merged).toBe(true);
     expect(merge.fastForward).toBe(false);
     const files = (await listFiles(project)).entries.map(e => e.path);
@@ -518,9 +519,9 @@ describe("branches are explicit", () => {
     await writeFile(user2, "a.txt", "conflicting user edit\n");
     await commitWorktree(user2, "user conflicting change");
 
-    await expect(mergeBranchToMain(project, "alice-a")).rejects.toThrow(
-      /conflict/i,
-    );
+    await expect(
+      mergeBranchToMain(scopeOf(project), "alice-a"),
+    ).rejects.toThrow(/conflict/i);
   });
 });
 

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -132,6 +132,20 @@ export function appRootFor(project: IAppProject): string {
 function appPath(project: IAppProject, relPath: string): string {
   return `${appRootFor(project)}/${assertSafeRelPath(relPath)}`;
 }
+
+/** Prefix a handle-relative path into its repo-relative form ("" root = repo). */
+function scopedPath(handle: WorktreeHandle, relPath: string): string {
+  const safe = assertSafeRelPath(relPath);
+  return handle.appRoot ? `${handle.appRoot}/${safe}` : safe;
+}
+
+/** The app this handle was opened for; workspace-scoped handles have none. */
+export function handleProject(handle: WorktreeHandle): IAppProject {
+  if (!handle.project) {
+    throw new Error("This operation requires an app-scoped worktree handle");
+  }
+  return handle.project;
+}
 import {
   getSandboxProvider,
   type SandboxExecContext,
@@ -213,10 +227,42 @@ export class WorktreeConflictError extends Error {
 
 export interface WorktreeHandle {
   doc: IAppWorktree;
-  project: IAppProject;
+  /** Absent for a workspace-scoped handle (Source Control, repo-level ops). */
+  project?: IAppProject;
   repoDir: string;
-  /** Repo-relative root of the app this handle was opened for. */
+  /** Repo-relative root this handle is scoped to; "" = the whole repo. */
   appRoot: string;
+}
+
+/**
+ * What repo-level reads operate on: the workspace repo, optionally narrowed
+ * to one content root. The repo is a WORKSPACE-level thing (§10) — an app is
+ * just one lens on it — so functions like status/history/branches take this
+ * instead of an IAppProject, and the Source Control surface needs no app
+ * handle at all.
+ */
+export interface RepoScope {
+  workspaceId: string;
+  /** Repo-relative content root to filter to; null = the whole repo. */
+  root: string | null;
+  defaultBranch: string;
+  /** Present when the scope is one app (window pokes carry the app id). */
+  projectId?: Types.ObjectId;
+}
+
+/** Scope of one app: its folder, its default branch. */
+export function scopeOf(project: IAppProject): RepoScope {
+  return {
+    workspaceId: project.workspaceId.toString(),
+    root: appRootFor(project),
+    defaultBranch: project.defaultBranch || DEFAULT_BRANCH,
+    projectId: project._id,
+  };
+}
+
+/** Scope of the whole workspace repo. */
+export function workspaceScope(workspaceId: string): RepoScope {
+  return { workspaceId, root: null, defaultBranch: DEFAULT_BRANCH };
 }
 
 /** Addresses the actor's sandbox — the one working copy. */
@@ -758,24 +804,11 @@ export async function deleteProject(project: IAppProject): Promise<void> {
  */
 export const PUBLISH_ACTOR = "publish";
 
-/**
- * Which branch an actor starts on when the caller does not name one: the
- * default branch, like a fresh clone on a laptop.
- *
- * Actors used to be forced onto a personal `user/<id>` branch ("you do not
- * edit production"). That guarded the wrong thing: publish deploys a PINNED
- * sha, so a commit on `main` moves the branch but ships nothing — exactly
- * like committing to main of a repo whose releases are tagged. Meanwhile the
- * forced branch made the everyday experience alien: everyone lived on a
- * branch named after their user id, and "just commit it" needed a merge
- * ceremony. Now the working copy is unrestricted, git-native; whoever wants
- * main protected does it at the remote (the git endpoint's pre-receive hook
- * carries GitHub's defaults — no force-push, no delete — and a mirrored
- * GitHub repo can layer its own rules).
- */
-export function defaultBranchForActor(_actorId: string): string {
-  return DEFAULT_BRANCH;
-}
+// The doctrine of which branch an actor starts on — and where each content
+// kind's commits land — lives in branch-policy.ts (apps.md §18). Re-exported
+// so existing importers keep working.
+export { defaultBranchForActor, sessionBranchFor } from "./branch-policy";
+import { defaultBranchForActor } from "./branch-policy";
 
 /**
  * Find-or-create the record of which branch this actor works on.
@@ -793,19 +826,47 @@ export async function ensureWorktree(
   actorId: string,
   options: { branch?: string } = {},
 ): Promise<WorktreeHandle> {
-  const repoDir = await repoFor(project);
+  const core = await ensureWorktreeCore(
+    project.workspaceId.toString(),
+    actorId,
+    options,
+  );
+  return { ...core, project, appRoot: appRootFor(project) };
+}
+
+/**
+ * The workspace-scoped handle: same session doc, same sandbox, no app lens.
+ * This is what repo-level surfaces (Source Control, workspace repo routes)
+ * use — the worktree was always keyed by (workspace, actor); only the code
+ * used to insist on an app to reach it.
+ */
+export async function ensureWorkspaceWorktree(
+  workspaceId: string,
+  actorId: string,
+  options: { branch?: string } = {},
+): Promise<WorktreeHandle> {
+  const core = await ensureWorktreeCore(workspaceId, actorId, options);
+  return { ...core, appRoot: "" };
+}
+
+async function ensureWorktreeCore(
+  workspaceId: string,
+  actorId: string,
+  options: { branch?: string } = {},
+): Promise<{ doc: IAppWorktree; repoDir: string }> {
+  const repoDir = await repoForWorkspace(workspaceId);
   if (!(await repoExists(repoDir))) {
-    throw new Error("Project repository is missing");
+    throw new Error("Workspace repository is missing");
   }
 
   const mainHead = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
-  if (!mainHead) throw new Error("Project branch is missing");
+  if (!mainHead) throw new Error("Workspace default branch is missing");
 
   // The doc remembers which branch this actor is on (checkoutBranch writes
   // it); an actor with no doc yet starts on the default branch, like a fresh
   // clone. options.branch overrides both (publish pins main explicitly).
   const existing = await AppWorktree.findOne({
-    workspaceId: project.workspaceId,
+    workspaceId: new Types.ObjectId(workspaceId),
     userId: actorId,
   });
   const branch =
@@ -818,10 +879,7 @@ export async function ensureWorktree(
     await updateRefCas(repoDir, `refs/heads/${branch}`, mainHead, ZERO_OID);
     branchHead = await resolveCommit(repoDir, `refs/heads/${branch}`);
     if (!branchHead) throw new Error(`Failed to create branch ${branch}`);
-    logger.info("Apps actor branch created", {
-      projectId: project._id.toString(),
-      branch,
-    });
+    logger.info("Apps actor branch created", { workspaceId, branch });
   }
 
   // No automatic merging of main into the actor's branch. That existed for
@@ -835,17 +893,12 @@ export async function ensureWorktree(
   // right after app creation, so a findOne+create pair races itself into
   // E11000 on the (workspaceId, userId) unique index.
   const doc = await AppWorktree.findOneAndUpdate(
-    { workspaceId: project.workspaceId, userId: actorId },
+    { workspaceId: new Types.ObjectId(workspaceId), userId: actorId },
     { $setOnInsert: { branch } },
     { new: true, upsert: true },
   );
 
-  return {
-    doc,
-    project,
-    repoDir,
-    appRoot: appRootFor(project),
-  };
+  return { doc, repoDir };
 }
 
 /**
@@ -1155,7 +1208,7 @@ export async function writeFile(
   relPath: string,
   contents: string,
 ): Promise<void> {
-  const safe = appPath(handle.project, relPath);
+  const safe = scopedPath(handle, relPath);
   if (Buffer.byteLength(contents, "utf8") > APPS_MAX_FILE_BYTES) {
     throw new Error("File exceeds the maximum size for a direct write");
   }
@@ -1180,7 +1233,7 @@ export async function readSessionFile(
   relPath: string,
 ): Promise<string> {
   const ctx = await ensureBox(handle);
-  const blob = await boxReadFile(ctx, appPath(handle.project, relPath));
+  const blob = await boxReadFile(ctx, scopedPath(handle, relPath));
   return blob.contents;
 }
 
@@ -1300,23 +1353,29 @@ export interface WorktreeStatus {
  * than presented as a clean tree.
  */
 export async function worktreeStatus(
-  project: IAppProject,
+  scope: RepoScope,
   userId: string,
 ): Promise<WorktreeStatus | null> {
-  const repoDir = await repoFor(project);
+  const repoDir = await repoForWorkspace(scope.workspaceId);
   const doc = await AppWorktree.findOne({
-    workspaceId: project.workspaceId,
+    workspaceId: new Types.ObjectId(scope.workspaceId),
     userId,
   });
   if (!doc) return null;
 
   const handle: WorktreeHandle = {
     doc,
-    project,
     repoDir,
-    appRoot: appRootFor(project),
+    appRoot: scope.root ?? "",
   };
   const ctx = boxCtx(handle);
+  const prefix = scope.root ? `${scope.root}/` : null;
+  const narrow = (changes: WorktreeStatus["repoChanges"]) =>
+    prefix
+      ? changes
+          .filter(ch => ch.path.startsWith(prefix))
+          .map(ch => ({ ...ch, path: ch.path.slice(prefix.length) }))
+      : changes;
 
   // Snapshot first: what the box's own agent pushed moments ago answers this
   // without three execs into the machine (~2s). The snapshot expires unless
@@ -1341,15 +1400,12 @@ export async function worktreeStatus(
       repoDir,
       `refs/heads/${snapshot.branch}`,
     );
-    const prefix = `${appRootFor(project)}/`;
     return {
       branch: snapshot.branch,
       baseSha: snapshot.head ?? branchHead ?? "",
       branchHead,
       ahead: snapshot.ahead ?? 0,
-      changes: snapshot.changes
-        .filter(ch => ch.path.startsWith(prefix))
-        .map(ch => ({ ...ch, path: ch.path.slice(prefix.length) })),
+      changes: narrow(snapshot.changes),
       repoChanges: snapshot.changes,
       offline: false,
     };
@@ -1379,15 +1435,12 @@ export async function worktreeStatus(
     repoDir,
     `refs/heads/${status.branch}`,
   );
-  const prefix = `${appRootFor(project)}/`;
   return {
     branch: status.branch,
     baseSha: status.head,
     branchHead,
     ahead: status.ahead,
-    changes: status.changes
-      .filter(ch => ch.path.startsWith(prefix))
-      .map(ch => ({ ...ch, path: ch.path.slice(prefix.length) })),
+    changes: narrow(status.changes),
     repoChanges: status.changes,
     offline: false,
   };
@@ -1413,17 +1466,17 @@ export async function defaultBranchSha(project: IAppProject): Promise<string> {
 }
 
 export async function projectHistory(
-  project: IAppProject,
+  scope: RepoScope,
   limit = 20,
   ref?: string,
-  scope: "app" | "repo" = "app",
+  view: "app" | "repo" = "app",
 ) {
-  const repoDir = await repoFor(project);
+  const repoDir = await repoForWorkspace(scope.workspaceId);
   // History follows the branch the caller is actually on (VS Code semantics),
   // falling back to the default branch when the ref is absent or bogus. The
   // shape check keeps user input out of argv option position; show-ref
   // verifies existence without ever resolving arbitrary expressions.
-  let target = `refs/heads/${project.defaultBranch || DEFAULT_BRANCH}`;
+  let target = `refs/heads/${scope.defaultBranch}`;
   if (ref && /^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(ref) && !ref.includes("..")) {
     const exists = await runGit(
       ["show-ref", "--verify", "--quiet", `refs/heads/${ref}`],
@@ -1438,7 +1491,7 @@ export async function projectHistory(
     repoDir,
     target,
     limit,
-    scope === "repo" ? undefined : appRootFor(project),
+    view === "repo" ? undefined : (scope.root ?? undefined),
   );
 }
 
@@ -1488,18 +1541,20 @@ export async function gitPathsAction(
  * the bare repo: no sandbox, no working copy.
  */
 export async function commitChanges(
-  project: IAppProject,
+  scope: RepoScope,
   sha: string,
   /** "repo": every file, repo-relative — the Source Control graph's view. */
-  scope: "app" | "repo" = "app",
+  view: "app" | "repo" = "app",
 ): Promise<{ sha: string; parent: string | null; files: ChangedFile[] }> {
-  const repoDir = await repoFor(project);
+  const repoDir = await repoForWorkspace(scope.workspaceId);
   const oid = await resolveCommit(repoDir, sha);
   if (!oid) throw new Error(`No such commit: ${sha}`);
   const parent = await resolveCommit(repoDir, `${oid}^`);
   const all = await diffNameStatus(repoDir, parent ?? EMPTY_TREE, oid);
-  if (scope === "repo") return { sha: oid, parent, files: all };
-  const root = appRootFor(project);
+  if (view === "repo" || scope.root == null) {
+    return { sha: oid, parent, files: all };
+  }
+  const root = scope.root;
   const files = all
     .filter(f => f.path.startsWith(`${root}/`))
     .map(f => ({ ...f, path: f.path.slice(root.length + 1) }));
@@ -1508,15 +1563,16 @@ export async function commitChanges(
 
 /** One app file before and after a commit (null = absent on that side). */
 export async function commitFileVersions(
-  project: IAppProject,
+  scope: RepoScope,
   sha: string,
   relPath: string,
 ): Promise<{ before: string | null; after: string | null; binary: boolean }> {
-  const repoDir = await repoFor(project);
+  const repoDir = await repoForWorkspace(scope.workspaceId);
   const oid = await resolveCommit(repoDir, sha);
   if (!oid) throw new Error(`No such commit: ${sha}`);
   const parent = await resolveCommit(repoDir, `${oid}^`);
-  const full = appPath(project, relPath);
+  const safe = assertSafeRelPath(relPath);
+  const full = scope.root ? `${scope.root}/${safe}` : safe;
   const read = async (ref: string | null) => {
     if (!ref) return null;
     try {
@@ -1701,10 +1757,8 @@ export interface BranchInfo {
   lastCommit?: { subject: string; author: string; timestamp: number };
 }
 
-export async function listBranches(
-  project: IAppProject,
-): Promise<BranchInfo[]> {
-  const repoDir = await repoFor(project);
+export async function listBranches(scope: RepoScope): Promise<BranchInfo[]> {
+  const repoDir = await repoForWorkspace(scope.workspaceId);
   const { stdout } = await runGit([
     "-C",
     repoDir,
@@ -1712,7 +1766,7 @@ export async function listBranches(
     "--format=%(refname:short)%00%(objectname)%00%(subject)%00%(authorname)%00%(authordate:unix)",
     "refs/heads/",
   ]);
-  const defaultBranch = project.defaultBranch || DEFAULT_BRANCH;
+  const defaultBranch = scope.defaultBranch;
   const branches: BranchInfo[] = [];
   for (const line of stdout.split("\n").filter(Boolean)) {
     const [name, head, subject, author, at] = line.split("\0");
@@ -1763,12 +1817,12 @@ export interface MergeResult {
  * with a structured error — v0 has no in-product conflict resolution.
  */
 export async function mergeBranchToMain(
-  project: IAppProject,
+  scope: RepoScope,
   branch: string,
   author?: GitAuthor,
 ): Promise<MergeResult> {
-  const repoDir = await repoFor(project);
-  const defaultBranch = project.defaultBranch || DEFAULT_BRANCH;
+  const repoDir = await repoForWorkspace(scope.workspaceId);
+  const defaultBranch = scope.defaultBranch;
   if (branch === defaultBranch) {
     return {
       merged: false,
@@ -1799,8 +1853,8 @@ export async function mergeBranchToMain(
     if (!swapped) {
       throw new WorktreeConflictError("Main advanced concurrently; retry.");
     }
-    queueMirrorPush(project.workspaceId.toString());
-    pokeApp(project.workspaceId, project._id, "merge");
+    queueMirrorPush(scope.workspaceId);
+    pokeApp(scope.workspaceId, scope.projectId ?? null, "merge");
     invalidatePullThrottle();
     return { merged: true, commitOid: branchHead, fastForward: true };
   } catch (error) {
@@ -1828,12 +1882,12 @@ export async function mergeBranchToMain(
     throw new WorktreeConflictError("Main advanced concurrently; retry.");
   }
   logger.info("Apps branch merged", {
-    projectId: project._id.toString(),
+    workspaceId: scope.workspaceId,
     branch,
     commitOid,
   });
-  queueMirrorPush(project.workspaceId.toString());
-  pokeApp(project.workspaceId, project._id, "merge");
+  queueMirrorPush(scope.workspaceId);
+  pokeApp(scope.workspaceId, scope.projectId ?? null, "merge");
   invalidatePullThrottle();
   return { merged: true, commitOid, fastForward: false };
 }
@@ -1945,7 +1999,7 @@ export async function trialMerge(
   author?: GitAuthor,
 ): Promise<TrialMergeResult> {
   const repoDir = handle.repoDir;
-  const mainBranch = handle.project.defaultBranch || DEFAULT_BRANCH;
+  const mainBranch = handle.project?.defaultBranch || DEFAULT_BRANCH;
 
   // A DISPOSABLE checkout, not a session. A merge needs a working directory,
   // but it does not need the actor's working copy and it certainly does not
@@ -2039,7 +2093,7 @@ export async function promoteToMain(
   handle: WorktreeHandle,
   input: { sha: string; expectedMain: string },
 ): Promise<void> {
-  const mainBranch = handle.project.defaultBranch || DEFAULT_BRANCH;
+  const mainBranch = handle.project?.defaultBranch || DEFAULT_BRANCH;
   const swapped = await updateRefCas(
     handle.repoDir,
     `refs/heads/${mainBranch}`,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -80,6 +80,7 @@ import {
   worktreeStatus,
   writeFile,
   repoForWorkspace,
+  scopeOf,
 } from "../apps/worktree.service";
 import { ensureWorkspaceTemplateSoon } from "../apps/workspace-template";
 import {
@@ -999,7 +1000,7 @@ appsRoutes.openapi(
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
       const userId = loaded.userId ?? "api-key";
-      const status = await worktreeStatus(loaded.project, userId);
+      const status = await worktreeStatus(scopeOf(loaded.project), userId);
       return c.json({ success: true as const, status }, 200);
     } catch (error) {
       return handleError(c, error);
@@ -1030,7 +1031,7 @@ appsRoutes.openapi(
       if ("errorResponse" in loaded) return loaded.errorResponse;
       const { limit, ref, scope } = c.req.valid("query");
       const commits = await projectHistory(
-        loaded.project,
+        scopeOf(loaded.project),
         limit ?? 20,
         ref,
         scope ?? "app",
@@ -1182,7 +1183,11 @@ appsRoutes.openapi(
       if ("errorResponse" in loaded) return loaded.errorResponse;
       const { path: relPath, sha } = c.req.valid("query");
       if (sha) {
-        const versions = await commitFileVersions(loaded.project, sha, relPath);
+        const versions = await commitFileVersions(
+          scopeOf(loaded.project),
+          sha,
+          relPath,
+        );
         return c.json({ success: true as const, versions }, 200);
       }
       const handle = await ensureWorktree(
@@ -1341,7 +1346,11 @@ appsRoutes.openapi(
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
       const { sha, scope } = c.req.valid("query");
-      const commit = await commitChanges(loaded.project, sha, scope ?? "app");
+      const commit = await commitChanges(
+        scopeOf(loaded.project),
+        sha,
+        scope ?? "app",
+      );
       return c.json({ success: true as const, commit }, 200);
     } catch (error) {
       return handleError(c, error);
@@ -1447,7 +1456,7 @@ appsRoutes.openapi(
     try {
       const loaded = await loadProject(c, { write: false });
       if ("errorResponse" in loaded) return loaded.errorResponse;
-      const branches = await listBranches(loaded.project);
+      const branches = await listBranches(scopeOf(loaded.project));
       return c.json({ success: true as const, branches }, 200);
     } catch (error) {
       return handleError(c, error);
@@ -1481,7 +1490,7 @@ appsRoutes.openapi(
       const { branch } = c.req.valid("json");
       const user = c.get("user");
       const result = await mergeBranchToMain(
-        loaded.project,
+        scopeOf(loaded.project),
         branch,
         user?.email ? { name: user.email, email: user.email } : undefined,
       );

--- a/api/src/routes/register-routes.ts
+++ b/api/src/routes/register-routes.ts
@@ -40,6 +40,7 @@ import { mcpPresetRoutes, mcpRoutes } from "./mcp.routes";
 import { mcpProtocolRoutes } from "./mcp-server.routes";
 import { mcpOAuthRoutes } from "./mcp-oauth.routes";
 import { appsRoutes } from "./apps";
+import { workspaceRepoRoutes } from "./workspace-repo";
 import { appsGitRoutes } from "./apps-git";
 import { appsBoxRoutes } from "./apps-box";
 import { appsPreviewRoutes } from "./apps-preview";
@@ -101,6 +102,9 @@ export function registerApiRoutes(app: OpenAPIHono<AuthEnv>): void {
   app.route("/api/workspaces/:workspaceId/notebooks", notebookSessionRoutes);
   // Apps (git-backed) — parallel to v1, always available (no feature flag).
   app.route("/api/workspaces/:workspaceId/apps", appsRoutes);
+  // The workspace repo itself (status, branches, commits, GitHub connect) —
+  // the repo is workspace infrastructure; apps/consoles/dbt are lenses on it.
+  app.route("/api/workspaces/:workspaceId/repo", workspaceRepoRoutes);
   app.route("/api/apps-preview", appsPreviewRoutes);
   // Intentionally public: the workspace repo over git's own HTTP protocol,
   // authorized by a scoped `mgt_` token. This is what makes a sandbox a

--- a/api/src/routes/workspace-repo.ts
+++ b/api/src/routes/workspace-repo.ts
@@ -1,0 +1,593 @@
+/**
+ * Workspace repository routes — the repo as a WORKSPACE-level thing.
+ *
+ * The workspace repo (§10: one bare repo per workspace; apps/, consoles/,
+ * skills/, later dbt/ are folders in it) used to be reachable only through an
+ * app handle: the Source Control panel grabbed `apps[0].id` and called
+ * app-scoped routes with `scope=repo`. That hack meant a workspace whose repo
+ * holds only consoles — or, after Block D3, only dbt — had no Source Control
+ * at all. These routes address the repo by what it is keyed by: the
+ * workspace. The app-scoped routes remain for app-scoped views (an app's own
+ * history popover).
+ *
+ * The GitHub connection endpoints live here too (install-url, branches):
+ * connecting a repo is workspace infrastructure, not an apps or dbt feature —
+ * this is where the appsStore's borrowed `/dbt/github/*` calls move to, so
+ * the dbt git surface can be deleted with Block D3 without breaking apps.
+ */
+import { createRoute, z } from "@hono/zod-openapi";
+import { Types } from "mongoose";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { workspaceService } from "../services/workspace.service";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
+import { GitHubInstallation } from "../database/workspace-schema";
+import { resolveRepoToken } from "../integrations/github/app-auth";
+import { signInstallState } from "../integrations/github/install-state";
+import { getGitHubAppSlug } from "../integrations/github/config";
+import { listBranches as listGithubBranches } from "../integrations/github/github-api";
+import { isValidRepoSegment } from "../services/workspace-repos.service";
+import {
+  DEFAULT_BRANCH,
+  repoDirFor,
+  repoExists,
+  resolveCommit,
+} from "../apps/repository.service";
+import {
+  WorktreeConflictError,
+  checkoutBranch,
+  commitChanges,
+  commitFileVersions,
+  commitWorktree,
+  ensureWorkspaceWorktree,
+  fileVersions,
+  gitPathsAction,
+  listBranches,
+  mergeBranchToMain,
+  projectHistory,
+  worktreeStatus,
+  workspaceScope,
+} from "../apps/worktree.service";
+
+const logger = loggers.api("workspace-repo");
+
+export const workspaceRepoRoutes = createRouter();
+
+const WorkspaceParam = z.object({
+  workspaceId: z
+    .string()
+    .openapi({ param: { name: "workspaceId", in: "path" } }),
+});
+
+workspaceRepoRoutes.use("*", unifiedAuthMiddleware);
+
+workspaceRepoRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (workspaceId) {
+    const user = c.get("user");
+    const workspace = c.get("workspace");
+    if (workspace) {
+      if (workspace._id.toString() !== workspaceId) {
+        return c.json(
+          {
+            success: false,
+            error: "API key not authorized for this workspace",
+          },
+          403,
+        );
+      }
+    } else if (user) {
+      const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+      if (!hasAccess) {
+        return c.json(
+          { success: false, error: "Access denied to workspace" },
+          403,
+        );
+      }
+    } else {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    enrichContextWithWorkspace(workspaceId);
+  }
+  await next();
+});
+
+function actingUserId(c: AuthenticatedContext): string {
+  return c.get("user")?.id ?? "api-key";
+}
+
+function handleError(c: AuthenticatedContext, error: unknown) {
+  if (error instanceof WorktreeConflictError) {
+    return c.json({ success: false, error: error.message }, 409);
+  }
+  logger.error("Workspace repo route error", { error });
+  return c.json(
+    {
+      success: false,
+      error: error instanceof Error ? error.message : "Internal error",
+    },
+    500,
+  );
+}
+
+const SafeRepoPath = z
+  .string()
+  .min(1)
+  .max(4096)
+  .refine(
+    p => !p.startsWith("/") && !p.split("/").includes(".."),
+    "path must stay inside the repository",
+  );
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/status",
+    tags: ["Workspace repo"],
+    summary: "Workspace repo status for the caller's session",
+    description:
+      "Repo-wide worktree status: the sandbox's working copy when it is running, the last commit on the caller's branch when it is not. `hasRepo: false` when the workspace has no repo yet. Never starts a sandbox.",
+    security: AUTH_SECURITY,
+    request: { params: WorkspaceParam },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const repoDir = repoDirFor(workspaceId);
+      if (!(await repoExists(repoDir))) {
+        return c.json(
+          { success: true as const, hasRepo: false as const, status: null },
+          200,
+        );
+      }
+      const userId = actingUserId(c);
+      const status = await worktreeStatus(workspaceScope(workspaceId), userId);
+      if (status) {
+        return c.json({ success: true as const, hasRepo: true, status }, 200);
+      }
+      // No session yet: report the default branch at rest, like a code host
+      // would — the panel is read-only until the first mutation creates a
+      // session anyway.
+      const branchHead = await resolveCommit(
+        repoDir,
+        `refs/heads/${DEFAULT_BRANCH}`,
+      );
+      return c.json(
+        {
+          success: true as const,
+          hasRepo: true,
+          status: {
+            branch: DEFAULT_BRANCH,
+            baseSha: branchHead ?? "",
+            branchHead,
+            ahead: 0,
+            changes: [],
+            repoChanges: [],
+            offline: true,
+          },
+        },
+        200,
+      );
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// History / commit inspection
+// ---------------------------------------------------------------------------
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/history",
+    tags: ["Workspace repo"],
+    summary: "Commit history of a branch (defaults to the default branch)",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      query: z.object({
+        limit: z.coerce.number().int().positive().max(200).optional(),
+        ref: z.string().max(200).optional(),
+      }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { limit, ref } = c.req.valid("query");
+      const commits = await projectHistory(
+        workspaceScope(workspaceId),
+        limit ?? 20,
+        ref,
+        "repo",
+      );
+      return c.json({ success: true as const, commits }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/git/commit",
+    tags: ["Workspace repo"],
+    summary: "Files changed by one commit (repo-relative paths)",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      query: z.object({ sha: z.string().regex(/^[0-9a-f]{7,40}$/) }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { sha } = c.req.valid("query");
+      const commit = await commitChanges(
+        workspaceScope(workspaceId),
+        sha,
+        "repo",
+      );
+      return c.json({ success: true as const, commit }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/git/file-versions",
+    tags: ["Workspace repo"],
+    summary: "HEAD, index and working-tree contents of a repo path (for diffs)",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      query: z.object({
+        path: SafeRepoPath,
+        /**
+         * With a commit: the file before and after THAT commit, read from the
+         * repo — no sandbox. Without: HEAD / index / working tree of the
+         * caller's box.
+         */
+        sha: z
+          .string()
+          .regex(/^[0-9a-f]{7,40}$/)
+          .optional(),
+      }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { path: relPath, sha } = c.req.valid("query");
+      if (sha) {
+        const versions = await commitFileVersions(
+          workspaceScope(workspaceId),
+          sha,
+          relPath,
+        );
+        return c.json({ success: true as const, versions }, 200);
+      }
+      const handle = await ensureWorkspaceWorktree(
+        workspaceId,
+        actingUserId(c),
+      );
+      const versions = await fileVersions(handle, relPath);
+      return c.json({ success: true as const, versions }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Branches
+// ---------------------------------------------------------------------------
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/branches",
+    tags: ["Workspace repo"],
+    summary: "List branches",
+    security: AUTH_SECURITY,
+    request: { params: WorkspaceParam },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const branches = await listBranches(workspaceScope(workspaceId));
+      return c.json({ success: true as const, branches }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/checkout",
+    tags: ["Workspace repo"],
+    summary: "Switch the caller's session to a branch (git checkout)",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              branch: z.string().min(1).max(200),
+              create: z.boolean().optional(),
+            }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { branch, create } = c.req.valid("json");
+      const handle = await ensureWorkspaceWorktree(
+        workspaceId,
+        actingUserId(c),
+      );
+      const result = await checkoutBranch(handle, branch, { create });
+      return c.json({ success: true as const, result }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/merge",
+    tags: ["Workspace repo"],
+    summary: "Merge a branch into the default branch",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({ branch: z.string().min(1).max(200) }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { branch } = c.req.valid("json");
+      const user = c.get("user");
+      const result = await mergeBranchToMain(
+        workspaceScope(workspaceId),
+        branch,
+        user?.email ? { name: user.email, email: user.email } : undefined,
+      );
+      return c.json({ success: true as const, result }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Commit + per-file git actions (the Source Control panel's verbs)
+// ---------------------------------------------------------------------------
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/commit",
+    tags: ["Workspace repo"],
+    summary: "Commit the caller's working copy onto their branch",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              message: z.string().min(1),
+              /** Commit only the index (a non-empty Staged group). */
+              stagedOnly: z.boolean().optional(),
+            }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { message, stagedOnly } = c.req.valid("json");
+      const user = c.get("user");
+      const handle = await ensureWorkspaceWorktree(
+        workspaceId,
+        actingUserId(c),
+      );
+      const result = await commitWorktree(
+        handle,
+        message,
+        user?.email ? { name: user.email, email: user.email } : undefined,
+        { stagedOnly },
+      );
+      return c.json({ success: true as const, result }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+const RepoPaths = z.object({
+  paths: z.array(SafeRepoPath).min(1).max(500),
+});
+
+for (const action of ["stage", "unstage", "discard"] as const) {
+  workspaceRepoRoutes.openapi(
+    createRoute({
+      method: "post",
+      path: `/git/${action}`,
+      tags: ["Workspace repo"],
+      summary:
+        action === "stage"
+          ? "Stage files for commit (git add)"
+          : action === "unstage"
+            ? "Unstage files (git reset HEAD --)"
+            : "Discard working-tree changes to files (checkout / clean)",
+      security: AUTH_SECURITY,
+      request: {
+        params: WorkspaceParam,
+        body: { content: { "application/json": { schema: RepoPaths } } },
+      },
+      responses: OPEN_RESPONSES,
+    }),
+    async c => {
+      try {
+        const { workspaceId } = c.req.valid("param");
+        const { paths } = c.req.valid("json");
+        const handle = await ensureWorkspaceWorktree(
+          workspaceId,
+          actingUserId(c),
+        );
+        await gitPathsAction(handle, action, paths);
+        return c.json({ success: true as const }, 200);
+      } catch (error) {
+        return handleError(c, error);
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GitHub connection (workspace infrastructure, not an apps/dbt feature)
+// ---------------------------------------------------------------------------
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/github/install-url",
+    tags: ["Workspace repo"],
+    summary: "Signed GitHub App install URL (admin+)",
+    security: AUTH_SECURITY,
+    request: { params: WorkspaceParam },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const slug = getGitHubAppSlug();
+      if (!slug) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "GitHub App is not configured (set GITHUB_APP_SLUG/GITHUB_APP_ID)",
+          },
+          400,
+        );
+      }
+      // Connecting a repo is a deployment-config mutation → admin+ (the
+      // /setup callback consumes this signed state).
+      const user = c.get("user");
+      if (!user || !(await workspaceService.isAdmin(workspaceId, user.id))) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Connecting GitHub requires the admin or owner workspace role",
+          },
+          403,
+        );
+      }
+      const returnClientUrl = process.env.CLIENT_URL || "http://localhost:5173";
+      // Signed, short-lived state pins the workspace + initiating user so the
+      // /setup callback cannot be forged to bind an arbitrary installation.
+      const state = signInstallState({
+        workspaceId,
+        userId: user.id,
+        clientUrl: returnClientUrl,
+      });
+      return c.json(
+        {
+          success: true as const,
+          url: `https://github.com/apps/${slug}/installations/new?state=${state}`,
+        },
+        200,
+      );
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+workspaceRepoRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/github/branches",
+    tags: ["Workspace repo"],
+    summary: "Branch names of a GitHub repo (connect/link UI)",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      query: z.object({
+        owner: z.string().min(1),
+        repo: z.string().min(1),
+        installationId: z.coerce.number().int().positive().optional(),
+      }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const { owner, repo, installationId } = c.req.valid("query");
+      if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+        return c.json(
+          { success: false, error: "Invalid owner or repo name" },
+          400,
+        );
+      }
+      if (installationId) {
+        const installation = await GitHubInstallation.findOne({
+          workspaceId: new Types.ObjectId(workspaceId),
+          installationId,
+        });
+        if (!installation) {
+          return c.json(
+            { success: false, error: "Installation not found" },
+            404,
+          );
+        }
+      }
+      const token = await resolveRepoToken(installationId);
+      const branches = await listGithubBranches(owner, repo, token);
+      return c.json({ success: true as const, branches }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "src/apps/worktree.service.test.ts",
+      "src/apps/workspace-repo.test.ts",
       "src/apps/bindings.service.test.ts",
       "src/apps/cloud-repo.service.test.ts",
       "src/apps/adversarial.test.ts",

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -1421,57 +1421,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List console versions */
-        get: operations["get_api_workspaces_workspaceId_consoles_id_versions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions/{version}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** GET /{id}/versions/{version} */
-        get: operations["get_api_workspaces_workspaceId_consoles_id_versions_version"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions/{version}/restore": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** POST /{id}/versions/{version}/restore */
-        post: operations["post_api_workspaces_workspaceId_consoles_id_versions_version_restore"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/workspaces/{workspaceId}/realtime": {
         parameters: {
             query?: never;
@@ -4401,6 +4350,230 @@ export interface paths {
         };
         /** Reveal App public-share password */
         get: operations["get_api_workspaces_workspaceId_apps_id_public_share_password"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Workspace repo status for the caller's session
+         * @description Repo-wide worktree status: the sandbox's working copy when it is running, the last commit on the caller's branch when it is not. `hasRepo: false` when the workspace has no repo yet. Never starts a sandbox.
+         */
+        get: operations["get_api_workspaces_workspaceId_repo_status"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Commit history of a branch (defaults to the default branch) */
+        get: operations["get_api_workspaces_workspaceId_repo_history"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/git/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Files changed by one commit (repo-relative paths) */
+        get: operations["get_api_workspaces_workspaceId_repo_git_commit"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/git/file-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** HEAD, index and working-tree contents of a repo path (for diffs) */
+        get: operations["get_api_workspaces_workspaceId_repo_git_file_versions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List branches */
+        get: operations["get_api_workspaces_workspaceId_repo_branches"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Switch the caller's session to a branch (git checkout) */
+        post: operations["post_api_workspaces_workspaceId_repo_checkout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/merge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Merge a branch into the default branch */
+        post: operations["post_api_workspaces_workspaceId_repo_merge"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Commit the caller's working copy onto their branch */
+        post: operations["post_api_workspaces_workspaceId_repo_commit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/git/stage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Stage files for commit (git add) */
+        post: operations["post_api_workspaces_workspaceId_repo_git_stage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/git/unstage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unstage files (git reset HEAD --) */
+        post: operations["post_api_workspaces_workspaceId_repo_git_unstage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/git/discard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Discard working-tree changes to files (checkout / clean) */
+        post: operations["post_api_workspaces_workspaceId_repo_git_discard"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/github/install-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Signed GitHub App install URL (admin+) */
+        get: operations["get_api_workspaces_workspaceId_repo_github_install_url"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/repo/github/branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Branch names of a GitHub repo (connect/link UI) */
+        get: operations["get_api_workspaces_workspaceId_repo_github_branches"];
         put?: never;
         post?: never;
         delete?: never;
@@ -10141,140 +10314,6 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            "2XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
-                };
-            };
-            /** @description Invalid request */
-            "4XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-            /** @description Internal server error */
-            "5XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-        };
-    };
-    get_api_workspaces_workspaceId_consoles_id_versions: {
-        parameters: {
-            query?: {
-                limit?: string;
-                offset?: string;
-            };
-            header?: never;
-            path: {
-                workspaceId: string;
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            "2XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
-                };
-            };
-            /** @description Invalid request */
-            "4XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-            /** @description Internal server error */
-            "5XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-        };
-    };
-    get_api_workspaces_workspaceId_consoles_id_versions_version: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceId: string;
-                id: string;
-                version: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            "2XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
-                };
-            };
-            /** @description Invalid request */
-            "4XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-            /** @description Internal server error */
-            "5XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorEnvelope"];
-                };
-            };
-        };
-    };
-    post_api_workspaces_workspaceId_consoles_id_versions_version_restore: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceId: string;
-                id: string;
-                version: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
-            };
-        };
         responses: {
             /** @description Successful response */
             "2XX": {
@@ -19587,6 +19626,576 @@ export interface operations {
             path: {
                 workspaceId: string;
                 id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_status: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_history: {
+        parameters: {
+            query?: {
+                limit?: number;
+                ref?: string;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_git_commit: {
+        parameters: {
+            query: {
+                sha: string;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_git_file_versions: {
+        parameters: {
+            query: {
+                path: string;
+                sha?: string;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_branches: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_checkout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    branch: string;
+                    create?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_merge: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    branch: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_commit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    message: string;
+                    stagedOnly?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_git_stage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    paths: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_git_unstage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    paths: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_repo_git_discard: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    paths: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_github_install_url: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_repo_github_branches: {
+        parameters: {
+            query: {
+                owner: string;
+                repo: string;
+                installationId?: number;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
             };
             cookie?: never;
         };

--- a/app/src/apps-runtime/shell.ts
+++ b/app/src/apps-runtime/shell.ts
@@ -76,6 +76,37 @@ export function focusAppsDiffTab(
 }
 
 /**
+ * A workspace-repo diff tab: any repo path, no app handle. The Source
+ * Control panel's "Open Changes", and the graph's per-commit file diffs.
+ */
+export function focusRepoDiffTab(
+  path: string,
+  mode: "working" | "index" | "commit",
+  /** "commit" mode: the commit whose change to `path` is shown. */
+  sha?: string,
+): string {
+  const fileName = basename(path);
+  const label =
+    mode === "commit"
+      ? (sha ?? "").slice(0, 7)
+      : mode === "index"
+        ? "Index"
+        : "Working Tree";
+  return useConsoleStore.getState().focusOrOpenTab(
+    {
+      kind: "repo-diff",
+      metadata: { path, mode, ...(mode === "commit" ? { sha } : {}) },
+    },
+    () => ({
+      title: `${fileName} (${label})`,
+      content: "",
+      kind: "repo-diff",
+      metadata: { path, mode, sha },
+    }),
+  ) as string;
+}
+
+/**
  * Close any `app` / `app-file` tab pointing at an app that no longer
  * exists, and report whether anything was closed.
  *

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -73,6 +73,7 @@ import AppWorkspace from "./AppWorkspace";
 import AppFileEditor from "./AppFileEditor";
 import AppDiffTab from "./AppDiffTab";
 import ConsoleDiffTab from "./ConsoleDiffTab";
+import RepoDiffTab from "./RepoDiffTab";
 import ConsoleHistoryPopover from "./ConsoleHistoryPopover";
 import AppBindingEditor from "./AppBindingEditor";
 import PlanDocumentTab from "./PlanDocumentTab";
@@ -2891,6 +2892,17 @@ function Editor({
                       consoleId={tab.metadata?.consoleId as string}
                       path={tab.metadata?.path as string}
                       sha={tab.metadata?.sha as string}
+                    />
+                  ) : tab.kind === "repo-diff" ? (
+                    <RepoDiffTab
+                      path={tab.metadata?.path as string}
+                      mode={
+                        (tab.metadata?.mode as
+                          | "working"
+                          | "index"
+                          | "commit") ?? "working"
+                      }
+                      sha={tab.metadata?.sha as string | undefined}
                     />
                   ) : tab.kind === "app-diff" ? (
                     <AppDiffTab

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -101,6 +101,10 @@ function segmentsForTab(
       const path = (tab.metadata?.path as string | undefined) || "";
       return plain(["Source Control", ...path.split("/").filter(Boolean)]);
     }
+    case "repo-diff": {
+      const path = (tab.metadata?.path as string | undefined) || "";
+      return plain(["Source Control", ...path.split("/").filter(Boolean)]);
+    }
     case "connectors":
       return plain(["Connectors", tab.title || "New connector"]);
     case "flow-editor":

--- a/app/src/components/RepoDiffTab.tsx
+++ b/app/src/components/RepoDiffTab.tsx
@@ -1,0 +1,127 @@
+/**
+ * A git diff of one repo file, opened from the Source Control view —
+ * VS Code's "Open Changes", addressed by WORKSPACE, not by app. Works for
+ * any path in the workspace repo (apps/, consoles/, skills/, later dbt/),
+ * which is what lets the panel exist in a workspace with no apps at all.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@mui/material";
+import { SquareArrowOutUpRight as OpenIcon } from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useAppsStore, type AppFileVersions } from "../store/appsStore";
+import { useRepoStore } from "../store/repoStore";
+import { focusAppsFileTab } from "../apps-runtime/shell";
+import { GitFileDiffView } from "./GitFileDiffView";
+
+export default function RepoDiffTab({
+  path,
+  mode,
+  sha,
+}: {
+  path: string;
+  /** "commit": what `sha` did to this file (parent → sha), from the repo. */
+  mode: "working" | "index" | "commit";
+  sha?: string;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const fetchFileVersions = useRepoStore(s => s.fetchFileVersions);
+  const fetchCommitFileVersions = useRepoStore(s => s.fetchCommitFileVersions);
+  const apps = useAppsStore(s => s.apps);
+  // The row for this path in the pushed status: any change to it (staged,
+  // discarded, edited in a shell) is the cue to re-read the versions.
+  const stamp = useRepoStore(s => {
+    const change = workspaceId
+      ? s.statusByWorkspace[workspaceId]?.repoChanges.find(c => c.path === path)
+      : undefined;
+    return change
+      ? `${change.status}:${change.staged}:${change.unstaged}`
+      : "clean";
+  });
+
+  const [versions, setVersions] = useState<AppFileVersions | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    let cancelled = false;
+    setLoading(true);
+    const load =
+      mode === "commit" && sha
+        ? // A commit is immutable: fold its two sides into the same shape
+          // the box versions use, so the rest of this view is unchanged.
+          fetchCommitFileVersions(workspaceId, sha, path).then(v =>
+            v
+              ? {
+                  head: v.before,
+                  index: v.after,
+                  working: v.after,
+                  binary: v.binary,
+                }
+              : null,
+          )
+        : fetchFileVersions(workspaceId, path);
+    void load.then(v => {
+      if (cancelled) return;
+      setVersions(v);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    workspaceId,
+    path,
+    mode,
+    sha,
+    stamp,
+    fetchFileVersions,
+    fetchCommitFileVersions,
+  ]);
+
+  const original =
+    mode === "working" ? (versions?.index ?? versions?.head) : versions?.head;
+  const modified = mode === "working" ? versions?.working : versions?.index;
+
+  // "Open File": only when the path lives inside an app this window knows,
+  // since file tabs are addressed app-relatively. Console and (later) dbt
+  // paths grow their own openers with their explorer integrations.
+  const owner = useMemo(() => {
+    for (const app of apps) {
+      if (app.slug && path.startsWith(`apps/${app.slug}/`)) {
+        return { app, rel: path.slice(`apps/${app.slug}/`.length) };
+      }
+    }
+    return null;
+  }, [apps, path]);
+
+  return (
+    <GitFileDiffView
+      path={path}
+      label={
+        mode === "commit"
+          ? `${(sha ?? "").slice(0, 7)}^ → ${(sha ?? "").slice(0, 7)}`
+          : mode === "index"
+            ? "HEAD → Index"
+            : "Index → Working Tree"
+      }
+      original={original}
+      modified={modified}
+      binary={versions?.binary}
+      loading={loading && !versions}
+      action={
+        owner ? (
+          <Button
+            size="small"
+            startIcon={<OpenIcon size={14} />}
+            onClick={() =>
+              focusAppsFileTab(owner.app.id, owner.rel, owner.app.slug)
+            }
+          >
+            Open file
+          </Button>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import { useConnectorStore } from "../store/connectorStore";
 import { useFlowStore } from "../store/flowStore";
 import { useChatStore } from "../store/chatStore";
 import { useExplorerStore } from "../store/explorerStore";
-import { useAppsStore } from "../store/appsStore";
+import { useRepoStore } from "../store/repoStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { trackEvent, resetIdentity } from "../lib/analytics";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -96,22 +96,18 @@ const topNavigationItems: {
 function useRepoDirty(enabled: boolean): boolean {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
-  const appId = useAppsStore(state => state.apps[0]?.id);
-  const fetchStatus = useAppsStore(state => state.fetchStatus);
-  const dirty = useAppsStore(state =>
-    Object.values(state.statusByApp).some(
-      status => (status?.repoChanges?.length ?? 0) > 0,
-    ),
+  const fetchStatus = useRepoStore(state => state.fetchStatus);
+  const dirty = useRepoStore(state =>
+    workspaceId
+      ? (state.statusByWorkspace[workspaceId]?.repoChanges?.length ?? 0) > 0
+      : false,
   );
   useEffect(() => {
-    if (!enabled || !workspaceId || !appId) return;
-    void fetchStatus(workspaceId, appId);
-    const timer = setInterval(
-      () => void fetchStatus(workspaceId, appId),
-      30_000,
-    );
+    if (!enabled || !workspaceId) return;
+    void fetchStatus(workspaceId);
+    const timer = setInterval(() => void fetchStatus(workspaceId), 30_000);
     return () => clearInterval(timer);
-  }, [enabled, workspaceId, appId, fetchStatus]);
+  }, [enabled, workspaceId, fetchStatus]);
   return dirty;
 }
 

--- a/app/src/components/SourceControlExplorer.tsx
+++ b/app/src/components/SourceControlExplorer.tsx
@@ -12,9 +12,9 @@
  * listed here are the repo-wide set — the same set a branch switch has to get
  * past, which the app-scoped view once hid.
  *
- * The apps API is addressed per app, but status/commit/history all operate
- * on the workspace repo, so any app id works as a handle; the first one
- * serves. No apps yet means no repo to control.
+ * Addressed by WORKSPACE via the `/repo/*` routes — no app handle. A repo
+ * that holds only consoles (or, after Block D3, only dbt) gets the same
+ * panel as one full of apps.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -59,16 +59,19 @@ import {
   type AppCommit,
   type AppCommitFile,
 } from "../store/appsStore";
+import { useRepoStore } from "../store/repoStore";
 import { CommitRow } from "./CommitRow";
 import {
   useConsoleStore,
   selectTabBySettingsSection,
 } from "../store/consoleStore";
 import { SECTION_LABELS } from "../pages/settings/sections";
-import { focusAppsDiffTab, focusAppsFileTab } from "../apps-runtime/shell";
+import { focusAppsFileTab, focusRepoDiffTab } from "../apps-runtime/shell";
 import VSScrollArea from "./VSScrollArea";
 import { basename, dirname } from "../utils/path";
 import { ConfirmDialog } from "./ConfirmDialog";
+
+const EMPTY_FILES: Record<string, AppCommitFile[]> = {};
 
 /** VS Code's status letters, in VS Code's colors. */
 const STATUS_STYLE: Record<
@@ -259,18 +262,22 @@ export default function SourceControlExplorer() {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
 
+  // Apps are only needed to map `apps/<slug>/…` paths onto app file tabs.
   const apps = useAppsStore(s => s.apps);
   const fetchApps = useAppsStore(s => s.fetchApps);
-  const statusByApp = useAppsStore(s => s.statusByApp);
-  const historyByApp = useAppsStore(s => s.repoHistoryByApp);
-  const fetchStatus = useAppsStore(s => s.fetchStatus);
-  const fetchHistory = useAppsStore(s => s.fetchHistory);
-  const commit = useAppsStore(s => s.commit);
+  const fetchStatus = useRepoStore(s => s.fetchStatus);
+  const fetchHistory = useRepoStore(s => s.fetchHistory);
+  const commit = useRepoStore(s => s.commit);
 
-  // Any app id reaches the workspace repo; the first one is the handle.
-  const appId = apps[0]?.id;
-  const status = appId ? statusByApp[appId] : undefined;
-  const history = appId ? historyByApp[appId] : undefined;
+  const hasRepo = useRepoStore(s =>
+    workspaceId ? s.hasRepoByWorkspace[workspaceId] : undefined,
+  );
+  const status = useRepoStore(s =>
+    workspaceId ? s.statusByWorkspace[workspaceId] : undefined,
+  );
+  const history = useRepoStore(s =>
+    workspaceId ? s.historyByWorkspace[workspaceId] : undefined,
+  );
   const changes = useMemo(() => status?.repoChanges ?? [], [status]);
   // VS Code's two groups. A file can be in both (staged, then edited again).
   // Older status payloads carry no flags: treat them as unstaged.
@@ -279,7 +286,7 @@ export default function SourceControlExplorer() {
     () => changes.filter(c => c.unstaged ?? !c.staged),
     [changes],
   );
-  const gitPaths = useAppsStore(s => s.gitPaths);
+  const gitPaths = useRepoStore(s => s.gitPaths);
   const [confirm, setConfirm] = useState<{
     title: string;
     body: string;
@@ -289,14 +296,14 @@ export default function SourceControlExplorer() {
 
   const runGit = useCallback(
     async (action: "stage" | "unstage" | "discard", paths: string[]) => {
-      if (!workspaceId || !appId || paths.length === 0) return;
+      if (!workspaceId || paths.length === 0) return;
       setActing(true);
       setError(null);
-      const result = await gitPaths(workspaceId, appId, action, paths);
+      const result = await gitPaths(workspaceId, action, paths);
       setActing(false);
       if (!result.ok) setError(result.error ?? `Could not ${action}`);
     },
-    [workspaceId, appId, gitPaths],
+    [workspaceId, gitPaths],
   );
 
   // Opening a change = its diff (VS Code's "Open Changes"); the inline
@@ -312,14 +319,9 @@ export default function SourceControlExplorer() {
     },
     [apps],
   );
-  const openDiff = useCallback(
-    (path: string, mode: "working" | "index") => {
-      if (!appId) return;
-      const owner = ownerOf(path);
-      focusAppsDiffTab(owner?.app.id ?? appId, path, mode, owner?.app.slug);
-    },
-    [appId, ownerOf],
-  );
+  const openDiff = useCallback((path: string, mode: "working" | "index") => {
+    focusRepoDiffTab(path, mode);
+  }, []);
   const openFile = useCallback(
     (path: string) => {
       const owner = ownerOf(path);
@@ -359,10 +361,10 @@ export default function SourceControlExplorer() {
   }, [workspaceId, fetchApps]);
 
   const refresh = useCallback(() => {
-    if (!workspaceId || !appId) return;
-    void fetchStatus(workspaceId, appId);
-    void fetchHistory(workspaceId, appId, "repo");
-  }, [workspaceId, appId, fetchStatus, fetchHistory]);
+    if (!workspaceId) return;
+    void fetchStatus(workspaceId);
+    void fetchHistory(workspaceId);
+  }, [workspaceId, fetchStatus, fetchHistory]);
 
   useEffect(refresh, [refresh]);
 
@@ -370,30 +372,30 @@ export default function SourceControlExplorer() {
   // status call (branch unknown -> default branch). Refetch once it lands.
   const currentBranch = status?.branch;
   useEffect(() => {
-    if (workspaceId && appId && currentBranch) {
-      void fetchHistory(workspaceId, appId, "repo");
+    if (workspaceId && currentBranch) {
+      void fetchHistory(workspaceId);
     }
-  }, [workspaceId, appId, currentBranch, fetchHistory]);
+  }, [workspaceId, currentBranch, fetchHistory]);
 
   const handleCommit = useCallback(async () => {
-    if (!workspaceId || !appId || !message.trim() || committing) return;
+    if (!workspaceId || !message.trim() || committing) return;
     setCommitting(true);
     setError(null);
-    const result = await commit(workspaceId, appId, message.trim(), {
+    const result = await commit(workspaceId, message.trim(), {
       stagedOnly: staged.length > 0,
     });
     setCommitting(false);
     if (result.ok) setMessage("");
     else setError(result.error ?? "Commit failed");
-  }, [workspaceId, appId, message, committing, commit, staged.length]);
+  }, [workspaceId, message, committing, commit, staged.length]);
 
   const branch = status?.branch ?? "…";
-  const branches = useAppsStore(s =>
-    appId ? s.branchesByApp[appId] : undefined,
+  const branches = useRepoStore(s =>
+    workspaceId ? s.branchesByWorkspace[workspaceId] : undefined,
   );
-  const fetchBranches = useAppsStore(s => s.fetchBranches);
-  const checkoutBranch = useAppsStore(s => s.checkoutBranch);
-  const mergeBranch = useAppsStore(s => s.mergeBranch);
+  const fetchBranches = useRepoStore(s => s.fetchBranches);
+  const checkoutBranch = useRepoStore(s => s.checkoutBranch);
+  const mergeBranch = useRepoStore(s => s.mergeBranch);
   const [merging, setMerging] = useState(false);
   // The current branch's entry in the listing — what "Merge into main" acts
   // on. Only offered for a non-default branch that is actually ahead.
@@ -401,20 +403,19 @@ export default function SourceControlExplorer() {
   const canMerge =
     !!currentEntry && !currentEntry.isDefault && currentEntry.aheadOfMain > 0;
   const mergeCurrent = useCallback(async () => {
-    if (!workspaceId || !appId || !currentEntry || merging) return;
+    if (!workspaceId || !currentEntry || merging) return;
     setMerging(true);
     setError(null);
-    const result = await mergeBranch(workspaceId, appId, currentEntry.name);
+    const result = await mergeBranch(workspaceId, currentEntry.name);
     setMerging(false);
     setBranchAnchor(null);
     if (!result.ok) setError(result.error ?? "Merge failed");
     else {
-      void fetchStatus(workspaceId, appId);
-      void fetchHistory(workspaceId, appId, "repo");
+      void fetchStatus(workspaceId);
+      void fetchHistory(workspaceId);
     }
   }, [
     workspaceId,
-    appId,
     currentEntry,
     merging,
     mergeBranch,
@@ -424,36 +425,32 @@ export default function SourceControlExplorer() {
 
   const switchTo = useCallback(
     async (target: string, options?: { create?: boolean }) => {
-      if (!workspaceId || !appId || switching) return;
+      if (!workspaceId || switching) return;
       setSwitching(true);
       setError(null);
-      const failure = await checkoutBranch(workspaceId, appId, target, options);
+      const failure = await checkoutBranch(workspaceId, target, options);
       setSwitching(false);
       setBranchAnchor(null);
       setCreateOpen(false);
       if (failure) setError(failure);
       else {
         setNewBranchName("");
-        void fetchHistory(workspaceId, appId, "repo");
+        void fetchHistory(workspaceId);
       }
     },
-    [workspaceId, appId, switching, checkoutBranch, fetchHistory],
+    [workspaceId, switching, checkoutBranch, fetchHistory],
   );
 
   const commits = useMemo(() => history ?? [], [history]);
 
   // Graph rows are the SAME CommitRow the app History popover uses — with
   // repo-wide changed files, since the graph is the whole repository.
-  const fetchCommitFiles = useAppsStore(s => s.fetchCommitFiles);
-  const commitFilesByApp = useAppsStore(s => s.commitFilesByApp);
-  const graphFiles = useMemo(() => {
-    const byKey = appId ? (commitFilesByApp[appId] ?? {}) : {};
-    const out: Record<string, AppCommitFile[]> = {};
-    for (const [key, files] of Object.entries(byKey)) {
-      if (key.startsWith("repo:")) out[key.slice(5)] = files;
-    }
-    return out;
-  }, [commitFilesByApp, appId]);
+  const fetchCommitFiles = useRepoStore(s => s.fetchCommitFiles);
+  const graphFiles = useRepoStore(s =>
+    workspaceId
+      ? (s.commitFilesByWorkspace[workspaceId] ?? EMPTY_FILES)
+      : EMPTY_FILES,
+  );
   const [graphExpanded, setGraphExpanded] = useState<string | null>(null);
   const [graphMenu, setGraphMenu] = useState<{
     anchor: HTMLElement;
@@ -463,23 +460,18 @@ export default function SourceControlExplorer() {
     (oid: string) => {
       const next = graphExpanded === oid ? null : oid;
       setGraphExpanded(next);
-      if (next && workspaceId && appId) {
-        void fetchCommitFiles(workspaceId, appId, next, "repo");
+      if (next && workspaceId) {
+        void fetchCommitFiles(workspaceId, next);
       }
     },
-    [graphExpanded, fetchCommitFiles, workspaceId, appId],
+    [graphExpanded, fetchCommitFiles, workspaceId],
   );
-  // A repo path opens as the owning app's commit diff; files outside any
-  // app (a root README) are listed but not openable.
+  // Any repo path opens as a workspace-scoped commit diff.
   const openRepoFileDiff = useCallback(
     (oid: string) => (file: AppCommitFile) => {
-      const m = file.path.match(/^apps\/([^/]+)\/(.+)$/);
-      if (!m) return;
-      const app = apps.find(a => a.slug === m[1]);
-      if (!app) return;
-      focusAppsDiffTab(app.id, m[2], "commit", app.slug, oid);
+      focusRepoDiffTab(file.path, "commit", oid);
     },
-    [apps],
+    [],
   );
 
   if (!workspaceId) return null;
@@ -504,13 +496,13 @@ export default function SourceControlExplorer() {
             SOURCE CONTROL
           </Typography>
           <Box sx={{ flex: 1 }} />
-          {appId && (
+          {hasRepo && (
             <Tooltip title="Switch branch — the same `git checkout` the terminal runs">
               <Button
                 size="small"
                 onClick={e => {
                   setBranchAnchor(e.currentTarget);
-                  if (workspaceId) void fetchBranches(workspaceId, appId);
+                  if (workspaceId) void fetchBranches(workspaceId);
                 }}
                 startIcon={
                   switching ? (
@@ -701,10 +693,10 @@ export default function SourceControlExplorer() {
           </Alert>
         )}
 
-        {!appId ? (
+        {hasRepo === false ? (
           <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
-            The workspace repository appears with its first app — create one in
-            Apps and this panel takes over from there.
+            The workspace repository appears with its first app, console or
+            skill — this panel takes over from there.
           </Typography>
         ) : (
           <>

--- a/app/src/lib/entity-icons.ts
+++ b/app/src/lib/entity-icons.ts
@@ -95,6 +95,7 @@ export const TAB_KIND_ICONS = {
   "app-file": FileCode,
   "app-diff": GitCompare,
   "console-diff": GitCompare,
+  "repo-diff": GitCompare,
   plan: ClipboardList,
   "dbt-file": FileCode,
   "dbt-job": CalendarClock,

--- a/app/src/lib/entity-labels.ts
+++ b/app/src/lib/entity-labels.ts
@@ -23,6 +23,7 @@ export const TAB_KIND_ENTITY_LABELS = {
   "app-file": "file",
   "app-diff": "diff",
   "console-diff": "diff",
+  "repo-diff": "diff",
   plan: "plan",
   settings: "settings section",
   members: "members page",

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -138,6 +138,7 @@ export function tabRevealTarget(
     }
     case "app-diff":
     case "console-diff":
+    case "repo-diff":
       // A transient diff view; nothing in an explorer corresponds to it.
       return null;
     default: {

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -69,6 +69,10 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
       mode: "working",
     },
   }),
+  "repo-diff": baseTab({
+    kind: "repo-diff",
+    metadata: { path: "consoles/revenue.sql", mode: "working" },
+  }),
   plan: baseTab({ kind: "plan", metadata: { chatId: "chat-1" } }),
   settings: baseTab({ kind: "settings", settingsSection: "models" }),
   members: baseTab({ kind: "members" }),

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -45,6 +45,7 @@ export const TAB_DEEP_LINK_PATTERNS = {
   "app-file": /^\/apps\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
   "app-diff": null,
   "console-diff": null,
+  "repo-diff": null,
   plan: /^\/p\/([a-zA-Z0-9-]+)/,
   settings: /^\/settings\/([a-z-]+)$/,
   // Legacy tab kind superseded by the settings "members" section.
@@ -117,6 +118,7 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
     }
     case "app-diff":
     case "console-diff":
+    case "repo-diff":
       // Diffs are transient views of the working copy: no deep link.
       return null;
     case "plan": {

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -14,7 +14,6 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { persist } from "zustand/middleware";
 import { api, unwrapBody, ApiError, toErrorMessage as message } from "../api";
-import { apiClient } from "../lib/api-client";
 import { reconcileAppsTabs } from "../apps-runtime/shell";
 
 export interface AppMeta {
@@ -235,7 +234,6 @@ interface AppsStore {
   /** Files per commit, per app — the History panel's "View changes". */
   commitFilesByApp: Record<string, Record<string, AppCommitFile[]>>;
   /** Repo-wide graph (Source Control panel) — same repo, no app pathspec. */
-  repoHistoryByApp: Record<string, AppCommit[]>;
   branchesByApp: Record<string, AppBranch[]>;
   terminalByApp: Record<string, AppTerminalEntry[]>;
   execRunning: Record<string, boolean>;
@@ -251,8 +249,6 @@ interface AppsStore {
     workspaceId: string,
     installationId: number,
   ) => Promise<AppGithubRepo[]>;
-  // TODO(apps): borrows dbt's raw (non-OpenAPI) install-url route until
-  // apps gets its own /apps/github/install-url endpoint.
   getGitHubInstallUrl: (workspaceId: string) => Promise<string | null>;
   /**
    * User-authorization OAuth flow: binds installations that already exist on
@@ -324,11 +320,7 @@ interface AppsStore {
   clearTerminal: (appId: string) => void;
 
   fetchStatus: (workspaceId: string, appId: string) => Promise<void>;
-  fetchHistory: (
-    workspaceId: string,
-    appId: string,
-    scope?: "app" | "repo",
-  ) => Promise<void>;
+  fetchHistory: (workspaceId: string, appId: string) => Promise<void>;
   fetchBranches: (workspaceId: string, appId: string) => Promise<void>;
   /** Fetch (or refresh) the cookie-free URL for an app's published build. */
   fetchViewUrl: (workspaceId: string, appId: string) => Promise<void>;
@@ -508,7 +500,6 @@ export const useAppsStore = create<AppsStore>()(
       viewUrlByApp: {},
       historyByApp: {},
       commitFilesByApp: {},
-      repoHistoryByApp: {},
       runningDevApps: [],
       boxStatus: undefined,
       boxSandboxId: null,
@@ -573,11 +564,13 @@ export const useAppsStore = create<AppsStore>()(
 
       getGitHubInstallUrl: async workspaceId => {
         try {
-          const response = await apiClient.get<{
-            success: boolean;
-            url: string;
-          }>(`/workspaces/${workspaceId}/dbt/github/install-url`);
-          return response.url ?? null;
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/repo/github/install-url",
+              { params: { path: { workspaceId } } },
+            ),
+          ) as { url?: string };
+          return body.url ?? null;
         } catch (e) {
           set(s => {
             s.error = message(e, "Failed to start GitHub App install");
@@ -588,17 +581,22 @@ export const useAppsStore = create<AppsStore>()(
 
       fetchGithubBranches: async (workspaceId, owner, repo, installationId) => {
         try {
-          const params = new URLSearchParams({ owner, repo });
-          if (installationId) {
-            params.set("installationId", String(installationId));
-          }
-          // TODO(workspace-repos): reuses dbt's raw branches route until repos
-          // get their own workspace-level GitHub surface.
-          const response = await apiClient.get<{
-            success: boolean;
-            branches: string[];
-          }>(`/workspaces/${workspaceId}/dbt/github/branches?${params}`);
-          return response.branches ?? [];
+          const body = unwrapBody(
+            await api.GET(
+              "/api/workspaces/{workspaceId}/repo/github/branches",
+              {
+                params: {
+                  path: { workspaceId },
+                  query: {
+                    owner,
+                    repo,
+                    ...(installationId ? { installationId } : {}),
+                  },
+                },
+              },
+            ),
+          ) as { branches?: string[] };
+          return body.branches ?? [];
         } catch (e) {
           set(s => {
             s.error = message(e, "Failed to list branches");
@@ -805,7 +803,6 @@ export const useAppsStore = create<AppsStore>()(
             delete s.filesByApp[appId];
             delete s.statusByApp[appId];
             delete s.historyByApp[appId];
-            delete s.repoHistoryByApp[appId];
             delete s.terminalByApp[appId];
             delete s.previewByApp[appId];
           });
@@ -1001,27 +998,23 @@ export const useAppsStore = create<AppsStore>()(
         }
       },
 
-      fetchHistory: async (workspaceId, appId, scope = "app") => {
+      fetchHistory: async (workspaceId, appId) => {
         try {
           // Show the branch the user's box is actually on (VS Code's graph
           // follows HEAD); the server falls back to the default branch when
-          // the ref is unknown, so a stale value degrades gracefully. The
-          // Source Control panel asks for repo scope — its CHANGES list is
-          // repo-wide, and a graph that hides your own cross-app commit is
-          // worse than useless.
+          // the ref is unknown, so a stale value degrades gracefully.
+          // Repo-wide history lives in repoStore now; this is the app's own.
           const ref = get().statusByApp[appId]?.branch;
           const body = unwrapBody(
             await api.GET("/api/workspaces/{workspaceId}/apps/{id}/history", {
               params: {
                 path: { workspaceId, id: appId },
-                query: { ...(ref ? { ref } : {}), scope },
+                query: { ...(ref ? { ref } : {}), scope: "app" },
               },
             }),
           ) as { commits?: AppCommit[] };
           set(s => {
-            if (scope === "repo") {
-              s.repoHistoryByApp[appId] = body.commits ?? [];
-            } else s.historyByApp[appId] = body.commits ?? [];
+            s.historyByApp[appId] = body.commits ?? [];
           });
         } catch (e) {
           set(s => {
@@ -1142,7 +1135,6 @@ export const useAppsStore = create<AppsStore>()(
           ) as { result?: { committed: boolean; reason?: string } };
           void get().fetchStatus(workspaceId, appId);
           void get().fetchHistory(workspaceId, appId);
-          void get().fetchHistory(workspaceId, appId, "repo");
           if (body.result?.committed) return { ok: true };
           return {
             ok: false,

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -21,6 +21,7 @@ export type TabKind =
   | "app-file"
   | "app-diff"
   | "console-diff"
+  | "repo-diff"
   | "plan"
   | "dbt-file"
   | "dbt-job"

--- a/app/src/store/repoStore.ts
+++ b/app/src/store/repoStore.ts
@@ -1,0 +1,298 @@
+/**
+ * The workspace repository — status, branches, history, commits — keyed by
+ * WORKSPACE, not by app.
+ *
+ * The Source Control panel and the rail's dirty dot used to reach the repo
+ * through "any app id" (`apps[0].id` + app routes with `scope=repo`), which
+ * left a workspace whose repo holds only consoles — or, after Block D3, only
+ * dbt — with a blank panel. This store talks to `/repo/*`, which needs no app
+ * handle. Shapes are shared with appsStore (`AppStatus`, `AppCommit`, …) so
+ * CommitRow / GitFileDiffView render either source unchanged.
+ */
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { api, unwrapBody, toErrorMessage as message } from "../api";
+import type {
+  AppBranch,
+  AppCommit,
+  AppCommitFile,
+  AppCommitFileVersions,
+  AppFileVersions,
+  AppStatus,
+} from "./appsStore";
+
+interface RepoState {
+  /** null = probed, no repo; undefined = not probed yet. */
+  hasRepoByWorkspace: Record<string, boolean>;
+  statusByWorkspace: Record<string, AppStatus | null>;
+  historyByWorkspace: Record<string, AppCommit[]>;
+  branchesByWorkspace: Record<string, AppBranch[]>;
+  commitFilesByWorkspace: Record<string, Record<string, AppCommitFile[]>>;
+  error: string | null;
+
+  fetchStatus: (workspaceId: string) => Promise<void>;
+  fetchHistory: (workspaceId: string) => Promise<void>;
+  fetchBranches: (workspaceId: string) => Promise<void>;
+  checkoutBranch: (
+    workspaceId: string,
+    branch: string,
+    options?: { create?: boolean },
+  ) => Promise<string | null>;
+  mergeBranch: (
+    workspaceId: string,
+    branch: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
+  commit: (
+    workspaceId: string,
+    message: string,
+    options?: { stagedOnly?: boolean },
+  ) => Promise<{ ok: boolean; error?: string }>;
+  gitPaths: (
+    workspaceId: string,
+    action: "stage" | "unstage" | "discard",
+    paths: string[],
+  ) => Promise<{ ok: boolean; error?: string }>;
+  fetchCommitFiles: (
+    workspaceId: string,
+    sha: string,
+  ) => Promise<AppCommitFile[] | null>;
+  fetchCommitFileVersions: (
+    workspaceId: string,
+    sha: string,
+    path: string,
+  ) => Promise<AppCommitFileVersions | null>;
+  fetchFileVersions: (
+    workspaceId: string,
+    path: string,
+  ) => Promise<AppFileVersions | null>;
+  getGitHubInstallUrl: (workspaceId: string) => Promise<string | null>;
+  fetchGithubBranches: (
+    workspaceId: string,
+    owner: string,
+    repo: string,
+    installationId?: number,
+  ) => Promise<string[]>;
+}
+
+export const useRepoStore = create<RepoState>()(
+  immer((set, get) => ({
+    hasRepoByWorkspace: {},
+    statusByWorkspace: {},
+    historyByWorkspace: {},
+    branchesByWorkspace: {},
+    commitFilesByWorkspace: {},
+    error: null,
+
+    fetchStatus: async workspaceId => {
+      try {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/repo/status", {
+            params: { path: { workspaceId } },
+          }),
+        ) as { hasRepo?: boolean; status?: AppStatus | null };
+        set(s => {
+          s.hasRepoByWorkspace[workspaceId] = body.hasRepo ?? false;
+          s.statusByWorkspace[workspaceId] = body.status ?? null;
+        });
+      } catch {
+        // Status is advisory; stale data is acceptable.
+      }
+    },
+
+    fetchHistory: async workspaceId => {
+      try {
+        // Follow the branch the user's box is actually on (VS Code's graph
+        // follows HEAD); the server falls back to the default branch when
+        // the ref is unknown, so a stale value degrades gracefully.
+        const ref = get().statusByWorkspace[workspaceId]?.branch;
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/repo/history", {
+            params: {
+              path: { workspaceId },
+              query: { ...(ref ? { ref } : {}) },
+            },
+          }),
+        ) as { commits?: AppCommit[] };
+        set(s => {
+          s.historyByWorkspace[workspaceId] = body.commits ?? [];
+        });
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to load history");
+        });
+      }
+    },
+
+    fetchBranches: async workspaceId => {
+      try {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/repo/branches", {
+            params: { path: { workspaceId } },
+          }),
+        ) as { branches?: AppBranch[] };
+        set(s => {
+          s.branchesByWorkspace[workspaceId] = body.branches ?? [];
+        });
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to load branches");
+        });
+      }
+    },
+
+    checkoutBranch: async (workspaceId, branch, options) => {
+      try {
+        unwrapBody(
+          await api.POST("/api/workspaces/{workspaceId}/repo/checkout", {
+            params: { path: { workspaceId } },
+            body: { branch, ...(options?.create ? { create: true } : {}) },
+          }),
+        );
+        await Promise.all([
+          get().fetchStatus(workspaceId),
+          get().fetchBranches(workspaceId),
+        ]);
+        return null;
+      } catch (e) {
+        return message(e, `Failed to switch to ${branch}`);
+      }
+    },
+
+    mergeBranch: async (workspaceId, branch) => {
+      try {
+        const body = unwrapBody(
+          await api.POST("/api/workspaces/{workspaceId}/repo/merge", {
+            params: { path: { workspaceId } },
+            body: { branch },
+          }),
+        ) as { result?: { merged: boolean; reason?: string } };
+        void get().fetchBranches(workspaceId);
+        void get().fetchStatus(workspaceId);
+        void get().fetchHistory(workspaceId);
+        if (body.result?.merged) return { ok: true };
+        return { ok: false, error: body.result?.reason ?? "Nothing to merge" };
+      } catch (e) {
+        return { ok: false, error: message(e, "Merge failed") };
+      }
+    },
+
+    commit: async (workspaceId, msg, options) => {
+      try {
+        const body = unwrapBody(
+          await api.POST("/api/workspaces/{workspaceId}/repo/commit", {
+            params: { path: { workspaceId } },
+            body: { message: msg, stagedOnly: options?.stagedOnly },
+          }),
+        ) as { result?: { committed: boolean; reason?: string } };
+        void get().fetchStatus(workspaceId);
+        void get().fetchHistory(workspaceId);
+        if (body.result?.committed) return { ok: true };
+        return { ok: false, error: body.result?.reason ?? "Nothing to commit" };
+      } catch (e) {
+        return { ok: false, error: message(e, "Commit failed") };
+      }
+    },
+
+    gitPaths: async (workspaceId, action, paths) => {
+      try {
+        await api.POST(
+          `/api/workspaces/{workspaceId}/repo/git/${action}` as "/api/workspaces/{workspaceId}/repo/git/stage",
+          { params: { path: { workspaceId } }, body: { paths } },
+        );
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: message(e, `Could not ${action}`) };
+      }
+    },
+
+    fetchCommitFiles: async (workspaceId, sha) => {
+      const cached = get().commitFilesByWorkspace[workspaceId]?.[sha];
+      if (cached) return cached;
+      try {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/repo/git/commit", {
+            params: { path: { workspaceId }, query: { sha } },
+          }),
+        ) as { commit?: { files?: AppCommitFile[] } };
+        const files = body.commit?.files ?? [];
+        set(s => {
+          (s.commitFilesByWorkspace[workspaceId] ??= {})[sha] = files;
+        });
+        return files;
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to load the commit");
+        });
+        return null;
+      }
+    },
+
+    fetchCommitFileVersions: async (workspaceId, sha, path) => {
+      try {
+        const body = unwrapBody(
+          await api.GET(
+            "/api/workspaces/{workspaceId}/repo/git/file-versions",
+            { params: { path: { workspaceId }, query: { sha, path } } },
+          ),
+        ) as { versions?: AppCommitFileVersions };
+        return body.versions ?? null;
+      } catch {
+        return null;
+      }
+    },
+
+    fetchFileVersions: async (workspaceId, path) => {
+      try {
+        const body = unwrapBody(
+          await api.GET(
+            "/api/workspaces/{workspaceId}/repo/git/file-versions",
+            { params: { path: { workspaceId }, query: { path } } },
+          ),
+        ) as { versions?: AppFileVersions };
+        return body.versions ?? null;
+      } catch {
+        return null;
+      }
+    },
+
+    getGitHubInstallUrl: async workspaceId => {
+      try {
+        const body = unwrapBody(
+          await api.GET(
+            "/api/workspaces/{workspaceId}/repo/github/install-url",
+            { params: { path: { workspaceId } } },
+          ),
+        ) as { url?: string };
+        return body.url ?? null;
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to start GitHub App install");
+        });
+        return null;
+      }
+    },
+
+    fetchGithubBranches: async (workspaceId, owner, repo, installationId) => {
+      try {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/repo/github/branches", {
+            params: {
+              path: { workspaceId },
+              query: {
+                owner,
+                repo,
+                ...(installationId ? { installationId } : {}),
+              },
+            },
+          }),
+        ) as { branches?: string[] };
+        return body.branches ?? [];
+      } catch (e) {
+        set(s => {
+          s.error = message(e, "Failed to list branches");
+        });
+        return [];
+      }
+    },
+  })),
+);

--- a/apps.md
+++ b/apps.md
@@ -2633,3 +2633,64 @@ retired the same evening: no dual-writes, no legacy `/versions` routes —
 save baselines and the version-comment diff read the file at HEAD. The 412
 now lands as UX: a failed save opens Settings → GitHub with a plain
 explanation. Template v7 documents `skills/` in AGENTS.md.
+
+## 19. The doctrine, decomposed: workspace-scoped repo + branch policy (2026-08-31, night)
+
+"Every save is a commit" (§10 Block A) was three rules traveling under one
+slogan, and preparing dbt's landing (Block D3) forced them apart. The user's
+framing that split them: the slogan is only true for ephemeral working
+copies — a laptop clone owes nobody a commit — and durability never implied
+the commits belong on main.
+
+1. **Durability.** An ephemeral working copy (the sandbox, a Monaco buffer)
+   never holds work the server is responsible for: agent turns and manual
+   saves commit AND push. A laptop clone is exempt. Enforced where writes
+   happen; unchanged.
+2. **Ref policy** — which branch those commits advance. Now ONE module:
+   `api/src/apps/branch-policy.ts` (`sessionBranchFor`, `commitBranchFor`).
+   Apps (and dbt, when it lands) follow the actor's session branch
+   (`AppWorktree.branch`, the pointer `git checkout` moves). Consoles and
+   skills pin to the default branch — not doctrine but a CONSTRAINT: their
+   Mongo rows are a derived index of main, so a save committed to a feature
+   branch would be visually reverted by the next index sync. Branch-scoped
+   indexes are the prerequisite for lifting it. Main-by-default for apps
+   stands on the pinned-sha argument (publish deploys a sha, so main is not
+   production); dbt inverts it (scheduled jobs build the tracked branch), so
+   its Block D3 default is a working branch with merge-to-main as deploy.
+3. **Granularity** — amend/squash/standalone per save is a per-surface
+   choice, deliberately not policy (see autoCommitFileEdit's history).
+
+**The repo is workspace-scoped in code now, not just in the data model.**
+The Source Control panel and the rail's dirty dot used to reach the repo
+through "any app id" (`apps[0].id` + app routes with `scope=repo`) — a
+workspace whose repo holds only consoles (or, post-D3, only dbt) had a blank
+panel. What landed:
+
+- `RepoScope` + `workspaceScope()`/`scopeOf(project)` in worktree.service;
+  status/history/branches/merge/commit-inspection take a scope, not an
+  IAppProject. `ensureWorkspaceWorktree(workspaceId, actorId)` returns the
+  same session doc with no app lens (`WorktreeHandle.project` is optional).
+- `/api/workspaces/:id/repo/*` (routes/workspace-repo.ts): status (with
+  `hasRepo`, and an at-rest default-branch answer when no session exists),
+  history, branches, checkout, merge, commit, stage/unstage/discard,
+  git/commit, git/file-versions — OpenAPI-typed, no app handle.
+- Frontend `repoStore` (workspace-keyed twin of appsStore's git slice, same
+  `AppCommit`/`AppStatus` shapes); SourceControlExplorer and the Sidebar
+  dirty dot rewired onto it; new `repo-diff` tab kind + `RepoDiffTab`
+  (workspace-addressed twin of AppDiffTab) so any repo path diffs without an
+  owning app — the graph and CHANGES rows open everything, with "Open file"
+  when an app owns the path (consoles/dbt grow their own openers with their
+  explorer integrations).
+- The GitHub connect surface appsStore had borrowed from dbt
+  (`/dbt/github/install-url`, `/dbt/github/branches` — both TODO-tagged)
+  moved to `/repo/github/*`: Block D3 can now delete dbt's git routes
+  without breaking apps, and appsStore no longer uses the raw client at all.
+
+Rail visibility deliberately unchanged (`settings.appsEnabled`, a
+synchronous fact per Sidebar's doctrine); when dbt lands in the repo the
+flag's meaning grows to "repo features", not into a network probe.
+
+Next on this axis (not started): agent-on-a-branch — commitAgentTurn keyed
+by actor commits to the branch the person is on; the review-flow convention
+(agent works its own branch, human merges) is §14.2's "staged group" item
+and becomes cheap once dbt normalizes branch-per-line-of-work.

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -9423,280 +9423,6 @@
         "operationId": "get_api_workspaces_workspaceId_consoles_id_git_file_versions"
       }
     },
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions": {
-      "get": {
-        "tags": [
-          "Consoles"
-        ],
-        "summary": "List console versions",
-        "security": [
-          {
-            "cookieAuth": []
-          },
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "workspaceId",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "offset",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "2XX": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GenericJsonResponse"
-                    },
-                    {
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get_api_workspaces_workspaceId_consoles_id_versions"
-      }
-    },
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions/{version}": {
-      "get": {
-        "tags": [
-          "Consoles"
-        ],
-        "summary": "GET /{id}/versions/{version}",
-        "security": [
-          {
-            "cookieAuth": []
-          },
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "workspaceId",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "version",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "2XX": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GenericJsonResponse"
-                    },
-                    {
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get_api_workspaces_workspaceId_consoles_id_versions_version"
-      }
-    },
-    "/api/workspaces/{workspaceId}/consoles/{id}/versions/{version}/restore": {
-      "post": {
-        "tags": [
-          "Consoles"
-        ],
-        "summary": "POST /{id}/versions/{version}/restore",
-        "security": [
-          {
-            "cookieAuth": []
-          },
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "workspaceId",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "version",
-            "in": "path"
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": {}
-              }
-            }
-          }
-        },
-        "responses": {
-          "2XX": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GenericJsonResponse"
-                    },
-                    {
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "Invalid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            }
-          }
-        },
-        "operationId": "post_api_workspaces_workspaceId_consoles_id_versions_version_restore"
-      }
-    },
     "/api/workspaces/{workspaceId}/realtime": {
       "get": {
         "tags": [
@@ -27252,6 +26978,1112 @@
           }
         },
         "operationId": "get_api_workspaces_workspaceId_apps_id_public_share_password"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/status": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Workspace repo status for the caller's session",
+        "description": "Repo-wide worktree status: the sandbox's working copy when it is running, the last commit on the caller's branch when it is not. `hasRepo: false` when the workspace has no repo yet. Never starts a sandbox.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_status"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/history": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Commit history of a branch (defaults to the default branch)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 200
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "required": false,
+            "name": "ref",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_history"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/git/commit": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Files changed by one commit (repo-relative paths)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{7,40}$"
+            },
+            "required": true,
+            "name": "sha",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_git_commit"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/git/file-versions": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "HEAD, index and working-tree contents of a repo path (for diffs)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 4096
+            },
+            "required": true,
+            "name": "path",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{7,40}$"
+            },
+            "required": false,
+            "name": "sha",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_git_file_versions"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/branches": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "List branches",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_branches"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/checkout": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Switch the caller's session to a branch (git checkout)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "create": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "branch"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_checkout"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/merge": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Merge a branch into the default branch",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  }
+                },
+                "required": [
+                  "branch"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_merge"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/commit": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Commit the caller's working copy onto their branch",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "stagedOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_commit"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/git/stage": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Stage files for commit (git add)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 4096
+                    },
+                    "minItems": 1,
+                    "maxItems": 500
+                  }
+                },
+                "required": [
+                  "paths"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_git_stage"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/git/unstage": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Unstage files (git reset HEAD --)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 4096
+                    },
+                    "minItems": 1,
+                    "maxItems": 500
+                  }
+                },
+                "required": [
+                  "paths"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_git_unstage"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/git/discard": {
+      "post": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Discard working-tree changes to files (checkout / clean)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 4096
+                    },
+                    "minItems": 1,
+                    "maxItems": 500
+                  }
+                },
+                "required": [
+                  "paths"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_repo_git_discard"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/github/install-url": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Signed GitHub App install URL (admin+)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_github_install_url"
+      }
+    },
+    "/api/workspaces/{workspaceId}/repo/github/branches": {
+      "get": {
+        "tags": [
+          "Workspace repo"
+        ],
+        "summary": "Branch names of a GitHub repo (connect/link UI)",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "owner",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "repo",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "required": false,
+            "name": "installationId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_repo_github_branches"
       }
     },
     "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}": {


### PR DESCRIPTION
## What

Decomposes the "every save is a commit" doctrine and makes the workspace repo a workspace-level concept in code, not just in the data model. This is the reliability refactor that has to precede dbt's move into the workspace monorepo (Block D3). Full write-up: apps.md §19.

### Branch policy (new: `api/src/apps/branch-policy.ts`)
- One module answers "which branch does this commit land on": `sessionBranchFor` (the pointer `git checkout` moves) and `commitBranchFor(kind, …)`.
- Apps (and dbt, when it lands) follow the actor's session branch; consoles/skills pin to main — documented as a derived-index **constraint** (a save on a feature branch would be visually reverted by the next index sync), not doctrine.
- `defaultBranchForActor` moved here with its pinned-sha rationale intact.

### The repo needs no app handle
- `RepoScope` + `workspaceScope()`/`scopeOf(project)`: status, history, branches, merge, commit inspection all take a scope instead of an `IAppProject`. `ensureWorkspaceWorktree(workspaceId, actorId)` opens the same per-(workspace, actor) session with no app lens.
- New OpenAPI-typed routes `/api/workspaces/:id/repo/*`: status (`hasRepo`, at-rest default-branch answer when no session), history, branches, checkout, merge, commit, stage/unstage/discard, git/commit, git/file-versions.
- Frontend: new `repoStore` (workspace-keyed, same `AppCommit`/`AppStatus` shapes), Source Control panel and the rail dirty dot rewired onto it — the "any app id reaches the workspace repo; the first one is the handle" hack is gone, so a repo holding only consoles (or, post-D3, only dbt) gets a working panel. New `repo-diff` tab (`RepoDiffTab`) diffs **any** repo path without an owning app.
- GitHub connect calls appsStore borrowed from dbt's raw routes (`/dbt/github/install-url`, `/dbt/github/branches`, both TODO-tagged) move to `/repo/github/*` — Block D3 can delete dbt's git surface without breaking apps. appsStore no longer uses the raw `apiClient` at all; dead `repoHistoryByApp` slice removed.

### Deliberately unchanged
- Rail visibility stays on `settings.appsEnabled` (synchronous-fact doctrine in Sidebar.tsx).
- Console/skill saves still commit to main — now via the policy module, with the why written down.
- Agent-on-a-branch (review flow) is scoped in §19 as the follow-up this enables.

## Testing
- New `api/src/apps/workspace-repo.test.ts` (7 tests): workspace worktree, offline status, repo-scope history/commits/file-versions, branches + fast-forward merge through `workspaceScope`, branch-policy semantics.
- Full apps suite: 12 files / 122 tests green. App: tsc, eslint, vite build, tab-routing + store tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat