### PR TITLE
feat(prompt): workspace custom prompt is PROMPT.md in the workspace repo

### DIFF
--- a/api/src/apps/config.ts
+++ b/api/src/apps/config.ts
@@ -67,7 +67,7 @@ export class RepoRequiredError extends Error {
   readonly code = "github_required";
   constructor() {
     super(
-      "Connect a GitHub repository first (Settings → GitHub). Mako keeps your apps and consoles in your own repo.",
+      "Connect a GitHub repository first (Settings → GitHub). Mako keeps your workspace content — apps, consoles, dbt, prompt — in your own repo.",
     );
     this.name = "RepoRequiredError";
   }

--- a/api/src/apps/workspace-prompt.test.ts
+++ b/api/src/apps/workspace-prompt.test.ts
@@ -1,0 +1,77 @@
+/**
+ * PROMPT.md in the workspace repo (apps.md §21): the same bare-repo +
+ * mongodb-memory-server rig the consoles/skills suites use.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  DEFAULT_BRANCH,
+  initRepo,
+  log as repoLog,
+  repoDirFor,
+} from "./repository.service";
+import {
+  PROMPT_PATH,
+  commitWorkspacePrompt,
+  readWorkspacePromptFile,
+} from "./workspace-prompt";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+const WS = new Types.ObjectId().toString();
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "prompt-test-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+});
+
+describe("workspace prompt in git", () => {
+  it("reads null with no repo or no file; round-trips a commit", async () => {
+    expect(await readWorkspacePromptFile(WS)).toBeNull();
+    await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+    expect(await readWorkspacePromptFile(WS)).toBeNull();
+
+    const result = await commitWorkspacePrompt(WS, "# RevOps context\n");
+    expect(result.unchanged).toBe(false);
+    expect(await readWorkspacePromptFile(WS)).toBe("# RevOps context\n");
+    const [head] = await repoLog(repoDirFor(WS), MAIN, 1);
+    expect(head.subject).toBe(`prompt: update ${PROMPT_PATH}`);
+  });
+
+  it("an identical save is a no-op; empty content deletes the file", async () => {
+    await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+    await commitWorkspacePrompt(WS, "same\n");
+    const again = await commitWorkspacePrompt(WS, "same\n");
+    expect(again.unchanged).toBe(true);
+
+    await commitWorkspacePrompt(WS, "   ");
+    expect(await readWorkspacePromptFile(WS)).toBeNull();
+    const [head] = await repoLog(repoDirFor(WS), MAIN, 1);
+    expect(head.subject).toBe(`prompt: clear ${PROMPT_PATH}`);
+  });
+
+  it("a trailing newline is normalized on", async () => {
+    await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+    await commitWorkspacePrompt(WS, "no newline");
+    expect(await readWorkspacePromptFile(WS)).toBe("no newline\n");
+  });
+});

--- a/api/src/apps/workspace-prompt.ts
+++ b/api/src/apps/workspace-prompt.ts
@@ -1,0 +1,90 @@
+/**
+ * The workspace custom prompt is a repo file: `PROMPT.md` (apps.md §21).
+ *
+ * It was a markdown blob in `workspace.settings.customPrompt` — edited in a
+ * settings textarea with no history, no review, no diff. As a file at the
+ * workspace repo root it gets git history and the Source Control diff
+ * surface, agents (and laptop clones) can read and propose changes to it,
+ * and it composes with the other repo-resident instructions (.makorules,
+ * skills/). Reads fall back to the legacy Mongo field so a workspace
+ * without a repo keeps its existing prompt; edits require the repo (§17).
+ *
+ * Ref policy: PROMPT.md commits to the DEFAULT branch — it is workspace
+ * config every agent turn reads, not per-session content (branch-policy.ts
+ * rule 2, same rationale as consoles/skills).
+ */
+import { RepoRequiredError, appsRequireConnectedRepo } from "./config";
+import { authorForUser } from "./workspace-consoles.service";
+import {
+  ensureWorkspaceRepo,
+  queueMirrorPush,
+  resolveMirrorTarget,
+} from "./cloud-repo.service";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  readBlob,
+  repoDirFor,
+  repoExists,
+} from "./repository.service";
+
+export const PROMPT_PATH = "PROMPT.md";
+
+/** The committed prompt, or null when the repo or file does not exist. */
+export async function readWorkspacePromptFile(
+  workspaceId: string,
+): Promise<string | null> {
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return null;
+  try {
+    const blob = await readBlob(
+      repoDir,
+      `refs/heads/${DEFAULT_BRANCH}`,
+      PROMPT_PATH,
+    );
+    return blob.isBinary ? null : blob.contents;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Commit the prompt (empty/whitespace content deletes the file). The one
+ * write path for the settings UI, the reset action, and adoption.
+ */
+export async function commitWorkspacePrompt(
+  workspaceId: string,
+  content: string,
+  actorUserId?: string,
+): Promise<{ commitOid?: string; unchanged: boolean }> {
+  // Production: the workspace's own repo is the only durable store (§17).
+  if (appsRequireConnectedRepo() && !(await resolveMirrorTarget(workspaceId))) {
+    throw new RepoRequiredError();
+  }
+  const repoDir = await ensureWorkspaceRepo(workspaceId);
+  if (!(await repoExists(repoDir))) throw new RepoRequiredError();
+  const author = actorUserId ? await authorForUser(actorUserId) : undefined;
+  const trimmed = content.trim();
+  const result = await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    trimmed
+      ? {
+          writes: {
+            [PROMPT_PATH]: content.endsWith("\n") ? content : `${content}\n`,
+          },
+        }
+      : { deletes: [PROMPT_PATH] },
+    {
+      message: trimmed
+        ? `prompt: update ${PROMPT_PATH}`
+        : `prompt: clear ${PROMPT_PATH}`,
+      author,
+    },
+  );
+  if (!result.unchanged) queueMirrorPush(workspaceId);
+  return {
+    commitOid: result.unchanged ? undefined : result.commitOid,
+    unchanged: result.unchanged,
+  };
+}

--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 8, fingerprint: "2aef3b436333c505" };
+const PINNED = { version: 9, fingerprint: "93aecd03bafeaf7f" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.ts
+++ b/api/src/apps/workspace-template.ts
@@ -31,7 +31,7 @@ import { fetchFromCloud, queueMirrorPush } from "./cloud-repo.service";
 
 const logger = loggers.app();
 
-export const WORKSPACE_TEMPLATE_VERSION = 8;
+export const WORKSPACE_TEMPLATE_VERSION = 9;
 
 /** Where `.mcp.json` points when MAKO_API_URL is not exported. */
 export const HOSTED_MAKO_URL = "https://app.mako.ai";
@@ -65,6 +65,11 @@ of the workspace. **\`main\` is production** — a commit on \`main\` deploys.
 - \`skills/<name>/SKILL.md\` — workspace-taught agent skills (YAML
   frontmatter: \`description\` is the retrieval trigger; then the playbook).
   A commit here is in the agent's retrieval index by its next turn.
+- \`dbt/\` — the workspace dbt project (\`dbt_project.yml\` at its root).
+  Edits through Mako are commits; jobs and deploys build \`main\`.
+- \`PROMPT.md\` — the workspace's custom agent prompt (business context,
+  conventions). Every agent turn reads it from \`main\`; edit and commit it
+  like any file.
 - \`.mako/workspace.json\` — workspace id + template version (managed).
 - \`.mcp.json\` — the \`mako\` MCP server for your agent (managed).
 

--- a/api/src/migrations/2026-09-01-020000_workspace_prompt_to_git.ts
+++ b/api/src/migrations/2026-09-01-020000_workspace_prompt_to_git.ts
@@ -1,0 +1,104 @@
+/**
+ * The workspace custom prompt becomes `PROMPT.md` in the workspace repo
+ * (apps.md §21).
+ *
+ * For every workspace with a `settings.customPrompt` AND a repo (local or
+ * connected mirror): write `PROMPT.md` (only when absent — an
+ * externally-authored file wins), push the mirror, then unset the Mongo
+ * field. Repo-less workspaces keep the Mongo value — reads fall back to it,
+ * and their first edit after connecting GitHub commits it.
+ *
+ * NOTE the mongoose connect below: repo helpers (`resolveMirrorTarget` →
+ * `getWorkspaceRepo`) use mongoose models. The dbt cutover migration skipped
+ * this and every model read buffered for 10s, timed out, and was swallowed
+ * into "no repo" — the draft salvage silently no-opped on the deploy runner
+ * (apps.md §20.3 post-mortem). Never remove it.
+ */
+import { Db } from "mongodb";
+import mongoose from "mongoose";
+import { loggers } from "../logging";
+import {
+  PROMPT_PATH,
+  commitWorkspacePrompt,
+  readWorkspacePromptFile,
+} from "../apps/workspace-prompt";
+import {
+  ensureLocalRepo,
+  mirrorPushNow,
+  resolveMirrorTarget,
+} from "../apps/cloud-repo.service";
+import { repoDirFor, repoExists } from "../apps/repository.service";
+
+const log = loggers.migration();
+
+export const description =
+  "Workspace custom prompt into the workspace repo as PROMPT.md (Mongo field kept only for repo-less workspaces)";
+
+export async function up(db: Db): Promise<void> {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      (db as unknown as { client: { s: { url: string } } }).client.s.url,
+      { dbName: db.databaseName },
+    );
+  }
+
+  const workspaces = await db
+    .collection("workspaces")
+    .find(
+      { "settings.customPrompt": { $exists: true, $nin: [null, ""] } },
+      { projection: { "settings.customPrompt": 1, name: 1 } },
+    )
+    .toArray();
+
+  let migrated = 0;
+  let skippedNoRepo = 0;
+  let failed = 0;
+  for (const ws of workspaces) {
+    const workspaceId = String(ws._id);
+    const content = (ws as { settings?: { customPrompt?: string } }).settings
+      ?.customPrompt;
+    if (!content?.trim()) continue;
+    try {
+      await ensureLocalRepo(workspaceId);
+      const hasRepo =
+        (await repoExists(repoDirFor(workspaceId))) ||
+        Boolean(await resolveMirrorTarget(workspaceId).catch(() => null));
+      if (!hasRepo) {
+        skippedNoRepo++;
+        continue;
+      }
+      if ((await readWorkspacePromptFile(workspaceId)) === null) {
+        await commitWorkspacePrompt(workspaceId, content);
+        await mirrorPushNow(workspaceId);
+      }
+      await db
+        .collection("workspaces")
+        .updateOne(
+          { _id: ws._id },
+          { $unset: { "settings.customPrompt": "" } },
+        );
+      migrated++;
+      log.info("Workspace prompt migrated", {
+        workspaceId,
+        name: (ws as { name?: string }).name,
+        path: PROMPT_PATH,
+      });
+    } catch (error) {
+      failed++;
+      log.error("Workspace prompt migration failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  if (failed > 0) {
+    throw new Error(
+      `Prompt migration failed for ${failed} workspace(s) — Mongo fields left in place; fix and re-run`,
+    );
+  }
+  log.info("workspace_prompt_to_git done", {
+    workspaces: workspaces.length,
+    migrated,
+    skippedNoRepo,
+  });
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -4,6 +4,7 @@
  * Uses agent registry for multi-agent support
  */
 
+import { readWorkspacePromptFile } from "../apps/workspace-prompt";
 import { Types } from "mongoose";
 import { createRoute, z } from "@hono/zod-openapi";
 import { ObjectId } from "mongodb";
@@ -521,7 +522,12 @@ agentRoutes.openapi(
         settings: 1,
         selfDirective: 1,
       });
-      workspaceCustomPrompt = workspace?.settings?.customPrompt || "";
+      // PROMPT.md in the workspace repo wins; the Mongo field is the
+      // pre-migration fallback (apps.md §21).
+      workspaceCustomPrompt =
+        (await readWorkspacePromptFile(workspaceId)) ??
+        workspace?.settings?.customPrompt ??
+        "";
       selfDirective = workspace?.selfDirective || "";
     } catch (err) {
       logger.warn("Failed to load workspace custom prompt", { error: err });

--- a/api/src/routes/custom-prompt.ts
+++ b/api/src/routes/custom-prompt.ts
@@ -12,6 +12,11 @@ import {
   jsonContent,
 } from "../openapi/core";
 import { prepareAgentTurnGuidance } from "../services/agent-turn-preparation.service";
+import { RepoRequiredError } from "../apps/config";
+import {
+  commitWorkspacePrompt,
+  readWorkspacePromptFile,
+} from "../apps/workspace-prompt";
 
 const logger = loggers.workspace();
 
@@ -134,7 +139,12 @@ customPromptRoutes.openapi(
       }
 
       // Return the custom prompt from workspace settings, or default if not set
-      const content = workspace.settings.customPrompt || DEFAULT_CUSTOM_PROMPT;
+      // The prompt lives in the workspace repo (PROMPT.md, apps.md §21);
+      // the Mongo field is the pre-migration fallback for repo-less
+      // workspaces.
+      const content =
+        (await readWorkspacePromptFile(workspaceId)) ??
+        (workspace.settings.customPrompt || DEFAULT_CUSTOM_PROMPT);
       const selfDirective =
         typeof workspace.selfDirective === "string"
           ? workspace.selfDirective
@@ -249,6 +259,14 @@ customPromptRoutes.openapi(
       ),
       400: errorJson("Invalid request"),
       404: errorJson("Workspace not found"),
+      412: jsonContent(
+        z.object({
+          success: z.literal(false),
+          error: z.string(),
+          code: z.string(),
+        }),
+        "Connect a GitHub repository first (the prompt lives in the workspace repo).",
+      ),
       500: errorJson("Failed to update custom prompt"),
     },
   }),
@@ -264,18 +282,19 @@ customPromptRoutes.openapi(
         );
       }
 
-      const workspace = await Workspace.findByIdAndUpdate(
-        workspaceId,
-        {
-          "settings.customPrompt": content,
-          updatedAt: new Date(),
-        },
-        { new: true },
-      );
-
+      const workspace = await Workspace.findById(workspaceId).select("_id");
       if (!workspace) {
         return c.json({ success: false, error: "Workspace not found" }, 404);
       }
+
+      // A save is a commit of PROMPT.md on the workspace repo's default
+      // branch. The legacy Mongo field is cleared so it can never shadow
+      // the file for readers still falling back to it.
+      await commitWorkspacePrompt(workspaceId, content, c.get("user")?.id);
+      await Workspace.updateOne(
+        { _id: workspace._id },
+        { $unset: { "settings.customPrompt": "" } },
+      );
 
       return c.json(
         {
@@ -285,6 +304,16 @@ customPromptRoutes.openapi(
         200,
       );
     } catch (error) {
+      if (error instanceof RepoRequiredError) {
+        return c.json(
+          {
+            success: false as const,
+            error: error.message,
+            code: error.code as string,
+          },
+          412,
+        );
+      }
       logger.error("Error updating custom prompt", { error });
       return c.json(
         {
@@ -321,6 +350,14 @@ customPromptRoutes.openapi(
       400: errorJson("Invalid workspace ID"),
       404: errorJson("Workspace not found"),
       500: errorJson("Failed to reset custom prompt"),
+      412: jsonContent(
+        z.object({
+          success: z.literal(false),
+          error: z.string(),
+          code: z.string(),
+        }),
+        "Connect a GitHub repository first (the prompt lives in the workspace repo).",
+      ),
     },
   }),
   async c => {
@@ -334,18 +371,20 @@ customPromptRoutes.openapi(
         );
       }
 
-      const workspace = await Workspace.findByIdAndUpdate(
-        workspaceId,
-        {
-          "settings.customPrompt": DEFAULT_CUSTOM_PROMPT,
-          updatedAt: new Date(),
-        },
-        { new: true },
-      );
-
+      const workspace = await Workspace.findById(workspaceId).select("_id");
       if (!workspace) {
         return c.json({ success: false, error: "Workspace not found" }, 404);
       }
+
+      await commitWorkspacePrompt(
+        workspaceId,
+        DEFAULT_CUSTOM_PROMPT,
+        c.get("user")?.id,
+      );
+      await Workspace.updateOne(
+        { _id: workspace._id },
+        { $unset: { "settings.customPrompt": "" } },
+      );
 
       return c.json(
         {
@@ -356,6 +395,16 @@ customPromptRoutes.openapi(
         200,
       );
     } catch (error) {
+      if (error instanceof RepoRequiredError) {
+        return c.json(
+          {
+            success: false as const,
+            error: error.message,
+            code: error.code as string,
+          },
+          412,
+        );
+      }
       logger.error("Error resetting custom prompt", { error });
       return c.json(
         {

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     include: [
       "src/apps/worktree.service.test.ts",
       "src/apps/workspace-repo.test.ts",
+      "src/apps/workspace-prompt.test.ts",
       "src/apps/bindings.service.test.ts",
       "src/apps/cloud-repo.service.test.ts",
       "src/apps/adversarial.test.ts",

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -10807,6 +10807,20 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Connect a GitHub repository first (the prompt lives in the workspace repo). */
+            412: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: false;
+                        error: string;
+                        code: string;
+                    };
+                };
+            };
             /** @description Failed to update custom prompt */
             500: {
                 headers: {
@@ -10922,6 +10936,20 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Connect a GitHub repository first (the prompt lives in the workspace repo). */
+            412: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: false;
+                        error: string;
+                        code: string;
+                    };
                 };
             };
             /** @description Failed to reset custom prompt */

--- a/app/src/pages/settings/SettingsPrompt.tsx
+++ b/app/src/pages/settings/SettingsPrompt.tsx
@@ -54,7 +54,7 @@ export default function SettingsPrompt() {
   return (
     <SettingsLayout
       title="Custom Prompt"
-      description="Customize the AI assistant's behavior by adding context about your business, data relationships, and common query patterns."
+      description="Customize the AI assistant's behavior by adding context about your business, data relationships, and common query patterns. Saved as PROMPT.md in your workspace repository — versioned, diffable, and editable from any clone."
     >
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>

--- a/apps.md
+++ b/apps.md
@@ -2764,3 +2764,31 @@ repo), jobs + runs collections and Inngest functions (executor edits only:
 CI arms removed), environments + personal schemas, artifact + cache keys
 (projectId-stable, so warm dirs and parse caches survive), lineage,
 `{{ dbt_schema }}` bindings.
+
+## 21. PROMPT.md: the workspace custom prompt is a repo file (2026-09-01)
+
+The RevOps context prompt lived in `workspace.settings.customPrompt` — a
+markdown blob edited in a settings textarea with no history, no review, no
+diff, invisible to clones and sandboxes. Now it is `PROMPT.md` at the
+workspace repo root: git history, the Source Control diff surface, editable
+from any clone, composing with the other repo-resident instructions
+(`.makorules`, `skills/`, AGENTS.md documents it — template v9).
+
+Mechanics: `api/src/apps/workspace-prompt.ts` (read at main; commit via
+`commitBlobsOnBranch`, empty content deletes the file; default-branch pinned
+per branch-policy rule 2 — every agent turn reads it, so it is workspace
+config, not per-session content). Readers (`custom-prompt` GET, agent turn
+assembly) prefer the file and fall back to the legacy Mongo field, which
+survives ONLY for repo-less workspaces; edits require the repo (§17, 412 +
+CTA like consoles). Migration writes PROMPT.md for repo-holding workspaces
+(external file wins if one exists), pushes the mirror, and unsets the Mongo
+field.
+
+Post-mortem folded in: the dbt cutover's draft salvage silently no-opped on
+the deploy runner because that migration never connected mongoose —
+`getWorkspaceRepo` buffered 10s, timed out, and `resolveMirrorTarget`
+swallowed it into "no repo" (the four 10-second-spaced warnings in the
+deploy log were the buffering timeouts; the rehearsal masked it because the
+scratch repo short-circuited before any Mongo read). The prompt migration
+carries the mongoose connect with a comment saying never to remove it, and
+the salvage was recovered by pushing the rehearsal's identical branches.

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -10389,6 +10389,35 @@
               }
             }
           },
+          "412": {
+            "description": "Connect a GitHub repository first (the prompt lives in the workspace repo).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                    "code"
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "description": "Failed to update custom prompt",
             "content": {
@@ -10589,6 +10618,35 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Connect a GitHub repository first (the prompt lives in the workspace repo).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                    "code"
+                  ]
                 }
               }
             }


### PR DESCRIPTION
## What

`settings.customPrompt` (the workspace's business-context prompt, injected into every agent turn) moves from a Mongo blob behind a settings textarea to **`PROMPT.md` at the workspace repo root** (apps.md §21):

- Save = commit on `main` (`prompt: update PROMPT.md`, authored as the user; empty content clears the file). Same 412 + connect-GitHub CTA as consoles for repo-less workspaces.
- Every agent turn and the settings GET read the file first, falling back to the legacy Mongo field (which survives only for workspaces without a repo).
- History and diffs come free via the Source Control rail; clones and the sandbox can read and propose changes to it.
- AGENTS.md template documents `PROMPT.md` + the `dbt/` folder (template v9, fingerprint re-pinned).

## Migration — with the dbt-salvage post-mortem folded in

`2026-09-01-020000_workspace_prompt_to_git`: for repo-holding workspaces, write `PROMPT.md` (an externally-authored file wins), `mirrorPushNow`, then unset the Mongo field; repo-less workspaces keep the fallback. **It connects mongoose first, with a comment saying never to remove it** — root cause of the dbt cutover's silent draft-salvage no-op was exactly this: no mongoose connection → `getWorkspaceRepo` buffered 10s → timeout swallowed into "no repo" (the deploy log's warnings were 10s apart). The salvage was recovered from the rehearsal's identical branches, now pushed as `dbt-drafts/*`.

## Testing
New `workspace-prompt.test.ts` (3 specs: round-trip + commit message, identical-save no-op, clear-on-empty, newline normalization) in the apps suite — 125 green. API tsc/eslint clean, app tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat