### PR TITLE
refactor(app): realtime reactions register next to their stores

### DIFF
--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -14,7 +14,8 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { persist } from "zustand/middleware";
 import { api, unwrapBody, ApiError, toErrorMessage as message } from "../api";
-import { reconcileAppsTabs } from "../apps-runtime/shell";
+import { focusAppsTab, reconcileAppsTabs } from "../apps-runtime/shell";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 export interface AppMeta {
   id: string;
@@ -1873,3 +1874,50 @@ export const useAppsStore = create<AppsStore>()(
     },
   ),
 );
+
+// ── Realtime reactions (registered here so the apps domain owns them) ──
+
+// Apps (git-backed): any durable change (agent turn, WIP flush, merge)
+// pokes open windows; the store refetches from the API (git is the
+// authority, so a refetch is always safe — openFile preserves dirty local
+// edits and only refreshes clean buffers).
+onRealtimeEvent("app.updated", "appsStore", (event, ctx) => {
+  const workspaceId = ctx.workspaceId;
+  if (!workspaceId) return;
+  const v2 = useAppsStore.getState();
+  // Explorer list (titles, new/deleted apps).
+  void v2.fetchApps(workspaceId);
+  if (event.origin === "lifecycle") return;
+  // §10 monorepo: appId "" = workspace-wide (a workspace worktree
+  // changed; it may span apps) — refresh every app this window has
+  // loaded. A non-empty appId scopes to that app as before.
+  const appIds = event.appId ? [event.appId] : Object.keys(v2.filesByApp);
+  for (const appId of appIds) {
+    // Only refresh heavier per-app state when this window has it loaded.
+    if (v2.filesByApp[appId]) {
+      void v2.fetchFiles(workspaceId, appId);
+      void v2.fetchStatus(workspaceId, appId);
+    }
+    if (v2.branchesByApp[appId]) {
+      void v2.fetchBranches(workspaceId, appId);
+    }
+    const selected = v2.selectedFile[appId];
+    if (selected) {
+      const entry = v2.fileContents[`${appId}\u0000${selected}`];
+      if (entry && !entry.dirty) {
+        void v2.openFile(workspaceId, appId, selected);
+      }
+    }
+  }
+});
+
+onRealtimeEvent("app.box-state", "appsStore", event => {
+  useAppsStore.getState().applyBoxState(event.userId, event.state);
+});
+
+onRealtimeEvent("app.open-app", "appsStore", (event, ctx) => {
+  // The user's own agent asked the UI to show an app. Scoped to the
+  // requesting user — a teammate's agent must not steal this focus.
+  if (!ctx.currentUserId || event.userId !== ctx.currentUserId) return;
+  focusAppsTab(event.appId, event.title ?? event.slug ?? "App", event.slug);
+});

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -17,6 +17,7 @@ import {
   type GlobalFilter,
   type TableRelationship,
 } from "../dashboard-runtime/types";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 export type {
   Dashboard,
@@ -1281,3 +1282,32 @@ export const selectSavedHash =
   (id: string | undefined) =>
   (state: DashboardStoreState): string | undefined =>
     id ? state.savedStateHashes[id] : undefined;
+
+// ── Realtime reaction (registered here so the dashboard domain owns it) ──
+
+// Server-persisted dashboard saves/restores (draft/published model): pull
+// the authoritative dashboard for an OPEN dashboard when its version
+// advances — but NEVER clobber a user mid-edit. Skips the reload if this
+// tab is editing or holds unsaved local changes (their work wins until they
+// save/discard); echo-suppressed by clientId; stale events ignored.
+onRealtimeEvent(
+  "dashboard.updated",
+  "dashboardStore",
+  (event, ctx) => {
+    if (!ctx.workspaceId) return;
+    const ds = useDashboardStore.getState();
+    const open = ds.openDashboards[event.dashboardId];
+    if (!open) return; // not open here — explorer/canvas refreshes lazily
+    if ((open.version ?? 0) >= event.version) return; // stale / own echo
+    if (ds.editingDashboards[event.dashboardId]) return; // don't stomp editor
+    const savedHash = ds.savedStateHashes[event.dashboardId];
+    if (
+      savedHash !== undefined &&
+      computeDashboardStateHash(open) !== savedHash
+    ) {
+      return; // unsaved local changes — preserve them
+    }
+    void ds.reloadDashboard(ctx.workspaceId, event.dashboardId);
+  },
+  { suppressOwnEcho: true },
+);

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -13,6 +13,7 @@ import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import { toLoadError, type LoadError } from "../api/result";
 import { realtimeClientId } from "../lib/realtime-client-id";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 export interface DbtEnvironment {
   name: string;
@@ -1221,4 +1222,70 @@ export const useDbtStore = create<DbtStore>()(
 
     reset: () => set(initialState),
   })),
+);
+
+// ── Realtime reactions (registered here so the dbt domain owns them) ──
+// All echo-suppressed by clientId. User-scoped events (drafts, checkouts)
+// carry forUserId: they only concern the acting user's windows — a draft is
+// invisible to everyone else, so other users must not react (or even
+// refetch).
+
+// Server-executed dbt file mutation tools: pull the fresh file content (or
+// drop a deleted file) for OPEN dbt projects.
+onRealtimeEvent(
+  "dbt.file.updated",
+  "dbtStore",
+  (event, ctx) => {
+    if (event.forUserId && event.forUserId !== ctx.currentUserId) return;
+    if (!ctx.workspaceId) return;
+    const dbt = useDbtStore.getState();
+    // Only touch projects this window has loaded.
+    if (!dbt.filePathsByProject[event.projectId]) return;
+    void dbt.applyRemoteFileUpdate(
+      ctx.workspaceId,
+      event.projectId,
+      event.path,
+      event.deleted,
+    );
+  },
+  { suppressOwnEcho: true },
+);
+
+onRealtimeEvent(
+  "dbt.job.updated",
+  "dbtStore",
+  (event, ctx) => {
+    if (!ctx.workspaceId) return;
+    const dbt = useDbtStore.getState();
+    if (!dbt.projects.some(p => p._id === event.projectId)) return;
+    void dbt.fetchJobs(ctx.workspaceId, event.projectId);
+  },
+  { suppressOwnEcho: true },
+);
+
+onRealtimeEvent(
+  "dbt.run.updated",
+  "dbtStore",
+  (event, ctx) => {
+    if (!ctx.workspaceId) return;
+    const dbt = useDbtStore.getState();
+    if (!dbt.projects.some(p => p._id === event.projectId)) return;
+    void dbt.fetchRuns(ctx.workspaceId, event.projectId);
+    if (event.jobId) {
+      void dbt.fetchRuns(ctx.workspaceId, event.projectId, event.jobId);
+    }
+  },
+  { suppressOwnEcho: true },
+);
+
+onRealtimeEvent(
+  "dbt.project.updated",
+  "dbtStore",
+  (_event, ctx) => {
+    if (!ctx.workspaceId) return;
+    // Refresh the project list lazily — only when the dbt surface was used.
+    if (!useDbtStore.getState().projectsLoaded) return;
+    void useDbtStore.getState().fetchProjects(ctx.workspaceId);
+  },
+  { suppressOwnEcho: true },
 );

--- a/app/src/store/lib/realtime-channel.test.ts
+++ b/app/src/store/lib/realtime-channel.test.ts
@@ -1,0 +1,85 @@
+/**
+ * realtime-channel registry: typed dispatch, keyed (HMR-idempotent)
+ * registration, the shared clientId echo guard, and handler error
+ * isolation.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { realtimeClientId } from "../../lib/realtime-client-id";
+import {
+  dispatchRealtimeEvent,
+  isOwnEcho,
+  onRealtimeEvent,
+  type RealtimeEvent,
+} from "./realtime-channel";
+
+const ctx = { workspaceId: "ws1", currentUserId: "u1" };
+
+const dashboardEvent = (clientId?: string): RealtimeEvent => ({
+  type: "dashboard.updated",
+  dashboardId: "d1",
+  version: 2,
+  updatedBy: "u2",
+  clientId,
+  origin: "save",
+});
+
+describe("realtime-channel", () => {
+  it("routes an event to its type's handlers with the dispatch context", () => {
+    const seen = vi.fn();
+    onRealtimeEvent("dashboard.updated", "t-route", seen);
+    dispatchRealtimeEvent(dashboardEvent(), ctx);
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(seen).toHaveBeenCalledWith(
+      expect.objectContaining({ dashboardId: "d1" }),
+      ctx,
+    );
+    // Other types don't reach it.
+    dispatchRealtimeEvent({ type: "notebook.tree.updated" }, ctx);
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-registering the same (type, key) replaces, not stacks", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    onRealtimeEvent("dashboard.updated", "t-replace", first);
+    onRealtimeEvent("dashboard.updated", "t-replace", second);
+    dispatchRealtimeEvent(dashboardEvent(), ctx);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppressOwnEcho drops this window's own writes only", () => {
+    const seen = vi.fn();
+    onRealtimeEvent("dashboard.updated", "t-echo", seen, {
+      suppressOwnEcho: true,
+    });
+    dispatchRealtimeEvent(dashboardEvent(realtimeClientId), ctx);
+    expect(seen).not.toHaveBeenCalled();
+    dispatchRealtimeEvent(dashboardEvent("someone-else"), ctx);
+    expect(seen).toHaveBeenCalledTimes(1);
+    dispatchRealtimeEvent(dashboardEvent(undefined), ctx);
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("a throwing handler does not starve the others", () => {
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const survivor = vi.fn();
+    onRealtimeEvent("dashboard.updated", "t-throws", () => {
+      throw new Error("boom");
+    });
+    onRealtimeEvent("dashboard.updated", "t-survives", survivor);
+    dispatchRealtimeEvent(dashboardEvent(), ctx);
+    expect(survivor).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("isOwnEcho matches only this window's clientId", () => {
+    expect(isOwnEcho({ clientId: realtimeClientId })).toBe(true);
+    expect(isOwnEcho({ clientId: "other" })).toBe(false);
+    expect(isOwnEcho({})).toBe(false);
+  });
+});

--- a/app/src/store/lib/realtime-channel.ts
+++ b/app/src/store/lib/realtime-channel.ts
@@ -1,0 +1,198 @@
+/**
+ * Typed registry for workspace realtime events.
+ *
+ * The transport (realtimeStore: EventSource, reconnect, watchdog) parses
+ * frames and dispatches them through here; each resource kind registers its
+ * reaction NEXT TO ITS OWN STORE (dashboardStore reacts to
+ * dashboard.updated, dbtStore to dbt.*, …) instead of the transport file
+ * reaching into six stores. `suppressOwnEcho` is the one copy of the
+ * clientId echo guard that used to be pasted into every handler.
+ *
+ * Registration is module-scoped and keyed: registering the same
+ * (type, key) again replaces the handler, so Vite HMR re-runs are
+ * idempotent. realtimeStore imports the registering store modules for
+ * side effects, which guarantees every handler is installed before the
+ * first event can arrive.
+ */
+import { realtimeClientId } from "../../lib/realtime-client-id";
+import type { AppsBoxState } from "../appsStore";
+
+/** Mirror of the server's RealtimeEvent union (api realtime.service.ts). */
+export type RealtimeEvent =
+  | {
+      type: "console.updated";
+      consoleId: string;
+      draftRevision: number;
+      name?: string;
+      updatedBy: string;
+      clientId?: string;
+      origin: "draft" | "save" | "agent";
+    }
+  | { type: "console.deleted"; consoleId: string }
+  | {
+      type: "console.run.completed";
+      consoleId: string;
+      status: "success" | "error";
+      rowCount?: number;
+      durationMs?: number;
+      error?: string;
+    }
+  | {
+      type: "chat.ui-intent";
+      chatId: string;
+      intent: "open_console";
+      consoleId: string;
+    }
+  | {
+      type: "chat.ui-intent";
+      chatId: string;
+      intent: "open_notebook";
+      notebookId: string;
+      title?: string;
+    }
+  | { type: "chat.activity"; chatId: string; state: "streaming" | "idle" }
+  | {
+      type: "app.updated";
+      appId: string;
+      updatedBy?: string;
+      origin:
+        | "commit"
+        | "merge"
+        | "discard"
+        | "checkout"
+        | "lifecycle"
+        | "push";
+    }
+  | {
+      type: "dbt.file.updated";
+      projectId: string;
+      path: string;
+      deleted?: boolean;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+      /** Draft (uncommitted) edit: only this user's windows should react. */
+      forUserId?: string;
+    }
+  | { type: "dbt.job.updated"; projectId: string; clientId?: string }
+  | {
+      type: "dbt.run.updated";
+      projectId: string;
+      runId?: string;
+      jobId?: string;
+      clientId?: string;
+    }
+  | { type: "dbt.project.updated"; projectId?: string; clientId?: string }
+  | {
+      type: "dashboard.updated";
+      dashboardId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "notebook.updated";
+      notebookId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "notebook.presence";
+      notebookId: string;
+      clientId: string;
+      userId: string;
+      userName: string;
+      activeCellId?: string | null;
+      gone?: boolean;
+    }
+  | {
+      type: "notebook.tree.updated";
+    }
+  // The (workspace, user) sandbox reported its own state, pushed from inside
+  // the box the moment it changed. Applied directly — no refetch.
+  | {
+      type: "app.box-state";
+      userId: string;
+      state: AppsBoxState;
+    }
+  // An agent in this user's chat asked the UI to open an Apps app tab
+  // (app_open_app). Scoped to the requesting user.
+  | {
+      type: "app.open-app";
+      userId: string;
+      appId: string;
+      slug?: string;
+      title?: string;
+    };
+
+export type RealtimeEventType = RealtimeEvent["type"];
+
+/** What the transport knows at dispatch time; handlers re-check as needed. */
+export interface RealtimeHandlerContext {
+  workspaceId: string | null;
+  /** Logged-in user id — filters user-scoped (forUserId / userId) events. */
+  currentUserId: string | null;
+}
+
+export type RealtimeHandler<T extends RealtimeEventType> = (
+  event: Extract<RealtimeEvent, { type: T }>,
+  ctx: RealtimeHandlerContext,
+) => void;
+
+interface Registration {
+  handler: RealtimeHandler<RealtimeEventType>;
+  suppressOwnEcho: boolean;
+}
+
+const registry = new Map<RealtimeEventType, Map<string, Registration>>();
+
+/** This window's own write, echoed back — the tab already has the content. */
+export function isOwnEcho(event: { clientId?: string }): boolean {
+  return Boolean(event.clientId && event.clientId === realtimeClientId);
+}
+
+/**
+ * Register a reaction to one event type. `key` names the registration
+ * (usually the store's name) so HMR re-runs replace rather than stack.
+ * `suppressOwnEcho` drops events whose clientId is this window's own.
+ */
+export function onRealtimeEvent<T extends RealtimeEventType>(
+  type: T,
+  key: string,
+  handler: RealtimeHandler<T>,
+  opts?: { suppressOwnEcho?: boolean },
+): void {
+  let byKey = registry.get(type);
+  if (!byKey) {
+    byKey = new Map();
+    registry.set(type, byKey);
+  }
+  byKey.set(key, {
+    // The map erases the per-type generic; dispatch re-establishes it by
+    // only routing events whose `type` matched the registration.
+    handler: handler as unknown as RealtimeHandler<RealtimeEventType>,
+    suppressOwnEcho: opts?.suppressOwnEcho ?? false,
+  });
+}
+
+/** Run every registered handler; one throwing must not starve the rest. */
+export function dispatchRealtimeEvent(
+  event: RealtimeEvent,
+  ctx: RealtimeHandlerContext,
+): void {
+  const byKey = registry.get(event.type);
+  if (!byKey) return;
+  for (const { handler, suppressOwnEcho } of byKey.values()) {
+    if (suppressOwnEcho && isOwnEcho(event as { clientId?: string })) continue;
+    try {
+      handler(event, ctx);
+    } catch (error) {
+      // A kind's reaction failing is that kind's problem; the channel and
+      // the other kinds keep working. Next poke/sync self-corrects.
+      console.error("realtime handler failed", event.type, error);
+    }
+  }
+}

--- a/app/src/store/notebookPresenceStore.ts
+++ b/app/src/store/notebookPresenceStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 /**
  * Live "who's in this notebook" state — presence, live cursors, and soft cell
@@ -85,3 +86,18 @@ export const useNotebookPresenceStore = create<NotebookPresenceStore>(set => ({
       return { viewers: { ...state.viewers, [notebookId]: next } };
     }),
 }));
+
+// ── Realtime reaction (presence frames route straight into this store) ──
+onRealtimeEvent("notebook.presence", "notebookPresenceStore", event => {
+  const presence = useNotebookPresenceStore.getState();
+  if (event.gone) {
+    presence.remove(event.notebookId, event.clientId);
+    return;
+  }
+  presence.touch(event.notebookId, {
+    clientId: event.clientId,
+    userId: event.userId,
+    userName: event.userName,
+    activeCellId: event.activeCellId ?? null,
+  });
+});

--- a/app/src/store/notebookStore.ts
+++ b/app/src/store/notebookStore.ts
@@ -6,6 +6,7 @@ import type { KernelOutput } from "../notebook-runtime/kernel";
 import { useUIStore } from "./uiStore";
 import { realtimeClientId } from "../lib/realtime-client-id";
 import { useNotebookTreeStore } from "./notebookTreeStore";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 /**
  * Notebook store — talks to the working-tree CRUD API
@@ -477,3 +478,26 @@ export const useNotebookStore = create<NotebookStore>((set, get) => {
       })),
   };
 });
+
+// ── Realtime reaction (registered here so the notebook domain owns it) ──
+
+// Notebook document changed (human or agent save): pull the authoritative
+// notebook for an OPEN notebook when its version advances (a tab that is
+// mid-save is skipped so it never stomps an in-flight local edit); if the
+// notebook isn't open here, refresh the explorer list so new notebooks
+// appear. Echo-suppressed by clientId.
+onRealtimeEvent(
+  "notebook.updated",
+  "notebookStore",
+  event => {
+    const nb = useNotebookStore.getState();
+    const open = nb.openNotebooks[event.notebookId];
+    if (!open) {
+      void nb.loadNotebooks();
+      return;
+    }
+    if ((open.version ?? 0) >= event.version) return; // stale / own echo
+    void nb.reloadOpenNotebook(event.notebookId);
+  },
+  { suppressOwnEcho: true },
+);

--- a/app/src/store/notebookTreeStore.ts
+++ b/app/src/store/notebookTreeStore.ts
@@ -4,6 +4,7 @@ import {
   type ResourceTreeEntry,
   type TreeAccessLevel,
 } from "./lib/createResourceTreeStore";
+import { onRealtimeEvent } from "./lib/realtime-channel";
 
 export type NotebookAccessLevel = TreeAccessLevel;
 export type NotebookEntry = ResourceTreeEntry;
@@ -76,4 +77,11 @@ export const useNotebookTreeStore = createResourceTreeStore<NotebookEntry>({
         }),
       ),
   },
+});
+
+// ── Realtime reaction: any tree mutation refreshes the explorer ──
+onRealtimeEvent("notebook.tree.updated", "notebookTreeStore", (_event, ctx) => {
+  if (ctx.workspaceId) {
+    void useNotebookTreeStore.getState().refresh(ctx.workspaceId);
+  }
 });

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -23,129 +23,28 @@ import {
   hasBlockedDraftSave,
   hasPendingAgentReview,
 } from "./consoleStore";
-import { useAppsStore, type AppsBoxState } from "./appsStore";
-import { focusAppsTab } from "../apps-runtime/shell";
-import { useDashboardStore } from "./dashboardStore";
-import { useDbtStore } from "./dbtStore";
 import { useNotebookStore } from "./notebookStore";
-import { useNotebookTreeStore } from "./notebookTreeStore";
 import { focusNotebookTab } from "../notebook-runtime/shell";
-import { useNotebookPresenceStore } from "./notebookPresenceStore";
-import { computeDashboardStateHash } from "../utils/stateHash";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
+import {
+  dispatchRealtimeEvent,
+  onRealtimeEvent,
+  type RealtimeEvent,
+} from "./lib/realtime-channel";
+// Each kind registers its realtime reaction next to its own store
+// (realtime-channel registry). Imported for those side effects so every
+// handler is installed before the first event can arrive; the store modules
+// above (console/notebook) register through the same mechanism where they
+// react.
+import "./appsStore";
+import "./dashboardStore";
+import "./dbtStore";
+import "./notebookPresenceStore";
+import "./notebookTreeStore";
 
-/** Mirror of the server's RealtimeEvent union (api realtime.service.ts). */
-export type RealtimeEvent =
-  | {
-      type: "console.updated";
-      consoleId: string;
-      draftRevision: number;
-      name?: string;
-      updatedBy: string;
-      clientId?: string;
-      origin: "draft" | "save" | "agent";
-    }
-  | { type: "console.deleted"; consoleId: string }
-  | {
-      type: "console.run.completed";
-      consoleId: string;
-      status: "success" | "error";
-      rowCount?: number;
-      durationMs?: number;
-      error?: string;
-    }
-  | {
-      type: "chat.ui-intent";
-      chatId: string;
-      intent: "open_console";
-      consoleId: string;
-    }
-  | {
-      type: "chat.ui-intent";
-      chatId: string;
-      intent: "open_notebook";
-      notebookId: string;
-      title?: string;
-    }
-  | { type: "chat.activity"; chatId: string; state: "streaming" | "idle" }
-  | {
-      type: "app.updated";
-      appId: string;
-      updatedBy?: string;
-      origin:
-        | "commit"
-        | "merge"
-        | "discard"
-        | "checkout"
-        | "lifecycle"
-        | "push";
-    }
-  | {
-      type: "dbt.file.updated";
-      projectId: string;
-      path: string;
-      deleted?: boolean;
-      updatedBy: string;
-      clientId?: string;
-      origin: "agent" | "save";
-      /** Draft (uncommitted) edit: only this user's windows should react. */
-      forUserId?: string;
-    }
-  | { type: "dbt.job.updated"; projectId: string; clientId?: string }
-  | {
-      type: "dbt.run.updated";
-      projectId: string;
-      runId?: string;
-      jobId?: string;
-      clientId?: string;
-    }
-  | { type: "dbt.project.updated"; projectId?: string; clientId?: string }
-  | {
-      type: "dashboard.updated";
-      dashboardId: string;
-      version: number;
-      updatedBy: string;
-      clientId?: string;
-      origin: "agent" | "save";
-    }
-  | {
-      type: "notebook.updated";
-      notebookId: string;
-      version: number;
-      updatedBy: string;
-      clientId?: string;
-      origin: "agent" | "save";
-    }
-  | {
-      type: "notebook.presence";
-      notebookId: string;
-      clientId: string;
-      userId: string;
-      userName: string;
-      activeCellId?: string | null;
-      gone?: boolean;
-    }
-  | {
-      type: "notebook.tree.updated";
-    }
-  // The (workspace, user) sandbox reported its own state, pushed from inside
-  // the box the moment it changed. Applied directly — no refetch.
-  | {
-      type: "app.box-state";
-      userId: string;
-      state: AppsBoxState;
-    }
-  // An agent in this user's chat asked the UI to open an Apps app tab
-  // (app_open_app). Scoped to the requesting user.
-  | {
-      type: "app.open-app";
-      userId: string;
-      appId: string;
-      slug?: string;
-      title?: string;
-    };
+export type { RealtimeEvent } from "./lib/realtime-channel";
 
 export type RealtimeStatus = "idle" | "connecting" | "open" | "reconnecting";
 
@@ -424,247 +323,35 @@ export const useRealtimeStore = create<RealtimeStore>()(
       })();
     };
 
-    // Apps (git-backed): any durable change (agent turn, WIP flush, merge)
-    // pokes open windows; the store refetches from the API (git is the
-    // authority, so a refetch is always safe — openFile preserves dirty local
-    // edits and only refreshes clean buffers).
-    const handleAppUpdated = (
-      event: Extract<RealtimeEvent, { type: "app.updated" }>,
-    ) => {
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      const v2 = useAppsStore.getState();
-      // Explorer list (titles, new/deleted apps).
-      void v2.fetchApps(workspaceId);
-      if (event.origin === "lifecycle") return;
-      // §10 monorepo: appId "" = workspace-wide (a workspace worktree
-      // changed; it may span apps) — refresh every app this window has
-      // loaded. A non-empty appId scopes to that app as before.
-      const appIds = event.appId ? [event.appId] : Object.keys(v2.filesByApp);
-      for (const appId of appIds) {
-        // Only refresh heavier per-app state when this window has it loaded.
-        if (v2.filesByApp[appId]) {
-          void v2.fetchFiles(workspaceId, appId);
-          void v2.fetchStatus(workspaceId, appId);
-        }
-        if (v2.branchesByApp[appId]) {
-          void v2.fetchBranches(workspaceId, appId);
-        }
-        const selected = v2.selectedFile[appId];
-        if (selected) {
-          const entry = v2.fileContents[`${appId}\u0000${selected}`];
-          if (entry && !entry.dirty) {
-            void v2.openFile(workspaceId, appId, selected);
-          }
-        }
-      }
-    };
-
-    // User-scoped dbt events (drafts, checkouts) carry forUserId: they only
-    // concern the acting user's windows — a draft is invisible to everyone
-    // else, so other users must not react (or even refetch).
-    const isForAnotherUser = (forUserId?: string): boolean =>
-      Boolean(forUserId && forUserId !== get().currentUserId);
-
-    // Server-executed dbt file mutation tools: pull the fresh file content (or
-    // drop a deleted file) for OPEN dbt projects. Echo-suppressed by clientId;
-    // draft edits (forUserId) only apply to the author's windows.
-    const handleDbtFileUpdated = (
-      event: Extract<RealtimeEvent, { type: "dbt.file.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      if (isForAnotherUser(event.forUserId)) return;
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      const dbt = useDbtStore.getState();
-      // Only touch projects this window has loaded.
-      if (!dbt.filePathsByProject[event.projectId]) return;
-      void dbt.applyRemoteFileUpdate(
-        workspaceId,
-        event.projectId,
-        event.path,
-        event.deleted,
-      );
-    };
-
-    const handleDbtJobUpdated = (
-      event: Extract<RealtimeEvent, { type: "dbt.job.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      const dbt = useDbtStore.getState();
-      if (!dbt.projects.some(p => p._id === event.projectId)) return;
-      void dbt.fetchJobs(workspaceId, event.projectId);
-    };
-
-    const handleDbtRunUpdated = (
-      event: Extract<RealtimeEvent, { type: "dbt.run.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      const dbt = useDbtStore.getState();
-      if (!dbt.projects.some(p => p._id === event.projectId)) return;
-      void dbt.fetchRuns(workspaceId, event.projectId);
-      if (event.jobId) {
-        void dbt.fetchRuns(workspaceId, event.projectId, event.jobId);
-      }
-    };
-
-    const handleDbtProjectUpdated = (
-      event: Extract<RealtimeEvent, { type: "dbt.project.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      // Refresh the project list lazily — only when the dbt surface was used.
-      if (!useDbtStore.getState().projectsLoaded) return;
-      void useDbtStore.getState().fetchProjects(workspaceId);
-    };
-
-    // Server-persisted dashboard saves/restores (draft/published model): pull
-    // the authoritative dashboard for an OPEN dashboard when its version
-    // advances — but NEVER clobber a user mid-edit. Skips the reload if this
-    // tab is editing or holds unsaved local changes (their work wins until they
-    // save/discard); echo-suppressed by clientId; stale events ignored.
-    const handleDashboardUpdated = (
-      event: Extract<RealtimeEvent, { type: "dashboard.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      const workspaceId = get().workspaceId;
-      if (!workspaceId) return;
-      const ds = useDashboardStore.getState();
-      const open = ds.openDashboards[event.dashboardId];
-      if (!open) return; // not open here — explorer/canvas refreshes lazily
-      if ((open.version ?? 0) >= event.version) return; // stale / own echo
-      if (ds.editingDashboards[event.dashboardId]) return; // don't stomp editor
-      const savedHash = ds.savedStateHashes[event.dashboardId];
-      if (
-        savedHash !== undefined &&
-        computeDashboardStateHash(open) !== savedHash
-      ) {
-        return; // unsaved local changes — preserve them
-      }
-      void ds.reloadDashboard(workspaceId, event.dashboardId);
-    };
-
-    // Notebook document changed (human or agent save): pull the authoritative
-    // notebook for an OPEN notebook when its version advances (a tab that is
-    // mid-save is skipped so it never stomps an in-flight local edit); if the
-    // notebook isn't open here, refresh the explorer list so new notebooks
-    // appear. Echo-suppressed by clientId.
-    const handleNotebookUpdated = (
-      event: Extract<RealtimeEvent, { type: "notebook.updated" }>,
-    ) => {
-      if (event.clientId && event.clientId === realtimeClientId) return;
-      const nb = useNotebookStore.getState();
-      const open = nb.openNotebooks[event.notebookId];
-      if (!open) {
-        void nb.loadNotebooks();
-        return;
-      }
-      if ((open.version ?? 0) >= event.version) return; // stale / own echo
-      void nb.reloadOpenNotebook(event.notebookId);
-    };
-
-    const handleNotebookPresence = (
-      event: Extract<RealtimeEvent, { type: "notebook.presence" }>,
-    ) => {
-      const presence = useNotebookPresenceStore.getState();
-      if (event.gone) {
-        presence.remove(event.notebookId, event.clientId);
-        return;
-      }
-      presence.touch(event.notebookId, {
-        clientId: event.clientId,
-        userId: event.userId,
-        userName: event.userName,
-        activeCellId: event.activeCellId ?? null,
+    // The console + chat reactions live here because they ARE this store's
+    // business: they drive the poke-then-pull revision sync and the chat
+    // activity state above. Everything else registers next to its own store.
+    onRealtimeEvent("console.updated", "realtimeStore", handleConsoleUpdated);
+    onRealtimeEvent("console.deleted", "realtimeStore", handleConsoleDeleted);
+    onRealtimeEvent(
+      "console.run.completed",
+      "realtimeStore",
+      handleRunCompleted,
+    );
+    onRealtimeEvent("chat.ui-intent", "realtimeStore", handleChatUiIntent);
+    onRealtimeEvent("chat.activity", "realtimeStore", event => {
+      set(state => {
+        state.chatActivity[event.chatId] = event.state;
       });
-    };
-
-    const handleNotebookTreeUpdated = () => {
-      const ws = get().workspaceId;
-      if (ws) void useNotebookTreeStore.getState().refresh(ws);
-    };
-
-    const handleBoxState = (
-      event: Extract<RealtimeEvent, { type: "app.box-state" }>,
-    ) => {
-      useAppsStore.getState().applyBoxState(event.userId, event.state);
-    };
-
-    const handleOpenApp = (
-      event: Extract<RealtimeEvent, { type: "app.open-app" }>,
-    ) => {
-      // The user's own agent asked the UI to show an app. Scoped to the
-      // requesting user — a teammate's agent must not steal this focus.
-      const me = get().currentUserId;
-      if (!me || event.userId !== me) return;
-      focusAppsTab(event.appId, event.title ?? event.slug ?? "App", event.slug);
-    };
+      // Agent turn finished: reconcile open consoles. Tool-agnostic
+      // catch-all for any console.updated poke missed during the turn
+      // (SSE blip, poke-before-tab-open race) and for detached
+      // server-side runs that completed while this window was attached.
+      if (event.state === "idle" && event.chatId === get().activeChatId) {
+        scheduleSync();
+      }
+    });
 
     const handleEvent = (event: RealtimeEvent) => {
-      switch (event.type) {
-        case "console.updated":
-          handleConsoleUpdated(event);
-          break;
-        case "app.updated":
-          handleAppUpdated(event);
-          break;
-        case "app.box-state":
-          handleBoxState(event);
-          break;
-        case "app.open-app":
-          handleOpenApp(event);
-          break;
-        case "dashboard.updated":
-          handleDashboardUpdated(event);
-          break;
-        case "notebook.updated":
-          handleNotebookUpdated(event);
-          break;
-        case "notebook.tree.updated":
-          handleNotebookTreeUpdated();
-          break;
-        case "notebook.presence":
-          handleNotebookPresence(event);
-          break;
-        case "dbt.file.updated":
-          handleDbtFileUpdated(event);
-          break;
-        case "dbt.job.updated":
-          handleDbtJobUpdated(event);
-          break;
-        case "dbt.run.updated":
-          handleDbtRunUpdated(event);
-          break;
-        case "dbt.project.updated":
-          handleDbtProjectUpdated(event);
-          break;
-        case "console.deleted":
-          handleConsoleDeleted(event);
-          break;
-        case "console.run.completed":
-          handleRunCompleted(event);
-          break;
-        case "chat.ui-intent":
-          handleChatUiIntent(event);
-          break;
-        case "chat.activity":
-          set(state => {
-            state.chatActivity[event.chatId] = event.state;
-          });
-          // Agent turn finished: reconcile open consoles. Tool-agnostic
-          // catch-all for any console.updated poke missed during the turn
-          // (SSE blip, poke-before-tab-open race) and for detached
-          // server-side runs that completed while this window was attached.
-          if (event.state === "idle" && event.chatId === get().activeChatId) {
-            scheduleSync();
-          }
-          break;
-      }
+      dispatchRealtimeEvent(event, {
+        workspaceId: get().workspaceId,
+        currentUserId: get().currentUserId,
+      });
     };
 
     const scheduleReconnect = () => {


### PR DESCRIPTION
The realtime handler inversion from the DRY audit: `realtimeStore` reached into six other stores — ~250 lines of apps/dashboard/dbt/notebook domain logic living inside the transport file, with the `clientId` echo guard pasted **seven times**.

## Shape

- **`store/lib/realtime-channel.ts`** — the `RealtimeEvent` union plus a typed registry. `onRealtimeEvent(type, key, handler, { suppressOwnEcho })`: keyed registration (Vite HMR re-runs replace instead of stack), the echo guard declared once as an option, per-handler error isolation (one kind's reaction throwing can't starve the others).
- **Each kind's reaction now lives next to its store** — `appsStore` (app.updated / box-state / open-app), `dashboardStore`, `dbtStore` (×4), `notebookStore`, `notebookPresenceStore`, `notebookTreeStore`. Handler bodies are verbatim moves; all the mid-edit/version/user-scoping guards are unchanged and now sit beside the state they read.
- **`realtimeStore` keeps what is genuinely its business**: the EventSource transport (reconnect, watchdog, wake heuristics), the console poke-then-pull revision sync, and chat activity/intents — registered through the same registry and dispatched uniformly. It imports the other store modules for side effects only, so every handler is installed before the first event can arrive. **984 → 671 lines**, and the transport file no longer knows any kind's semantics.

New tab kinds get the same rule folder/version routes got on the backend: register through the channel, never add a case to a switch in the transport file.

## Tests

`realtime-channel.test.ts`: routing + dispatch context, keyed replacement, echo suppression (own / other / absent clientId), error isolation. Full app suite green (63 files / 435 — the count delta vs. yesterday is master's dbt migration trimming its frontend tests, verified by stashing this diff). Typecheck + lint clean. No API contract changes.

Also in this session's cleanup: removed the stale `mako-version-comment-pr` worktree (PR #660 merged long ago).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZR5pr8Wxrw4NfPHSsb7CW