### PR TITLE
feat(skills): agent saves are proposals; honest counters; capped per-turn catalog

### DIFF
--- a/api/src/agent-lib/tools/skill-tools.ts
+++ b/api/src/agent-lib/tools/skill-tools.ts
@@ -120,20 +120,44 @@ export function createSkillTools(workspaceId: string, userId?: string) {
   return {
     save_skill: tool({
       description: [
-        "Save or overwrite a workspace-scoped skill — a named playbook that",
-        "will be auto-injected into future sessions when its `loadWhen`",
-        "trigger matches the user query. Use this whenever the user teaches",
-        "you something durable about this workspace (a schema fact, a gotcha,",
-        "a query pattern, a definition). Skills survive across sessions.",
+        "Propose or update a workspace-scoped skill — a named playbook",
+        "retrieved in future sessions when its `loadWhen` trigger matches.",
         "",
-        "Choose `name` as a stable snake_case identifier (e.g.",
-        "`mrr_walkthrough_fr`, `sms_funnel_conversion`). Write `loadWhen` as",
-        "a trigger phrase — what query or task should cause this to load.",
-        "Keep `body` compact and structured.",
+        "THE BAR: save only knowledge a TEAMMATE would need in a MONTH —",
+        "durable, cross-cutting workspace facts (metric definitions, mart",
+        "semantics, domain rules, data-source caveats). Do NOT save:",
+        "session-specific bug workarounds, product behavior of Mako itself",
+        "(it changes under you), or one-off task notes.",
+        "",
+        "ROUTE BY SCOPE before saving: knowledge about ONE app belongs in",
+        "that app's AGENTS.md (`apps/<slug>/AGENTS.md`, edit it with the app",
+        "file tools); dbt-project conventions belong in `dbt/.makorules.md`;",
+        "the workspace's overall business context belongs in `PROMPT.md`.",
+        "Only what fits none of those becomes a skill.",
+        "",
+        "A NEW skill you save is a PROPOSAL: it is committed to the repo but",
+        "stays inactive (suppressed) until a person activates it in the",
+        "Skills panel or flips `suppressed: false` in its SKILL.md. Tell the",
+        "user you proposed it. Updates to an existing skill apply directly.",
+        "",
+        "Choose `name` as a stable snake_case identifier; write `loadWhen`",
+        "as the trigger phrase; keep `body` compact and structured.",
       ].join("\n"),
       inputSchema: saveSkillSchema,
       execute: async input => {
-        return saveSkill(workspaceId, input, authorId);
+        const result = await saveSkill(workspaceId, input, authorId, {
+          origin: "agent",
+        });
+        if (result.success && result.skill.pendingApproval) {
+          return {
+            ...result,
+            note:
+              "Saved as a PROPOSAL — inactive until a person activates it " +
+              "in the Skills panel (or sets `suppressed: false` in " +
+              `skills/${result.skill.name}/SKILL.md). Let the user know.`,
+          };
+        }
+        return result;
       },
     }),
     delete_skill: tool({

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4240,8 +4240,12 @@ export interface ISkill extends Document {
   createdBy: string;
   /** Soft-disable without deletion — lets admins A/B whether a skill helps. */
   suppressed: boolean;
+  /** Explicit load_skill calls — the honest "someone reached for this". */
   useCount: number;
   lastUsedAt?: Date;
+  /** Auto-injection exposure (pre-turn retrieval). NOT a usefulness signal. */
+  injectedCount?: number;
+  lastInjectedAt?: Date;
   /** Single-slot undo for wrong overwrites. */
   previousBody?: string;
   previousUpdatedAt?: Date;
@@ -4272,6 +4276,8 @@ const SkillSchema = new Schema<ISkill>(
     createdBy: { type: String, required: true },
     suppressed: { type: Boolean, default: false },
     useCount: { type: Number, default: 0 },
+    injectedCount: { type: Number, default: 0 },
+    lastInjectedAt: { type: Date },
     lastUsedAt: { type: Date },
     previousBody: { type: String },
     previousUpdatedAt: { type: Date },

--- a/api/src/services/skills.service.test.ts
+++ b/api/src/services/skills.service.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Skill discipline (apps.md §22): agent saves are proposals, the per-turn
+ * index is capped, and the exposure counter is separate from the honest
+ * use counter. Real bare repo + mongodb-memory-server, embeddings off.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { Skill } from "../database/workspace-schema";
+import {
+  initRepo,
+  readBlob,
+  repoDirFor,
+  DEFAULT_BRANCH,
+} from "../apps/repository.service";
+import { retrieveRelevantSkills, saveSkill } from "./skills.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+const WS = new Types.ObjectId().toString();
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skills-discipline-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.AI_GATEWAY_API_KEY;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await Skill.deleteMany({});
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+  await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+});
+
+const input = (name: string) => ({
+  name,
+  loadWhen: `when asked about ${name}`,
+  body: `How to handle ${name}.`,
+});
+
+describe("agent saves are proposals", () => {
+  it("a NEW agent-origin skill starts suppressed in Mongo AND in the file", async () => {
+    const result = await saveSkill(WS, input("mrr_walkthrough"), "agent", {
+      origin: "agent",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.skill.pendingApproval).toBe(true);
+
+    const row = await Skill.findOne({ name: "mrr_walkthrough" });
+    expect(row?.suppressed).toBe(true);
+    const blob = await readBlob(
+      repoDirFor(WS),
+      `refs/heads/${DEFAULT_BRANCH}`,
+      "skills/mrr_walkthrough/SKILL.md",
+    );
+    expect(blob.contents).toContain("suppressed: true");
+
+    // Suppressed proposals never reach the injected index.
+    const retrieval = await retrieveRelevantSkills(WS, "mrr walkthrough");
+    expect(retrieval.index.some(e => e.name === "mrr_walkthrough")).toBe(false);
+  });
+
+  it("a user-origin save is active immediately; agent UPDATES keep state", async () => {
+    const user = await saveSkill(WS, input("churn_definitions"), "u1", {
+      origin: "user",
+    });
+    expect(user.success && !user.skill.pendingApproval).toBe(true);
+    expect(
+      (await Skill.findOne({ name: "churn_definitions" }))?.suppressed,
+    ).toBe(false);
+
+    // Agent improving the existing ACTIVE skill must not deactivate it.
+    const update = await saveSkill(
+      WS,
+      { ...input("churn_definitions"), body: "Better body." },
+      "agent",
+      { origin: "agent" },
+    );
+    expect(update.success).toBe(true);
+    expect(
+      (await Skill.findOne({ name: "churn_definitions" }))?.suppressed,
+    ).toBe(false);
+  });
+});
+
+describe("index cap + honest counters", () => {
+  it("shows at most 30 workspace entries and reports the omission count", async () => {
+    for (let i = 0; i < 35; i++) {
+      await Skill.create({
+        workspaceId: new Types.ObjectId(WS),
+        name: `skill_${i}`,
+        loadWhen: `topic ${i}`,
+        body: "b",
+        entities: [],
+        scopeType: "workspace",
+        createdBy: "u1",
+        suppressed: false,
+        useCount: 0,
+      });
+    }
+    const result = await retrieveRelevantSkills(WS, "anything at all");
+    const workspaceShown = result.index.filter(e => e.scope === "workspace");
+    expect(workspaceShown.length).toBe(30);
+    expect(result.omittedFromIndex).toBe(5);
+  });
+
+  it("auto-injection bumps injectedCount, never useCount", async () => {
+    await Skill.create({
+      workspaceId: new Types.ObjectId(WS),
+      name: "stripe_mrr_churn",
+      loadWhen: "stripe mrr churn analysis",
+      body: "the playbook",
+      entities: ["stripe", "mrr", "churn"],
+      scopeType: "workspace",
+      createdBy: "u1",
+      suppressed: false,
+      useCount: 0,
+    });
+    const result = await retrieveRelevantSkills(WS, "analyze stripe mrr churn");
+    expect(result.injected.map(i => i.name)).toContain("stripe_mrr_churn");
+    // The bump is fire-and-forget; give it a beat.
+    await new Promise(r => setTimeout(r, 150));
+    const row = await Skill.findOne({ name: "stripe_mrr_churn" });
+    expect(row?.injectedCount).toBe(1);
+    expect(row?.useCount).toBe(0);
+  });
+});

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -48,6 +48,13 @@ const AUTO_INJECT_LIMIT = 3;
  * `load_skill` explicitly if it decides it needs it.
  */
 const AUTO_INJECT_THRESHOLD = 0.25;
+/**
+ * Workspace entries shown in the always-injected index. The full catalog
+ * grew past 200 (apps.md §22) — injecting every trigger line each turn cost
+ * ~4-5K tokens of mostly-irrelevant catalog. The rest stays reachable via
+ * search_skills / get_relevant_skills, and the block says how many.
+ */
+const SKILL_INDEX_LIMIT = 30;
 /** Weights for the composite retrieval score. Sum should be ~1. */
 const ENTITY_WEIGHT = 0.6;
 const SEMANTIC_WEIGHT = 0.4;
@@ -83,8 +90,10 @@ export interface SkillRetrievalHit {
 }
 
 export interface SkillRetrievalResult {
-  /** The compact index of every non-suppressed skill — always injected. */
+  /** Compact index: top workspace skills for THIS turn + all system skills. */
   index: SkillIndexEntry[];
+  /** Workspace skills not shown in the index (find via search_skills). */
+  omittedFromIndex: number;
   /** Top-k hits with bodies for auto-injection (score >= threshold). */
   injected: SkillRetrievalHit[];
   /** Candidates that scored but didn't clear the threshold (for trace). */
@@ -165,8 +174,26 @@ export async function saveSkill(
   workspaceId: string,
   input: SkillInput,
   createdBy: string,
+  options: {
+    /**
+     * "agent": a NEW skill starts SUPPRESSED — a proposal a human activates
+     * in the Skills panel (or by flipping `suppressed: false` in the file).
+     * The eager-hoarding era put 200 unreviewed skills in the live index
+     * (apps.md §22); proposals cost nothing until someone approves them.
+     * Updates to an existing skill keep its current suppressed state.
+     */
+    origin?: "agent" | "user";
+  } = {},
 ): Promise<
-  | { success: true; skill: { id: string; name: string; created: boolean } }
+  | {
+      success: true;
+      skill: {
+        id: string;
+        name: string;
+        created: boolean;
+        pendingApproval?: boolean;
+      };
+    }
   | { success: false; error: string }
 > {
   const validation = validateInput(input);
@@ -188,6 +215,7 @@ export async function saveSkill(
     workspaceId: new Types.ObjectId(workspaceId),
     name,
   });
+  const pendingApproval = options.origin === "agent" && !existing;
 
   if (!existing) {
     const totalSkills = await Skill.countDocuments({
@@ -228,7 +256,7 @@ export async function saveSkill(
         // The file carries the author-DECLARED entities; the Mongo row below
         // carries the declared ∪ extracted union the retrieval uses.
         entities: unionEntities(input.entities, []),
-        suppressed: !!existing?.suppressed,
+        suppressed: pendingApproval || !!existing?.suppressed,
         body,
       },
       { author: await skillCommitAuthor(createdBy), loadAdoptable },
@@ -252,12 +280,17 @@ export async function saveSkill(
       embeddingModel: model ?? undefined,
       scopeType: "workspace",
       createdBy,
-      suppressed: false,
+      suppressed: pendingApproval,
       useCount: 0,
     });
     return {
       success: true,
-      skill: { id: created._id.toString(), name: created.name, created: true },
+      skill: {
+        id: created._id.toString(),
+        name: created.name,
+        created: true,
+        ...(pendingApproval ? { pendingApproval: true } : {}),
+      },
     };
   }
 
@@ -566,10 +599,12 @@ export async function retrieveRelevantSkills(
     suppressed: { $ne: true },
   })
     .select("name loadWhen suppressed useCount entities")
-    .sort({ useCount: -1, updatedAt: -1 })
+    // NOT sorted by useCount: the counter measures auto-injection exposure,
+    // and sorting by it fed back into what got injected (rich-get-richer).
+    .sort({ updatedAt: -1 })
     .lean();
 
-  const index: SkillIndexEntry[] = indexDocs.map(s => ({
+  const workspaceIndexAll: SkillIndexEntry[] = indexDocs.map(s => ({
     id: (s._id as Types.ObjectId).toString(),
     name: s.name,
     loadWhen: s.loadWhen,
@@ -579,20 +614,35 @@ export async function retrieveRelevantSkills(
   }));
 
   const systemSkills = getSystemSkillIndex();
-  for (const skill of systemSkills) {
-    index.push({
-      id: skill.id,
-      name: skill.name,
-      loadWhen: skill.description,
-      scope: "system",
-      suppressed: false,
-      useCount: 0,
-      references: skill.references,
-    });
-  }
+  const systemIndex: SkillIndexEntry[] = systemSkills.map(skill => ({
+    id: skill.id,
+    name: skill.name,
+    loadWhen: skill.description,
+    scope: "system",
+    suppressed: false,
+    useCount: 0,
+    references: skill.references,
+  }));
 
-  if (index.length === 0 || !queryText || queryText.trim().length === 0) {
-    return { index, injected: [], considered: [], queryEntities: [] };
+  const buildIndex = (workspaceShown: SkillIndexEntry[]): SkillIndexEntry[] => [
+    ...workspaceShown,
+    ...systemIndex,
+  ];
+  const omitted = Math.max(0, workspaceIndexAll.length - SKILL_INDEX_LIMIT);
+
+  if (
+    (workspaceIndexAll.length === 0 && systemIndex.length === 0) ||
+    !queryText ||
+    queryText.trim().length === 0
+  ) {
+    // No query to rank against: most recently updated first (the docs sort).
+    return {
+      index: buildIndex(workspaceIndexAll.slice(0, SKILL_INDEX_LIMIT)),
+      omittedFromIndex: omitted,
+      injected: [],
+      considered: [],
+      queryEntities: [],
+    };
   }
 
   const queryEntities = extractEntities(queryText);
@@ -707,22 +757,37 @@ export async function retrieveRelevantSkills(
     }
   }
 
-  // Fire-and-forget: bump useCount + lastUsedAt for workspace skills we
-  // injected. System skills have no Mongo row, so skip them.
+  // Fire-and-forget: auto-injection bumps injectedCount (EXPOSURE), never
+  // useCount — useCount is reserved for explicit load_skill calls so the two
+  // signals stay honest for curation. System skills have no Mongo row.
   const workspaceInjectedIds = injected
     .filter(i => i.scope === "workspace")
     .map(i => new Types.ObjectId(i.id));
   if (workspaceInjectedIds.length > 0) {
     void Skill.updateMany(
       { _id: { $in: workspaceInjectedIds } },
-      { $inc: { useCount: 1 }, $set: { lastUsedAt: new Date() } },
+      { $inc: { injectedCount: 1 }, $set: { lastInjectedAt: new Date() } },
     ).catch(err => {
       logger.debug("Skill useCount bump failed", { error: err });
     });
   }
 
+  // The shown workspace index follows THIS turn's relevance ranking; ties
+  // (score 0) keep the recency order from the query above.
+  const scoreById = new Map(workspaceCandidates.map(c => [c.id, c.score]));
+  const shownWorkspace = [...workspaceIndexAll]
+    .map((entry, position) => ({ entry, position }))
+    .sort(
+      (a, b) =>
+        (scoreById.get(b.entry.id) ?? 0) - (scoreById.get(a.entry.id) ?? 0) ||
+        a.position - b.position,
+    )
+    .slice(0, SKILL_INDEX_LIMIT)
+    .map(x => x.entry);
+
   return {
-    index,
+    index: buildIndex(shownWorkspace),
+    omittedFromIndex: omitted,
     injected,
     considered: considered.slice(0, 5),
     queryEntities,
@@ -756,6 +821,12 @@ export function renderSkillsPromptBlock(result: SkillRetrievalResult): string {
         ? ` (references: ${s.references.join(", ")})`
         : "";
     lines.push(`- [${s.scope}] \`${s.name}\`: ${s.loadWhen}${references}`);
+  }
+  if (result.omittedFromIndex > 0) {
+    lines.push(
+      `- …plus ${result.omittedFromIndex} more workspace skills not shown — ` +
+        "find them with `search_skills` or `get_relevant_skills`.",
+    );
   }
 
   if (result.injected.length > 0) {

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "src/apps/worktree.service.test.ts",
       "src/apps/workspace-repo.test.ts",
       "src/apps/workspace-prompt.test.ts",
+      "src/services/skills.service.test.ts",
       "src/apps/bindings.service.test.ts",
       "src/apps/cloud-repo.service.test.ts",
       "src/apps/adversarial.test.ts",

--- a/apps.md
+++ b/apps.md
@@ -2792,3 +2792,39 @@ deploy log were the buffering timeouts; the rehearsal masked it because the
 scratch repo short-circuited before any Mongo read). The prompt migration
 carries the mongoose connect with a comment saying never to remove it, and
 the salvage was recovered by pushing the rehearsal's identical branches.
+
+## 22. Skill discipline: proposals, honest counters, a capped catalog (2026-09-01)
+
+The pre-git agent hoarded 202 workspace skills in two months (83 from one
+user's sessions), a large share of them session-specific gotchas about
+machinery deleted this very week. Three mechanical faults made it possible
+and made it costly:
+
+1. **No bar on writes** — `save_skill` was rewarded for saving everything.
+2. **A lying counter** — auto-injection bumped the same `useCount` as an
+   explicit `load_skill`, and the index was SORTED by it, so exposure fed
+   exposure (193/200 skills showed 10+ "uses", zero never-used, top 1,578).
+3. **A linear tax** — all 200 trigger lines were injected into EVERY turn's
+   system prompt (~4-5K tokens of catalog).
+
+The fix, shipped as one PR:
+
+- **Agent saves are proposals**: a NEW skill saved by the agent commits to
+  the repo `suppressed: true` and stays out of the live index until a person
+  activates it (Skills panel toggle, or flipping the frontmatter in
+  `skills/<name>/SKILL.md` — the push-sync applies it). Updates to an
+  existing active skill apply directly. The tool's description now carries
+  the bar (would a teammate need it in a month?) and routes by scope:
+  app-specific → `apps/<slug>/AGENTS.md`, dbt → `dbt/.makorules.md`,
+  business context → `PROMPT.md`.
+- **Honest telemetry**: auto-injection bumps `injectedCount`/`lastInjectedAt`
+  (exposure); `useCount`/`lastUsedAt` is reserved for explicit `load_skill`
+  (someone reached for it). The index is no longer sorted by any counter.
+- **Capped catalog**: the per-turn index shows the top 30 workspace skills
+  ranked by THIS turn's retrieval score (recency when no query), plus a
+  "…N more via search_skills" line; system skills always show.
+
+Curation of the existing 202 is a separate reviewed commit (skills-triage
+branch): delete stale-machinery gotchas, fold app-specific knowledge into
+the apps' own AGENTS.md, merge duplicate families. The push-sync makes the
+merge self-applying — deleted files drop their index rows, no migration.


### PR DESCRIPTION
202 skills in two months, most of them session gotchas about machinery that
no longer exists, every trigger line injected into every turn (~4-5K
tokens), and a useCount that measured auto-injection exposure while the
index was sorted by it (exposure feeding exposure: 193/200 at 10+ "uses").

Now (apps.md §22): a NEW skill saved by the agent commits suppressed — a
proposal a person activates in the Skills panel or by flipping the
frontmatter (push-sync applies it); updates to active skills apply
directly. save_skill's description carries the would-a-teammate-need-this
bar and routes by scope (app knowledge → apps/<slug>/AGENTS.md, dbt →
dbt/.makorules.md, business context → PROMPT.md). Auto-injection bumps a
new injectedCount; useCount is reserved for explicit load_skill. The
per-turn index caps at 30 workspace entries ranked by this turn's retrieval
score, with a "…N more via search_skills" line.

Curation of the existing 202 lands separately as a reviewed skills-triage
branch on the workspace repo.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat
