### PR TITLE
Apps: scope turn-end auto-commit to the app folders the chat touched

### DIFF
--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -257,7 +257,7 @@ export function createAppsTools({
 
     app_bash: tool({
       description:
-        "Run a bash command in the app's sandbox session. cwd is the APP's folder (apps/<slug>) inside the workspace repo, not the repo root, so package.json and src/ are right here and `cwd` is interpreted relative to it. Use for anything a developer would do in a terminal: ls, grep, sed, cat, node, npm/pnpm install, npm run build, git status/log/diff. Each call is a one-shot command: backgrounding a long-running process (`vite &`) does NOT leave a server running the user can reach — use the app's preview controls for that. Git is fully yours: commit with app_commit or run git yourself — branch, checkout, merge, push; the sandbox is a real clone with a real remote. Note the checkout is SHARED with the user, so a branch switch changes what they see too — do it when the task calls for it, and say so.",
+        "Run a bash command in the app's sandbox session. cwd is the APP's folder (apps/<slug>) inside the workspace repo, not the repo root, so package.json and src/ are right here and `cwd` is interpreted relative to it. Use for anything a developer would do in a terminal: ls, grep, sed, cat, node, npm/pnpm install, npm run build, git status/log/diff. Each call is a one-shot command: backgrounding a long-running process (`vite &`) does NOT leave a server running the user can reach — use the app's preview controls for that. Git is fully yours: commit with app_commit or run git yourself — branch, checkout, merge, push; the sandbox is a real clone with a real remote. Note the checkout is SHARED with the user AND their other concurrent chats: a branch switch changes what everyone sees (do it when the task calls for it, and say so), and dirty files or 'Mako Agent' commits you don't recognize are someone else's in-flight work — normal, not corruption; leave them alone. Your end-of-turn auto-commit only includes apps YOU touched this turn.",
       inputSchema: z.object({
         appId: z
           .string()
@@ -494,6 +494,7 @@ export function createAppsTools({
     app_status: tool({
       description:
         "Show an Apps worktree's durable status: base commit, WIP snapshot, changed files vs base, and whether the branch has moved. " +
+        "`changes` is THIS app's uncommitted slice; `repoChanges` is the whole shared working copy — entries outside this app usually belong to the user or one of their other chats, and are not yours to commit, revert, or clean. " +
         "This is the SANDBOX's git state, not what is deployed — for the live app's published commit, use app_publish_status.",
       inputSchema: z.object({ appId: z.string() }),
       execute: async ({ appId }) => {
@@ -501,7 +502,22 @@ export function createAppsTools({
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
           const status = await worktreeStatus(scopeOf(loaded.project), actorId);
-          return { success: true, status };
+          // The working copy is shared (user + their other chats), so foreign
+          // WIP is normal. Say so explicitly — without this, agents read a
+          // stranger's dirty files (or a turn commit they didn't make) as
+          // corruption and burn turns "fixing" it.
+          const root = `${appRootFor(loaded.project)}/`;
+          const foreign =
+            status?.repoChanges.filter(ch => !ch.path.startsWith(root))
+              .length ?? 0;
+          return {
+            success: true,
+            status,
+            hint:
+              foreign > 0
+                ? `${foreign} uncommitted change(s) elsewhere in the repo (outside ${appRootFor(loaded.project)}) — likely the user's or a concurrent chat's in-flight work. Leave them alone: don't commit, revert, or clean them. Your end-of-turn auto-commit only includes apps you touched this turn.`
+                : undefined,
+          };
         } catch (error) {
           return { success: false, error: errorMessage(error) };
         }
@@ -881,7 +897,7 @@ export function createAppsTools({
 
     app_commit: tool({
       description:
-        "Commit the current WIP snapshot of an Apps project onto this conversation's branch with a message (compare-and-swap; fails cleanly if the branch moved). Note: uncommitted work is auto-committed at the end of every turn anyway; use this for meaningful mid-turn checkpoints with a good message.",
+        "Commit THIS app's uncommitted work (scoped to its apps/<slug> folder — other apps' and other chats' in-flight files in the shared checkout are untouched) onto the current branch with a message. Note: apps you touched are auto-committed at the end of every turn anyway; use this for meaningful mid-turn checkpoints with a good message.",
       inputSchema: z.object({
         appId: z.string(),
         message: z.string().min(1).describe("Commit message"),

--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -47,6 +47,7 @@ import {
   worktreeStatus,
   writeFile,
   scopeOf,
+  appRootFor,
 } from "../../apps/worktree.service";
 import { materializeAppBinding } from "../../apps/bindings.service";
 import {
@@ -71,6 +72,15 @@ export interface AppsToolsOptions {
   userId?: string;
   /** Resolved model accepts image input; undefined = assume yes (external MCP). */
   supportsVision?: boolean;
+  /**
+   * Caller-owned set the write-capable tools add their app's repo-relative
+   * root (`apps/<slug>`) to. The sandbox is ONE working copy per
+   * (workspace, user) shared by every chat that user runs, so the turn-end
+   * auto-commit needs to know which folders THIS chat wrote to — otherwise it
+   * `git add -A`s the whole tree and sweeps a concurrent chat's in-flight
+   * work on another app into this turn's commit.
+   */
+  touchedPaths?: Set<string>;
 }
 
 type LoadResult = { project: IAppProject } | { error: string };
@@ -79,6 +89,7 @@ export function createAppsTools({
   workspaceId,
   userId,
   supportsVision,
+  touchedPaths,
 }: AppsToolsOptions): ToolSet {
   // A conversation is not a line of work.
   //
@@ -95,6 +106,10 @@ export function createAppsTools({
   const actorId = userId ?? "api-key";
   const ensureActorWorktree = (project: IAppProject) =>
     ensureWorktree(project, actorId);
+  // Every tool that can dirty the working copy records the app folder it
+  // wrote to; see AppsToolsOptions.touchedPaths for why.
+  const markTouched = (project: IAppProject) =>
+    touchedPaths?.add(appRootFor(project));
   // The branch is whatever the checkout is on — main by default, or wherever
   // the user (or this agent, via `git checkout` in app_bash) switched to.
   // Read it fresh per call; a cached value goes stale the moment anyone
@@ -223,6 +238,7 @@ export function createAppsTools({
           // heard yet, so without a catch-up the brand-new app lists as
           // empty and the agent rebuilds the scaffold by hand over it.
           await catchUpLiveBox(project, actorId);
+          markTouched(project);
           const { entries } = await listFiles(project, actorId);
           return {
             success: true,
@@ -266,6 +282,7 @@ export function createAppsTools({
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
           const handle = await ensureActorWorktree(loaded.project);
+          markTouched(loaded.project);
           const result = await execInWorktree(handle, command, {
             cwd,
             timeoutMs: timeoutSeconds ? timeoutSeconds * 1000 : undefined,
@@ -409,6 +426,7 @@ export function createAppsTools({
             }
           }
           const handle = await ensureActorWorktree(loaded.project);
+          markTouched(loaded.project);
           await writeFile(handle, relPath, contents);
           markRead(appId, relPath);
           return { success: true, path: relPath };
@@ -453,6 +471,7 @@ export function createAppsTools({
             replaceAll ?? false,
           );
           if (!result.ok) return { success: false, error: result.error };
+          markTouched(loaded.project);
           await writeFile(handle, relPath, result.contents);
           return {
             success: true,
@@ -846,6 +865,7 @@ export function createAppsTools({
         const loaded = await loadProject(appId, { write: true });
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
+          markTouched(loaded.project);
           const result = await materializeAppBinding(
             loaded.project,
             name,
@@ -871,7 +891,13 @@ export function createAppsTools({
         if ("error" in loaded) return { success: false, error: loaded.error };
         try {
           const handle = await ensureActorWorktree(loaded.project);
-          const result = await commitWorktree(handle, message);
+          markTouched(loaded.project);
+          // Scoped to THIS app's folder: the working copy is shared by every
+          // chat this user runs, so an unscoped commit would sweep a
+          // concurrent chat's in-flight work on another app in with it.
+          const result = await commitWorktree(handle, message, undefined, {
+            paths: [handle.appRoot],
+          });
           return { success: result.committed, ...result };
         } catch (error) {
           logger.error("app_commit failed", { error, appId });

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -24,14 +24,41 @@ use the `app_*` tools described here.
 - You work on THE USER'S branch (`user/<id>`), the same one they edit from the
   UI and the terminal — a conversation is not a line of work, so it does not
   get a branch of its own. Your accumulated changes are committed and pushed
-  automatically at the end of every turn; committed-and-pushed work survives
-  the sandbox dying, uncommitted work lives only in the working copy, exactly
-  as on a laptop.
+  automatically at the end of every turn, scoped to the apps YOUR tools
+  touched this turn; committed-and-pushed work survives the sandbox dying,
+  uncommitted work lives only in the working copy, exactly as on a laptop.
 - The user merges their branch into `main` from the branch menu, or you can
   merge with `app_merge_to_main` when they ask you to ship.
 - The sandbox may be hot, paused (E2B resumes it), or dead (a fresh clone
   replaces it). Never assume in-memory state from earlier turns; the durable
   truth is what reached the server.
+
+## You are not alone in this checkout
+
+There is ONE working copy per user per workspace, shared by the user's UI,
+their terminal, and every chat they run — including other agent sessions
+working on other apps at the same time. Expect traces of work that is not
+yours, and treat them as normal, not as corruption:
+
+- **Dirty files outside your app** (`app_status`'s `repoChanges`, or
+  `git status` in `app_bash`) are usually the user's or a concurrent chat's
+  in-flight work. Leave them alone: never commit, revert, discard, or clean
+  paths outside the app you were asked to work on.
+- **Commits you don't recognize** — committer `Mako Agent` (another chat's
+  turn-end commit), or `edit: <path>` (a user save) — are other sessions
+  doing their job. Never rewrite, revert, or "fix" them; check `git log` if
+  you need orientation, then move on.
+- **An unexpectedly clean tree** after you left uncommitted work usually
+  means a turn-end auto-commit already captured it. Confirm with `git log`
+  (your changes will be in an `Agent turn:` commit) instead of assuming loss.
+- **Your end-of-turn auto-commit and `app_commit` are scoped** to the
+  `apps/<slug>` folders your own tools touched — you cannot sweep someone
+  else's app, and they cannot sweep yours. Work you do OUTSIDE any app folder
+  via `app_bash` is not auto-committed; commit it yourself with git if it
+  must survive.
+- **Branch switches are global** for this user: `git checkout` changes what
+  the user and every other chat sees. Switch only when the task calls for
+  it, and say so.
 
 ## The core loop: edit → look → report what you SAW
 

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -48,6 +48,14 @@ export interface AgentContext {
   /** Branch of the caller's Apps checkout — saves the agent a `git status` round trip. */
   appsBranch?: string;
   /**
+   * Mutable, request-owned: apps tools add the repo-relative root
+   * (`apps/<slug>`) of every app they WRITE to during this turn. The turn-end
+   * auto-commit stages only these paths, so a chat never commits what a
+   * concurrent chat (same user, same shared sandbox) has in flight on
+   * another app.
+   */
+  appsTouchedPaths?: Set<string>;
+  /**
    * Whether the resolved model accepts image input (model-catalog
    * capability). Gates image parts in tool outputs (app_browse screenshots)
    * — a text-only model receiving an image part loses the whole tool result.

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -64,6 +64,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     workspaceId,
     userId,
     supportsVision: context.modelSupportsVision,
+    touchedPaths: context.appsTouchedPaths,
   });
 
   const {

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -403,9 +403,12 @@ export function buildCurrentScreenContext(context: AgentContext): string {
 
   if (context.appsBranch) {
     // Orientation the agent would otherwise burn a tool call on: its Apps
-    // checkout (shared with the user) and the branch it is on.
+    // checkout (ONE working copy shared with the user and their other chats)
+    // and the branch it is on. The shared-checkout warning is what keeps an
+    // agent from reading a concurrent session's WIP or turn commits as
+    // corruption and burning turns "fixing" them.
     sections.push(
-      `Apps checkout: on branch \`${context.appsBranch}\` (shared with the user; commits land here).`,
+      `Apps checkout: on branch \`${context.appsBranch}\` (one working copy, shared with the user and their other chats; commits land here). Files or commits you don't recognize are someone else's in-flight work — leave them alone. Your end-of-turn auto-commit covers only apps you touch this turn.`,
     );
     sections.push("");
   }

--- a/api/src/apps/box.ts
+++ b/api/src/apps/box.ts
@@ -689,8 +689,42 @@ export async function boxCommitAll(input: {
   committer?: { name?: string; email?: string };
   /** Commit only what is staged (VS Code with a non-empty Staged group). */
   stagedOnly?: boolean;
+  /**
+   * Repo-relative pathspecs to limit the commit to. The working copy is ONE
+   * clone per (workspace, user), shared by every chat that user runs — so an
+   * unscoped commit sweeps whatever a concurrent chat left in its app's
+   * folder. With paths, both the `add` and the `commit` are pathspec-scoped:
+   * `git commit -- <paths>` takes the listed paths' contents and disregards
+   * anything staged for other paths, which stays staged for whoever staged it.
+   */
+  paths?: string[];
 }): Promise<BoxCommitResult> {
   const { ctx, message, author, committer, stagedOnly } = input;
+  let paths = input.paths?.map(safeRepoPath);
+  if (paths && paths.length > 0) {
+    // One pathspec that matches nothing — neither in the working tree nor in
+    // HEAD (an app whose folder never actually got created, say) — makes BOTH
+    // `git add` and `git commit` abort outright, taking the valid paths down
+    // with it. Keep only the paths git can resolve.
+    const probe = paths
+      .map(
+        p =>
+          `{ [ -e ${sh(p)} ] || git cat-file -e ${sh(`HEAD:${p}`)} 2>/dev/null; } && printf '%s\\n' ${sh(p)}`,
+      )
+      .join("; ");
+    const existing = await boxExec(
+      ctx,
+      `cd ${sh(boxRoot(ctx))} && { ${probe}; true; }`,
+      { timeoutMs: 60_000 },
+    );
+    paths = existing.stdout.split("\n").filter(Boolean);
+  }
+  // A pathspec scope with nothing left in it: there is nothing of OURS to
+  // stage or commit. Don't fall back to an unscoped sweep — that is exactly
+  // the concurrent-chat clobber the scope exists to prevent. The push
+  // fall-through below still runs, making any earlier local-only commit
+  // durable.
+  const nothingInScope = paths !== undefined && paths.length === 0;
   const identity =
     author?.name && author?.email
       ? ["-c", `user.name=${author.name}`, "-c", `user.email=${author.email}`]
@@ -703,41 +737,48 @@ export async function boxCommitAll(input: {
       ? `GIT_COMMITTER_NAME=${sh(committer.name)} GIT_COMMITTER_EMAIL=${sh(committer.email)} `
       : "";
 
-  if (!stagedOnly) {
-    const staged = await boxExec(ctx, boxGit(ctx, "add", "-A"), {
-      timeoutMs: 120_000,
-    });
+  if (!stagedOnly && !nothingInScope) {
+    const staged = await boxExec(
+      ctx,
+      paths?.length
+        ? boxGit(ctx, "add", "-A", "--", ...paths)
+        : boxGit(ctx, "add", "-A"),
+      { timeoutMs: 120_000 },
+    );
     if (staged.exitCode !== 0) {
       throw new Error(`Could not stage changes: ${staged.stderr.slice(-300)}`);
     }
   }
 
-  const committed = await boxExec(
-    ctx,
-    committerEnv +
-      [
-        "git",
-        "-C",
-        sh(boxRoot(ctx)),
-        ...identity.map(sh),
-        "commit",
-        "-q",
-        "-m",
-        sh(message),
-      ].join(" "),
-    { timeoutMs: 120_000 },
-  );
-  let madeCommit = true;
-  if (committed.exitCode !== 0) {
-    const said = `${committed.stdout}${committed.stderr}`;
-    if (/nothing to commit|nothing added to commit/i.test(said)) {
-      // No NEW commit — but don't return yet. An earlier commit whose push
-      // failed (stale tunnel origin, say) is still local-only, and this is
-      // exactly the moment to make it durable: fall through to the push,
-      // which is a no-op when everything is already upstream.
-      madeCommit = false;
-    } else {
-      throw new Error(`Could not commit: ${said.slice(-300)}`);
+  let madeCommit = !nothingInScope;
+  if (!nothingInScope) {
+    const committed = await boxExec(
+      ctx,
+      committerEnv +
+        [
+          "git",
+          "-C",
+          sh(boxRoot(ctx)),
+          ...identity.map(sh),
+          "commit",
+          "-q",
+          "-m",
+          sh(message),
+          ...(paths?.length ? ["--", ...paths.map(sh)] : []),
+        ].join(" "),
+      { timeoutMs: 120_000 },
+    );
+    if (committed.exitCode !== 0) {
+      const said = `${committed.stdout}${committed.stderr}`;
+      if (/nothing to commit|nothing added to commit/i.test(said)) {
+        // No NEW commit — but don't return yet. An earlier commit whose push
+        // failed (stale tunnel origin, say) is still local-only, and this is
+        // exactly the moment to make it durable: fall through to the push,
+        // which is a no-op when everything is already upstream.
+        madeCommit = false;
+      } else {
+        throw new Error(`Could not commit: ${said.slice(-300)}`);
+      }
     }
   }
 

--- a/api/src/apps/worktree.service.test.ts
+++ b/api/src/apps/worktree.service.test.ts
@@ -20,6 +20,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import {
+  appRootFor,
   boxCtx,
   checkoutBranch,
   commitAgentTurn,
@@ -522,6 +523,119 @@ describe("branches are explicit", () => {
     await expect(
       mergeBranchToMain(scopeOf(project), "alice-a"),
     ).rejects.toThrow(/conflict/i);
+  });
+});
+
+describe("concurrent chats share one box but not one commit", () => {
+  // The incident this guards: one user, two chats, two apps — ONE sandbox
+  // (keyed by workspace:user). Chat A's turn-end auto-commit ran an unscoped
+  // `git add -A` and swept chat B's in-flight app in with it. Turn commits
+  // are now pathspec-scoped to what each chat's tools actually touched.
+  it("a turn commit scoped to touched paths leaves the other chat's app alone", async () => {
+    const appA = await createProject({
+      workspaceId: WS,
+      title: "App A",
+      userId: USER,
+    });
+    const appB = await createProject({
+      workspaceId: WS,
+      title: "App B",
+      userId: USER,
+    });
+
+    // Both "chats" write into the SAME working copy, different app folders.
+    const handleA = await ensureWorktree(appA, USER);
+    const handleB = await ensureWorktree(appB, USER);
+    await writeFile(handleA, "bindings/a.sql", "SELECT 1;\n");
+    await writeFile(handleB, "bindings/b.sql", "SELECT 2;\n");
+
+    // Chat A's turn ends first, scoped to what ITS tools touched.
+    const results = await commitAgentTurn(WS, USER, "chat A work", [
+      appRootFor(appA),
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0].commitOid).toBeTruthy();
+
+    // A's file is committed; B's is NOT in the commit and still dirty in the
+    // working copy, exactly where chat B left it.
+    const committedA = (await listFiles(appA)).entries.map(e => e.path);
+    expect(committedA).toContain("bindings/a.sql");
+    const committedB = (await listFiles(appB)).entries.map(e => e.path);
+    expect(committedB).not.toContain("bindings/b.sql");
+    const statusB = await worktreeStatus(scopeOf(appB), USER);
+    expect(statusB?.changes.map(ch => ch.path)).toContain("bindings/b.sql");
+
+    // Chat B's own turn end commits ITS app.
+    await commitAgentTurn(WS, USER, "chat B work", [appRootFor(appB)]);
+    expect((await listFiles(appB)).entries.map(e => e.path)).toContain(
+      "bindings/b.sql",
+    );
+    const history = (await projectHistory(scopeOf(appB))).map(c => c.subject);
+    expect(history[0]).toBe("Agent turn: chat B work");
+    expect(history).not.toContain("Agent turn: chat A work");
+  });
+
+  it("a turn that touched no app commits nothing at all", async () => {
+    const project = await makeProject();
+    const handle = await ensureWorktree(project, USER);
+    await writeFile(handle, "bindings/other-chat.sql", "SELECT 3;\n");
+
+    // A concurrent chat that used no apps tools ends its turn: empty touched
+    // set means NOTHING of its own to commit — before the scope existed this
+    // swept the other chat's file into an unrelated "Agent turn" commit.
+    const results = await commitAgentTurn(WS, USER, "sql-only turn", []);
+    expect(results).toEqual([]);
+    const status = await worktreeStatus(scopeOf(project), USER);
+    expect(status?.changes.map(ch => ch.path)).toContain(
+      "bindings/other-chat.sql",
+    );
+  });
+
+  it("a touched path that never materialized does not poison the commit", async () => {
+    const project = await makeProject();
+    const handle = await ensureWorktree(project, USER);
+    await writeFile(handle, "src/real.ts", "export {};\n");
+
+    // `apps/never-created` was marked touched (say, a failed app_bash), but
+    // no folder exists in the tree or HEAD. git aborts add/commit outright on
+    // an unmatched pathspec — the filter must keep the real path committable.
+    const results = await commitAgentTurn(WS, USER, "with a dead path", [
+      appRootFor(project),
+      "apps/never-created",
+    ]);
+    expect(results[0].commitOid).toBeTruthy();
+    expect((await listFiles(project)).entries.map(e => e.path)).toContain(
+      "src/real.ts",
+    );
+  });
+
+  it("app_commit's pathspec scope keeps a commit inside its app", async () => {
+    const appA = await createProject({
+      workspaceId: WS,
+      title: "Scoped A",
+      userId: USER,
+    });
+    const appB = await createProject({
+      workspaceId: WS,
+      title: "Scoped B",
+      userId: USER,
+    });
+    const handleA = await ensureWorktree(appA, USER);
+    const handleB = await ensureWorktree(appB, USER);
+    await writeFile(handleA, "mine.txt", "a\n");
+    await writeFile(handleB, "theirs.txt", "b\n");
+
+    // What the app_commit tool now runs: a commit scoped to its app root.
+    const result = await commitWorktree(handleA, "checkpoint", undefined, {
+      paths: [handleA.appRoot],
+    });
+    expect(result.committed).toBe(true);
+    expect((await listFiles(appA)).entries.map(e => e.path)).toContain(
+      "mine.txt",
+    );
+    expect((await listFiles(appB)).entries.map(e => e.path)).not.toContain(
+      "theirs.txt",
+    );
   });
 });
 

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -1640,7 +1640,7 @@ export async function commitWorktree(
   handle: WorktreeHandle,
   message: string,
   author?: GitAuthor,
-  options: { stagedOnly?: boolean } = {},
+  options: { stagedOnly?: boolean; paths?: string[] } = {},
 ): Promise<CommitResult> {
   const ctx = await ensureBox(handle);
   const result = await boxCommitAll({
@@ -1648,6 +1648,7 @@ export async function commitWorktree(
     message,
     author,
     stagedOnly: options.stagedOnly,
+    paths: options.paths,
   });
   if (!result.committed) return result;
   await syncBranchFromBox(handle);
@@ -1689,6 +1690,15 @@ export async function autoCommitFileEdit(
  * ACTOR, not by chat: a conversation is not a line of work, so the agent
  * commits to the branch the person is on rather than one of its own.
  *
+ * `touchedPaths` is what keeps concurrent chats out of each other's commits:
+ * the sandbox is ONE working copy per (workspace, user), shared by every chat
+ * that user runs, so an unscoped commit here swept whatever another chat had
+ * in flight (apps.md §14.2 "commit only what it touched"). Callers pass the
+ * repo-relative roots this turn's apps tools actually wrote to — empty means
+ * the turn touched no app and there is nothing of OURS to commit, so we must
+ * not commit at all. `undefined` keeps the old commit-everything behavior for
+ * callers with no tracking (deliberate full sweeps).
+ *
  * Never throws — finalization must not fail a turn. Nothing is lost by
  * failing: the work is in the working copy, exactly where it would be if a
  * person had written it and not committed yet.
@@ -1697,7 +1707,9 @@ export async function commitAgentTurn(
   workspaceId: string,
   actorId: string,
   turnSummary?: string,
+  touchedPaths?: string[],
 ): Promise<Array<{ commitOid?: string }>> {
+  if (touchedPaths && touchedPaths.length === 0) return [];
   const doc = await AppWorktree.findOne({
     workspaceId: new Types.ObjectId(workspaceId),
     userId: actorId,
@@ -1726,6 +1738,7 @@ export async function commitAgentTurn(
       message,
       author: human,
       committer: { name: "Mako Agent", email: "agent@mako.ai" },
+      paths: touchedPaths,
     });
     if (!result.committed) return [];
     // Mirror queue and window poke happen in the git endpoint's push

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -729,11 +729,18 @@ agentRoutes.openapi(
       .lean()
       .catch(() => null);
 
+    // What THIS turn's apps tools write to (repo-relative `apps/<slug>`
+    // roots). The sandbox is shared across every chat this user runs, so the
+    // turn-end auto-commit must stage only these paths — an unscoped commit
+    // sweeps a concurrent chat's in-flight work on another app.
+    const appsTouchedPaths = new Set<string>();
+
     // Build agent context
     const agentContext: AgentContext = {
       workspaceId,
       chatId,
       appsBranch: appsWorktree?.branch ?? undefined,
+      appsTouchedPaths,
       activeView,
       activeExplorer,
       userId: actorId,
@@ -1257,11 +1264,13 @@ agentRoutes.openapi(
                 }
                 const durationMs = Date.now() - startTime;
 
-                // Apps (Cursor-cloud model): turn any WIP the agent
-                // accumulated on this conversation's app branches into one
-                // commit per turn. No-op unless the turn touched an Apps
-                // worktree; never throws.
-                if (!isAborted) {
+                // Apps (Cursor-cloud model): turn the WIP this turn's apps
+                // tools produced into one commit per turn, scoped to the app
+                // folders THIS chat actually wrote to — the sandbox is shared
+                // across the user's chats, so an unscoped commit would sweep
+                // a concurrent chat's in-flight work on another app. No-op
+                // when the turn touched no app; never throws.
+                if (!isAborted && appsTouchedPaths.size > 0) {
                   try {
                     const lastUserText = [...allMessages]
                       .reverse()
@@ -1272,7 +1281,9 @@ agentRoutes.openapi(
                       )
                       .map(p => p.text)
                       .join(" ");
-                    await commitAgentTurn(workspaceId, actorId, lastUserText);
+                    await commitAgentTurn(workspaceId, actorId, lastUserText, [
+                      ...appsTouchedPaths,
+                    ]);
                   } catch (err) {
                     logger.warn("Apps turn commit failed", { error: err });
                   }

--- a/apps.md
+++ b/apps.md
@@ -1493,10 +1493,14 @@ got here; where this section disagrees with one of them, this one wins.
   mutating paths are blocked, and only while a repair runs.
 - **The agent gets rewritten for the sandbox.** Collapse the `App2 *` tool
   family into bash + read + edit; move git/vite/dbt know-how into skills;
-  feed it the pushed box state; commit only what it touched (today's
-  end-of-turn `git add -A` sweeps unrelated files); land its changes as a
-  staged group the user reviews with the diff view; give it its own `git
-  worktree` per chat so it and the user stop treading on each other.
+  feed it the pushed box state; ~~commit only what it touched (today's
+  end-of-turn `git add -A` sweeps unrelated files)~~ — DONE: the turn-end
+  commit and `app_commit` are pathspec-scoped to the `apps/<slug>` roots the
+  chat's tools actually wrote to, so two concurrent chats (one shared box per
+  workspace:user) no longer sweep each other's in-flight apps into one
+  commit; land its changes as a staged group the user reviews with the diff
+  view; give it its own `git worktree` per chat so it and the user stop
+  treading on each other.
 - **Coding agents in the box.** Two tracks: ship the CLIs (Claude Code,
   Codex, OpenCode, Pi) in the template so people use their own accounts in
   the terminal — nearly free; then drive an agent running in the box over


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two concurrent chat sessions (same user, same workspace) working on **two different apps** mixed their sandbox work: one chat's turn-end auto-commit swept the other chat's in-flight changeset (e.g. a new `bindings/es_claims48.sql` plus unrelated `csm-activity` edits) into a single `Agent turn:` commit with a misleading message — and the affected chat's model then burned turns investigating the "corruption".

Root cause: the sandbox is deliberately **one working copy per `(workspace, user)`** (`sessionKeyFor` in `api/src/apps/worktree.service.ts`) shared by every chat that user runs — but `commitAgentTurn` ran an **unscoped `git add -A`** over the whole workspace monorepo at the end of every turn, with no notion of which chat touched what. `apps.md` §14.2 already named this failure mode: *"commit only what it touched (today's end-of-turn `git add -A` sweeps unrelated files)"*.

## Fix — part 1: commit only what the chat touched

- **`boxCommitAll` (`api/src/apps/box.ts`)** takes optional repo-relative `paths`; both the `add` and the `commit` are pathspec-scoped. `git commit -- <paths>` disregards content staged for other paths — anything a concurrent chat staged stays staged for that chat's own commit. Paths that exist neither in the working tree nor in `HEAD` are filtered first, since one unmatched pathspec aborts both `git add` and `git commit` outright.
- **Apps tools (`api/src/agent-lib/tools/apps-tools.ts`)** record the `apps/<slug>` root of every app they write to (`app_create_app`, `app_bash`, `app_write_file`, `app_edit_file`, `app_materialize`, `app_commit`) into a request-owned set threaded via `AgentContext.appsTouchedPaths`.
- **`commitAgentTurn`** accepts the touched roots: non-empty → pathspec-scoped commit; **empty → no commit at all** (previously a turn that never touched apps still swept another chat's WIP); `undefined` keeps the explicit full-sweep behavior for callers without tracking.
- **`app_commit`** is scoped to its own app root for the same reason — a mid-turn checkpoint on app A no longer sweeps app B.
- `apps.md` §14.2 updated to mark this item done.

## Fix — part 2: orient the model so it doesn't get lost

The LLM had no way to know the checkout is shared, so foreign WIP / foreign commits / a suddenly-clean tree read as corruption. Now every layer the model learns from says so:

- **System prompt** (`api/src/agents/unified/prompt.ts`): the Apps-checkout orientation line states the working copy is shared with the user *and their other chats*, that unrecognized files/commits are someone else's in-flight work, and that the turn-end auto-commit covers only apps this chat touches.
- **`app_status`** documents `changes` (this app) vs `repoChanges` (whole shared tree) and returns an explicit `hint` when uncommitted work exists outside this app: "likely the user's or a concurrent chat's — leave it alone".
- **`app_bash` / `app_commit` descriptions** carry the shared-checkout expectations and the scoped-commit contract.
- **Apps skill** (`api/src/agent-skills/apps/SKILL.md`): new *"You are not alone in this checkout"* section — foreign dirty files, foreign `Mako Agent` / `edit:` commits, the clean-tree-after-auto-commit case (check `git log`, don't assume loss), scope rules, and that branch switches are global.

## Testing

- New integration tests in `api/src/apps/worktree.service.test.ts` (real git + local sandbox + real git server): two chats writing to two apps in one box commit independently; an empty touched-set commits nothing; a dead pathspec doesn't poison the commit; `app_commit` scoping stays inside its app. Full apps suite: **12 files / 129 tests pass** (`pnpm --filter api run test:apps`).
- `pnpm --filter api run lint` (0 errors), `pnpm --filter api run build` (typecheck) pass; `pnpm run openapi:sync` produced no drift; `tool-working-set` tier-policy and `mako-mcp-server` tests pass.

## Not covered (future work, per §14.2)

Two chats editing the **same** app still share files (needs per-chat `git worktree`), and `app_bash` writes outside the app's folder aren't auto-committed — the folder-level scope is the contract (the skill now tells the agent to commit such work itself via git).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dccc0229-c573-4910-a29a-0998afd40e20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dccc0229-c573-4910-a29a-0998afd40e20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

