### PR TITLE
fix(apps): the git endpoint freshens from the mirror before serving a fetch

### DIFF
--- a/api/src/apps/cloud-repo.service.test.ts
+++ b/api/src/apps/cloud-repo.service.test.ts
@@ -65,6 +65,7 @@ import {
   fetchFromCloud,
   mirrorPushNow,
   resolveMirrorTarget,
+  freshenForServe,
 } from "./cloud-repo.service";
 
 let tmpRoot: string;
@@ -379,5 +380,57 @@ describe("fetchFromCloud on a connected repo", () => {
 
     await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
     expect(await headOf(repoDirFor(workspaceId))).toBe(ourCommit);
+  });
+});
+
+/**
+ * serveGit calls this before answering a FETCH: an instance whose clone
+ * predates a push must pull the mirror or a just-pushed sha is
+ * `upload-pack: not our ref` (the deploy-on-push race seen in prod).
+ */
+describe("freshenForServe", () => {
+  it("makes a mirror-only commit servable, and throttles repeat calls", async () => {
+    const remoteDir = await makeBareRemote("acme", "freshen");
+    state.binding = { owner: "acme", repo: "freshen" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await adoptConnectedRepo(workspaceId, state.binding);
+
+    // Another instance handled a push: the commit exists only on the mirror.
+    const pushedSha = await commitFiles(
+      remoteDir,
+      { "apps/a/index.html": "<h1>new</h1>" },
+      "push handled elsewhere",
+    );
+    const has = (sha: string) =>
+      runGit([
+        "-C",
+        repoDirFor(workspaceId),
+        "cat-file",
+        "-e",
+        `${sha}^{commit}`,
+      ]);
+    await expect(has(pushedSha)).rejects.toThrow();
+
+    await freshenForServe(workspaceId);
+    await expect(has(pushedSha)).resolves.toBeDefined();
+
+    // Inside the throttle window a newer mirror commit is NOT pulled…
+    const laterSha = await commitFiles(
+      remoteDir,
+      { "apps/a/later.txt": "later" },
+      "later push",
+    );
+    await freshenForServe(workspaceId);
+    await expect(has(laterSha)).rejects.toThrow();
+
+    // …and a zero-interval call (the window elapsed) pulls it.
+    await freshenForServe(workspaceId, 0);
+    await expect(has(laterSha)).resolves.toBeDefined();
+  });
+
+  it("serves local state quietly when the mirror is unreachable", async () => {
+    state.binding = null; // no connected repo — nothing to freshen from
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await expect(freshenForServe(workspaceId, 0)).resolves.toBeUndefined();
   });
 });

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -331,6 +331,47 @@ export async function ensureCommitLocally(
   return run;
 }
 
+/**
+ * Freshen the local bare repo from the cloud mirror before SERVING a fetch.
+ *
+ * ensureLocalRepo only restores a MISSING repo; an instance whose clone
+ * predates a push happily serves stale refs, and a sandbox fetching a
+ * just-pushed sha gets `upload-pack: not our ref` — seen in prod when
+ * deploy-on-push raced the GitHub webhook across Cloud Run instances (the
+ * webhook instance had the commit, the instance serving the sandbox's
+ * fetch did not, and the deploy burned its retries inside the window).
+ *
+ * Throttled per workspace: bursts of fetches (a clone is several requests)
+ * share one mirror pull. Failure is non-fatal — serve local state and let
+ * the client's git command produce the specific error.
+ */
+const FRESHEN_INTERVAL_MS = 3_000;
+const lastFreshenAt = new Map<string, number>();
+const freshenInFlight = new Map<string, Promise<void>>();
+
+export async function freshenForServe(
+  workspaceId: string,
+  intervalMs: number = FRESHEN_INTERVAL_MS,
+): Promise<void> {
+  if (Date.now() - (lastFreshenAt.get(workspaceId) ?? 0) < intervalMs) return;
+  const existing = freshenInFlight.get(workspaceId);
+  if (existing) return existing;
+  const run = (async () => {
+    try {
+      await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
+    } catch (error) {
+      logger.warn("Freshen before serve failed; serving local state", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      lastFreshenAt.set(workspaceId, Date.now());
+    }
+  })().finally(() => freshenInFlight.delete(workspaceId));
+  freshenInFlight.set(workspaceId, run);
+  return run;
+}
+
 export async function fetchFromCloud(
   workspaceId: string,
   branch: string,

--- a/api/src/routes/apps-git.ts
+++ b/api/src/routes/apps-git.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import type { Context } from "hono";
 import { appsReposRoot } from "../apps/config";
-import { ensureLocalRepo } from "../apps/cloud-repo.service";
+import { ensureLocalRepo, freshenForServe } from "../apps/cloud-repo.service";
 import { DEFAULT_BRANCH, repoExists } from "../apps/repository.service";
 import { GitTokenError, verifyGitToken } from "../apps/git-token.service";
 import { notifyRepoPushed } from "../apps/worktree.service";
@@ -218,6 +218,17 @@ async function serveGit(c: Context): Promise<Response> {
   }
 
   const isReceivePack = parts.rest === "/git-receive-pack";
+  // A FETCH must see commits that landed on the mirror via another instance
+  // (GitHub webhook, publish, another window's push): pull the mirror —
+  // throttled — before advertising refs or answering upload-pack, or a
+  // just-pushed sha is `not our ref` here even though the workspace has it.
+  // Pushes skip this: receive-pack only appends, and the post-receive hook
+  // mirrors outward.
+  const service = new URL(c.req.url).searchParams.get("service");
+  const isUploadPack =
+    parts.rest === "/git-upload-pack" ||
+    (parts.rest === "/info/refs" && service === "git-upload-pack");
+  if (isUploadPack) await freshenForServe(payload.wsId);
   return runHttpBackend({
     repoRoot: appsReposRoot(),
     hooksDir: await hooksDir(),


### PR DESCRIPTION
## The incident (2026-09-01 ~06:30 UTC)

Two pushes to `realadvisor/mako-workspace` main (4739ccb7, ef33bd07) never deployed; `publishedSha` stayed stale until the next push. Initially reported as "Inngest v4 broke deploy-on-push" — **v4 is exonerated**: the deploy events were delivered and `apps-deploy` ran with retries exactly as configured. Every run died in the sandbox's fetch:

```
Could not check out ef33bd07 in the sandbox:
fatal: remote error: upload-pack: not our ref ef33bd07…
```

## Root cause

`serveGit` only ran `ensureLocalRepo`, which restores a **missing** repo and does nothing for a **stale** one. On multi-instance Cloud Run, the instance that handled the GitHub webhook fetched the new commits into its bare repo — but the instance serving the sandbox's `git fetch` (via the load balancer) kept its older clone and advertised refs predating the push. #874's `ensureCommitLocally` closed this exact hole for pinned *reads*; the git-*serving* side still raced. The deploy's 2 retries (~90s) all landed inside the window; the hourly reconcile or the next push were the only healers.

## Fix

`freshenForServe(workspaceId)` in `cloud-repo.service`: before advertising refs (`info/refs?service=git-upload-pack`) or answering `git-upload-pack`, pull the cloud mirror — throttled per workspace (3s, so a clone's burst of requests shares one pull), deduped in-flight, and non-fatal on mirror errors (serve local state; the client's git command reports the specific failure). Pushes (`receive-pack`) skip it — they only append, and the post-receive hook mirrors outward.

## Verification

- New tests on the real-git cloud-repo harness: a mirror-only commit becomes servable after freshen; the throttle skips inside the window and pulls after it (proven with a zero-interval call); an unconnected workspace serves local state quietly.
- Full apps vitest suite: 13 files / 131 tests green.
- Prod evidence trail in the incident thread: both failed pushes show the identical `not our ref` signature; every other push that night (23:08, 06:18, 06:25, 06:27, 06:51) built in seconds; the affected app self-healed on the 06:51 push (`publishedSha=3acf85a3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZR5pr8Wxrw4NfPHSsb7CW