### PR TITLE
feat(apps): app_publish + app_build_log agent tools; honest app_publish_status

### DIFF
--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -56,6 +56,7 @@ import {
   repoDirFor,
   resolveCommit,
 } from "../../apps/repository.service";
+import { freshenForServe } from "../../apps/cloud-repo.service";
 import { runGit } from "../../apps/git";
 import { buildLogPath } from "../../apps/deployment.service";
 import { getSandboxProvider } from "../../apps/sandbox/provider";
@@ -507,6 +508,9 @@ export function createAppsTools({
         try {
           const project = loaded.project;
           const branch = project.defaultBranch || DEFAULT_BRANCH;
+          // Pull the cloud mirror first: the serving instance may not have
+          // seen the push this status call is asking about (#894's race).
+          await freshenForServe(project.workspaceId.toString(), 0);
           const repoDir = repoDirFor(project.workspaceId.toString());
           const branchSha = await resolveCommit(
             repoDir,
@@ -590,6 +594,11 @@ export function createAppsTools({
         try {
           const project = loaded.project;
           const branch = project.defaultBranch || DEFAULT_BRANCH;
+          // Force-freshen before resolving: this tool exists precisely for
+          // "the push's automatic deploy did not land", which is also when
+          // this instance may not have pulled that push yet — without this
+          // we would enqueue the PREVIOUS sha and report success.
+          await freshenForServe(project.workspaceId.toString(), 0);
           const sha = await resolveCommit(
             repoDirFor(project.workspaceId.toString()),
             `refs/heads/${branch}`,

--- a/api/src/agent-lib/tools/apps-tools.ts
+++ b/api/src/agent-lib/tools/apps-tools.ts
@@ -47,6 +47,8 @@ import {
   worktreeStatus,
   writeFile,
   scopeOf,
+  PUBLISH_ACTOR,
+  boxCtx,
 } from "../../apps/worktree.service";
 import { materializeAppBinding } from "../../apps/bindings.service";
 import {
@@ -54,6 +56,9 @@ import {
   repoDirFor,
   resolveCommit,
 } from "../../apps/repository.service";
+import { runGit } from "../../apps/git";
+import { buildLogPath } from "../../apps/deployment.service";
+import { getSandboxProvider } from "../../apps/sandbox/provider";
 import {
   devConsolePath,
   devLogPath,
@@ -502,11 +507,55 @@ export function createAppsTools({
         try {
           const project = loaded.project;
           const branch = project.defaultBranch || DEFAULT_BRANCH;
+          const repoDir = repoDirFor(project.workspaceId.toString());
           const branchSha = await resolveCommit(
-            repoDirFor(project.workspaceId.toString()),
+            repoDir,
             `refs/heads/${branch}`,
           );
+          // The commit that last TOUCHED this app's folder — commits to other
+          // apps or non-app files must not read as "this app is stale".
+          let branchAppSha: string | null = null;
+          if (branchSha) {
+            try {
+              const { stdout } = await runGit([
+                "-C",
+                repoDir,
+                "log",
+                "-1",
+                "--pretty=%H",
+                `refs/heads/${branch}`,
+                "--",
+                `apps/${project.slug}/`,
+              ]);
+              branchAppSha = stdout.trim() || null;
+            } catch {
+              branchAppSha = null;
+            }
+          }
           const publishedSha = project.publishedSha ?? null;
+          // Up to date when the published deployment contains the app's last
+          // change: either shas match, or the published commit is a
+          // descendant of the last app-touching commit.
+          let upToDate =
+            !!publishedSha && !!branchSha && publishedSha === branchSha;
+          if (!upToDate && publishedSha && branchAppSha) {
+            if (publishedSha === branchAppSha) upToDate = true;
+            else {
+              try {
+                await runGit([
+                  "-C",
+                  repoDir,
+                  "merge-base",
+                  "--is-ancestor",
+                  branchAppSha,
+                  publishedSha,
+                ]);
+                upToDate = true;
+              } catch {
+                /* not an ancestor — genuinely stale */
+              }
+            }
+          }
           return {
             success: true,
             status: {
@@ -515,9 +564,101 @@ export function createAppsTools({
               publishedAt: project.publishedAt ?? null,
               branch,
               branchSha,
-              upToDate:
-                !!publishedSha && !!branchSha && publishedSha === branchSha,
+              branchAppSha,
+              upToDate,
             },
+          };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    }),
+
+    app_publish: tool({
+      description:
+        "Deploy the app's default branch NOW. Enqueues the exact build+deploy " +
+        "the push webhook uses (single-build concurrency per app, so it never " +
+        "races a push-triggered build) and returns immediately with the " +
+        "enqueued sha — poll app_publish_status until publishedSha reaches it " +
+        "(typically under 2 minutes; a failing build surfaces in " +
+        "app_build_log). Use when a push's automatic deploy did not land, or " +
+        "to force a redeploy of the current branch tip.",
+      inputSchema: z.object({ appId: z.string() }),
+      execute: async ({ appId }) => {
+        const loaded = await loadProject(appId, { write: true });
+        if ("error" in loaded) return { success: false, error: loaded.error };
+        try {
+          const project = loaded.project;
+          const branch = project.defaultBranch || DEFAULT_BRANCH;
+          const sha = await resolveCommit(
+            repoDirFor(project.workspaceId.toString()),
+            `refs/heads/${branch}`,
+          );
+          if (!sha) {
+            return { success: false, error: `branch ${branch} has no commits` };
+          }
+          const { requestAppDeploys } = await import(
+            "../../inngest/functions/apps-deploy"
+          );
+          await requestAppDeploys(
+            project.workspaceId.toString(),
+            [project.slug ?? appId],
+            sha,
+            "manual",
+          );
+          return {
+            success: true,
+            enqueued: { branch, sha },
+            message:
+              "Deploy enqueued. Poll app_publish_status until publishedSha " +
+              "reaches this sha; if it does not land, read app_build_log.",
+          };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    }),
+
+    app_build_log: tool({
+      description:
+        "Tail the PUBLISH build log (npm install + build output from the " +
+        "shared publish sandbox) — the first place to look when app_publish " +
+        "or a push deploy does not land. Distinct from app_dev_log (the dev " +
+        "server's log). Never starts a sandbox: an empty result means no " +
+        "publish build has run recently.",
+      inputSchema: z.object({
+        appId: z.string(),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Byte offset to tail from (default 0; use the returned size to poll).",
+          ),
+      }),
+      execute: async ({ appId, offset }) => {
+        const loaded = await loadProject(appId, { write: false });
+        if ("error" in loaded) return { success: false, error: loaded.error };
+        try {
+          const handle = await ensureWorktree(loaded.project, PUBLISH_ACTOR);
+          const ctx = boxCtx(handle);
+          if (!(await getSandboxProvider().hasSession(ctx))) {
+            return { success: true, size: 0, chunk: "" };
+          }
+          const start = (offset ?? 0) + 1;
+          const result = await getSandboxProvider().exec(
+            ctx,
+            `wc -c < ${buildLogPath(handle)} 2>/dev/null || echo 0; ` +
+              `tail -c +${start} ${buildLogPath(handle)} 2>/dev/null | head -c 65536`,
+            { timeoutMs: 30_000 },
+          );
+          const newline = result.stdout.indexOf("\n");
+          const size = Number(result.stdout.slice(0, newline).trim()) || 0;
+          return {
+            success: true,
+            size,
+            chunk: result.stdout.slice(newline + 1),
           };
         } catch (error) {
           return { success: false, error: errorMessage(error) };

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -187,6 +187,8 @@ export const APP_TOOL_NAMES = new Set<string>([
   "app_edit_file",
   "app_status",
   "app_publish_status",
+  "app_publish",
+  "app_build_log",
   "app_commit",
   "app_open_app",
   "app_dev_log",

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -149,6 +149,7 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   // ── Apps (git-backed, server) — full headless authoring surface ────
   app_bash: bridge(),
   app_browse: bridge(),
+  app_build_log: bridge(),
   app_commit: bridge(),
   app_create_app: bridge(),
   app_dev_log: bridge(),
@@ -160,6 +161,7 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   app_list_branches: bridge(),
   app_merge_to_main: bridge(),
   app_open_app: bridge(),
+  app_publish: bridge(),
   app_read_file: bridge(),
   app_status: bridge(),
   app_publish_status: bridge(),

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -4,6 +4,7 @@ import { loadContext } from "./context.js";
 import { login } from "./login.js";
 import { dev } from "./dev.js";
 import { status } from "./status.js";
+import { publish } from "./publish.js";
 
 const HELP = `mako — Mako from your terminal
 
@@ -12,6 +13,7 @@ const HELP = `mako — Mako from your terminal
   mako whoami                                     show which host/workspace you are signed in to
   mako dev     [<app>] [--port <n>] [--open]      run apps/<app> locally with real data
   mako status  [<app>]                            what is LIVE: published commit vs the tip of main
+  mako publish [<app>]                            deploy the app's main branch now (enqueue + wait)
 
 Run inside a workspace checkout; the host comes from --api-url, MAKO_API_URL,
 the repo's .env, or defaults to https://app.mako.ai. An API key in .env
@@ -47,6 +49,8 @@ export async function main(argv, io = { log: console.log }) {
       return dev(ctx, positional, flags, io);
     case "status":
       return status(ctx, positional, io);
+    case "publish":
+      return publish(ctx, positional, io);
     default:
       io.log(`unknown command "${command}"\n\n${HELP}`);
       return 2;

--- a/packages/cli/src/publish.js
+++ b/packages/cli/src/publish.js
@@ -1,0 +1,41 @@
+// `mako publish [<app>]` — deploy the app's default branch now. Calls the
+// MCP app_publish tool (enqueue-and-poll: the same build+deploy the push
+// webhook runs, single-build concurrency per app), then polls
+// app_publish_status until the enqueued sha is live.
+import path from "node:path";
+import { findRepoRoot, resolveAppDir } from "./context.js";
+import { callMcpTool } from "./status.js";
+
+const POLL_MS = 5000;
+const TIMEOUT_MS = 5 * 60 * 1000;
+const short = sha => (typeof sha === "string" ? sha.slice(0, 7) : "?");
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+export async function publish(ctx, positional, io = { log: console.log }) {
+  const repoRoot = findRepoRoot();
+  const appDir = resolveAppDir(repoRoot, positional[0]);
+  const slug = path.basename(appDir);
+
+  const out = await callMcpTool(ctx, "app_publish", { appId: slug });
+  if (!out?.success) {
+    io.log(`apps/${slug}: ${out?.error ?? "publish refused"}`);
+    return 1;
+  }
+  const sha = out.enqueued?.sha;
+  io.log(`apps/${slug}: deploy enqueued at ${short(sha)} — waiting…`);
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(POLL_MS);
+    const st = await callMcpTool(ctx, "app_publish_status", { appId: slug }).catch(() => null);
+    if (st?.success && st.status?.publishedSha === sha) {
+      io.log(`apps/${slug}: LIVE at ${short(sha)}.`);
+      return 0;
+    }
+  }
+  io.log(
+    `apps/${slug}: still not live after ${TIMEOUT_MS / 60000} min — ` +
+      "the build may have failed; check app_build_log or the app header in Mako.",
+  );
+  return 1;
+}


### PR DESCRIPTION
## Why

Tonight's deploy-race incident (see #894) showed agents have no recovery surface: when deploy-on-push failed, the only paths were clicking the UI Publish button or driving session-cookie fetches from a browser. Three additions close that:

## Changes

- **`app_publish`** (MCP/agent tool): enqueue-and-poll. Sends the same `apps/deploy` Inngest event the push webhook uses (`requestAppDeploys(..., "manual")`) — single-build concurrency per app means it can never race a push-triggered build, and no MCP call is held open across a sandbox build. Returns the enqueued sha; agents poll `app_publish_status`. Shape per mako-58's review (thanks — the original synchronous idea was exactly the 502 trap).
- **`app_build_log`**: tails the publish sandbox's build log (same mechanics as `GET /{id}/build/log`); never starts a sandbox. The first look when a deploy doesn't land.
- **`app_publish_status`**: `upToDate` now compares `publishedSha` against the last commit that *touched the app's folder* (plus an ancestor check) instead of the branch tip — commits to other apps or `dbt/` no longer read as staleness. This false negative fired twice in real use tonight.
- **CLI**: `mako publish [<app>]` — trigger then wait until the sha is live (speaks MCP like `mako status`).
- Wiring: bridge-policy entries (alphabetical), apps-mode tier classification.

**Deliberately not included**: dbt triggering — `dbt_run_job` already exists behind the `warehouse:write` key scope; the gap there is operational (mint agent keys with that scope), not missing surface.

## Testing

- `tool-working-set` tier-policy test passes with the new tools classified; CLI node tests pass; eslint clean.
- `tsc -p tsconfig.build.json` — no errors in touched files. Pre-existing, unrelated: `src/inngest/functions/*` typing errors (Inngest v4 fallout — flagged to the session that owns #889) and the env-dependent `mako-mcp-server.test` bridge assertion (`dbt_list_recoverable_files` on this machine, `run_app` on others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBu5kWvdBipSVJfxKpapGh