### PR TITLE
feat(dbt): jobs and environments are YAML files in the workspace repo — config-as-code

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -63,6 +63,11 @@ import {
 } from "../../dbt/dbt-working-tree.service";
 import { resolveDbtRules } from "../../dbt/dbt-rules.service";
 import {
+  commitDbtJobFile,
+  deleteDbtJobFile,
+  reserveJobSlug,
+} from "../../dbt/dbt-config.service";
+import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
 } from "../../dbt/adapter-map";
@@ -1279,6 +1284,7 @@ export const createDbtServerTools = (
           const job = await DbtJob.create({
             workspaceId: project.workspaceId,
             projectId: project._id,
+            slug: await reserveJobSlug(project._id, name),
             name,
             environment: env,
             commands,
@@ -1288,6 +1294,7 @@ export const createDbtServerTools = (
             createdBy: "agent",
           });
           await applyJobScheduleChange(job);
+          await commitDbtJobFile(project, job, actingUserId);
           publishJobUpdated(projectId);
           return {
             success: true,
@@ -1358,6 +1365,7 @@ export const createDbtServerTools = (
           }
           await job.save();
           await applyJobScheduleChange(job);
+          await commitDbtJobFile(project, job, actingUserId);
           publishJobUpdated(projectId);
           return {
             success: true,
@@ -1397,6 +1405,7 @@ export const createDbtServerTools = (
           if (!job) return { success: false, error: "Job not found" };
           const name = job.name;
           await DbtJob.deleteOne({ _id: job._id, projectId: project._id });
+          await deleteDbtJobFile(project, job.slug, actingUserId);
           publishJobUpdated(projectId);
           return { success: true, jobId: job._id.toString(), name };
         } catch (error) {

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -202,6 +202,16 @@ export function notifyRepoPushed(workspaceId: string, userId: string): void {
       error: error instanceof Error ? error.message : String(error),
     });
   });
+  // dbt orchestration config (jobs/environments YAML — apps.md §23):
+  // external edits re-register schedules on the next push.
+  void import("../dbt/dbt-config.service")
+    .then(m => m.syncDbtConfigFromRepo(workspaceId, userId))
+    .catch(error => {
+      logger.warn("dbt config sync after push failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
 }
 
 // The sandbox HAS a remote, and a credential for it — see box.ts. Two things

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4544,6 +4544,10 @@ export interface IDbtJob extends Document {
   workspaceId: Types.ObjectId;
   projectId: Types.ObjectId;
   name: string;
+  /** Filename identity in dbt/jobs/<slug>.yml (apps.md §23). */
+  slug?: string;
+  /** Blob sha of the job file this row mirrors (sync levelling). */
+  sourceBlobSha?: string;
   /** Environment name from the project's environments list. */
   environment: string;
   /** Validated against the dbt command allowlist (api/src/dbt/commands.ts). */
@@ -4583,6 +4587,8 @@ const DbtJobSchema = new Schema<IDbtJob>(
       required: true,
     },
     name: { type: String, required: true, trim: true },
+    slug: { type: String },
+    sourceBlobSha: { type: String },
     environment: { type: String, required: true },
     commands: { type: [String], default: [] },
     schedule: {
@@ -4606,6 +4612,10 @@ const DbtJobSchema = new Schema<IDbtJob>(
 );
 
 DbtJobSchema.index({ workspaceId: 1, projectId: 1 });
+DbtJobSchema.index(
+  { projectId: 1, slug: 1 },
+  { unique: true, partialFilterExpression: { slug: { $type: "string" } } },
+);
 DbtJobSchema.index({ "scheduledRun.nextAt": 1, enabled: 1 }, { sparse: true });
 
 export const DbtJob = mongoose.model<IDbtJob>("DbtJob", DbtJobSchema);

--- a/api/src/dbt/dbt-config-files.ts
+++ b/api/src/dbt/dbt-config-files.ts
@@ -1,0 +1,186 @@
+/**
+ * dbt orchestration config as files (apps.md §23): the pure format layer.
+ *
+ * - `dbt/jobs/<slug>.yml` — ONE file per job (a central registry would be a
+ *   merge-conflict magnet; per-file is the recorded doctrine). The filename
+ *   slug is the job's identity; `name` inside is the display name.
+ * - `dbt/environments.yml` — the project's environments + settings. A
+ *   singleton by nature (one dbt project per workspace), so one file is not
+ *   a registry-of-many.
+ *
+ * Credentials never appear here: environments reference a connection by id.
+ * Run state (history, scheduler claims, failure counters) never appears
+ * here: those are runtime fields on the Mongo index rows.
+ */
+import yaml from "js-yaml";
+
+export const DBT_JOBS_DIR = "dbt/jobs";
+export const DBT_ENVIRONMENTS_PATH = "dbt/environments.yml";
+
+export interface DbtJobFile {
+  name: string;
+  environment: string;
+  commands: string[];
+  schedule?: { cron: string; timezone: string } | null;
+  enabled: boolean;
+  deferToProduction: boolean;
+}
+
+export interface DbtEnvironmentsFile {
+  dbtVersion?: string;
+  defaultEnvironment: string;
+  prodEnvironment?: string;
+  environments: Array<{
+    name: string;
+    connectionId: string;
+    targetSchema: string;
+    threads?: number;
+    vars?: Record<string, unknown>;
+    ownerUserId?: string;
+  }>;
+}
+
+export function jobFilePath(slug: string): string {
+  return `${DBT_JOBS_DIR}/${slug}.yml`;
+}
+
+export function slugFromJobFilePath(repoRelative: string): string | null {
+  const m = repoRelative.match(/^dbt\/jobs\/([a-z0-9][a-z0-9-]*)\.yml$/);
+  return m ? m[1] : null;
+}
+
+/** Stable filename identity for a job, derived once from its display name. */
+export function slugifyJobName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return slug || "job";
+}
+
+export function serializeJobFile(job: DbtJobFile): string {
+  const doc: Record<string, unknown> = {
+    name: job.name,
+    environment: job.environment,
+    commands: job.commands,
+  };
+  if (job.schedule) {
+    doc.schedule = {
+      cron: job.schedule.cron,
+      timezone: job.schedule.timezone,
+    };
+  }
+  doc.enabled = job.enabled;
+  if (job.deferToProduction) doc.defer_to_production = true;
+  return yaml.dump(doc, { lineWidth: 100, noRefs: true });
+}
+
+export function parseJobFile(contents: string): DbtJobFile | null {
+  let raw: unknown;
+  try {
+    raw = yaml.load(contents);
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const doc = raw as Record<string, unknown>;
+  const name = typeof doc.name === "string" ? doc.name.trim() : "";
+  const environment =
+    typeof doc.environment === "string" ? doc.environment.trim() : "";
+  const commands = Array.isArray(doc.commands)
+    ? doc.commands.filter((c): c is string => typeof c === "string" && !!c)
+    : [];
+  if (!name || !environment || commands.length === 0) return null;
+  let schedule: DbtJobFile["schedule"] = null;
+  const s = doc.schedule as Record<string, unknown> | undefined;
+  if (s && typeof s === "object") {
+    if (typeof s.cron === "string" && typeof s.timezone === "string") {
+      schedule = { cron: s.cron, timezone: s.timezone };
+    } else {
+      return null; // half a schedule is a broken file, not "no schedule"
+    }
+  }
+  return {
+    name,
+    environment,
+    commands: commands.slice(0, 10),
+    schedule,
+    enabled: doc.enabled !== false,
+    deferToProduction: doc.defer_to_production === true,
+  };
+}
+
+export function serializeEnvironmentsFile(file: DbtEnvironmentsFile): string {
+  const doc: Record<string, unknown> = {};
+  if (file.dbtVersion) doc.dbt_version = file.dbtVersion;
+  doc.default_environment = file.defaultEnvironment;
+  if (file.prodEnvironment) doc.prod_environment = file.prodEnvironment;
+  doc.environments = file.environments.map(env => {
+    const e: Record<string, unknown> = {
+      name: env.name,
+      connection_id: env.connectionId,
+      target_schema: env.targetSchema,
+    };
+    if (env.threads != null) e.threads = env.threads;
+    if (env.vars && Object.keys(env.vars).length > 0) e.vars = env.vars;
+    if (env.ownerUserId) e.owner_user_id = env.ownerUserId;
+    return e;
+  });
+  return yaml.dump(doc, { lineWidth: 100, noRefs: true });
+}
+
+export function parseEnvironmentsFile(
+  contents: string,
+): DbtEnvironmentsFile | null {
+  let raw: unknown;
+  try {
+    raw = yaml.load(contents);
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const doc = raw as Record<string, unknown>;
+  const defaultEnvironment =
+    typeof doc.default_environment === "string"
+      ? doc.default_environment.trim()
+      : "";
+  const list = Array.isArray(doc.environments) ? doc.environments : [];
+  const environments: DbtEnvironmentsFile["environments"] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") return null;
+    const e = entry as Record<string, unknown>;
+    const name = typeof e.name === "string" ? e.name.trim() : "";
+    const connectionId =
+      typeof e.connection_id === "string" ? e.connection_id.trim() : "";
+    const targetSchema =
+      typeof e.target_schema === "string" ? e.target_schema.trim() : "";
+    if (!name || !connectionId || !targetSchema) return null;
+    environments.push({
+      name,
+      connectionId,
+      targetSchema,
+      threads: typeof e.threads === "number" ? e.threads : undefined,
+      vars:
+        e.vars && typeof e.vars === "object"
+          ? (e.vars as Record<string, unknown>)
+          : undefined,
+      ownerUserId:
+        typeof e.owner_user_id === "string" ? e.owner_user_id : undefined,
+    });
+  }
+  if (!defaultEnvironment || environments.length === 0) return null;
+  if (!environments.some(e => e.name === defaultEnvironment)) return null;
+  return {
+    dbtVersion:
+      typeof doc.dbt_version === "string" ? doc.dbt_version : undefined,
+    defaultEnvironment,
+    prodEnvironment:
+      typeof doc.prod_environment === "string"
+        ? doc.prod_environment
+        : undefined,
+    environments,
+  };
+}

--- a/api/src/dbt/dbt-config.service.test.ts
+++ b/api/src/dbt/dbt-config.service.test.ts
@@ -1,0 +1,248 @@
+/**
+ * dbt orchestration config as files (apps.md §23): write-through, push-sync
+ * reconciliation, adoption. Real bare repo + mongodb-memory-server.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { DbtJob, DbtProject } from "../database/workspace-schema";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  initRepo,
+  readBlob,
+  repoDirFor,
+} from "../apps/repository.service";
+import {
+  DBT_ENVIRONMENTS_PATH,
+  jobFilePath,
+  parseJobFile,
+  serializeJobFile,
+} from "./dbt-config-files";
+import {
+  adoptDbtConfig,
+  commitDbtJobFile,
+  deleteDbtJobFile,
+  reserveJobSlug,
+  syncDbtConfigFromRepo,
+} from "./dbt-config.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+const WS = new Types.ObjectId();
+const CONN = new Types.ObjectId();
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "dbt-config-test-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await Promise.all([DbtProject.deleteMany({}), DbtJob.deleteMany({})]);
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+  await initRepo(repoDirFor(WS.toString()), { "README.md": "x\n" });
+});
+
+async function seedProject() {
+  return DbtProject.create({
+    workspaceId: WS,
+    name: "Analytics",
+    dbtVersion: "1.9",
+    environments: [
+      { name: "dev", connectionId: CONN, targetSchema: "dbt_dev", threads: 4 },
+      {
+        name: "prod",
+        connectionId: CONN,
+        targetSchema: "dbt_prod",
+        threads: 8,
+      },
+    ],
+    defaultEnvironment: "dev",
+    createdBy: "u1",
+  });
+}
+
+async function seedJob(project: { _id: Types.ObjectId }, name: string) {
+  return DbtJob.create({
+    workspaceId: WS,
+    projectId: project._id,
+    slug: await reserveJobSlug(project._id, name),
+    name,
+    environment: "prod",
+    commands: ["build --select realadvisor"],
+    schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+    enabled: true,
+    createdBy: "u1",
+  });
+}
+
+async function fileAt(rel: string): Promise<string | null> {
+  try {
+    const blob = await readBlob(repoDirFor(WS.toString()), MAIN, rel);
+    return blob.isBinary ? null : blob.contents;
+  } catch {
+    return null;
+  }
+}
+
+describe("format round-trip", () => {
+  it("serialize/parse preserves the definition", () => {
+    const file = {
+      name: "Nightly build",
+      environment: "prod",
+      commands: ["build --select realadvisor", "test"],
+      schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+      enabled: true,
+      deferToProduction: true,
+    };
+    expect(parseJobFile(serializeJobFile(file))).toEqual(file);
+  });
+
+  it("rejects half a schedule and empty commands", () => {
+    expect(parseJobFile("name: x\nenvironment: e\ncommands: []\n")).toBeNull();
+    expect(
+      parseJobFile(
+        "name: x\nenvironment: e\ncommands: [build]\nschedule:\n  cron: '* * * * *'\n",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("write-through", () => {
+  it("commitDbtJobFile writes dbt/jobs/<slug>.yml and stamps the sha", async () => {
+    const project = await seedProject();
+    const job = await seedJob(project, "Nightly prod build");
+    await commitDbtJobFile(project, job);
+    const contents = await fileAt(jobFilePath(job.slug!));
+    expect(contents).toContain("Nightly prod build");
+    expect(contents).toContain("cron: 0 6 * * *");
+    const fresh = await DbtJob.findById(job._id);
+    expect(fresh?.sourceBlobSha).toBeTruthy();
+
+    await deleteDbtJobFile(project, job.slug);
+    expect(await fileAt(jobFilePath(job.slug!))).toBeNull();
+  });
+});
+
+describe("sync from repo", () => {
+  it("an external job edit updates the row and re-registers the schedule; runtime fields survive", async () => {
+    const project = await seedProject();
+    const job = await seedJob(project, "Nightly prod build");
+    await commitDbtJobFile(project, job);
+    await DbtJob.updateOne(
+      { _id: job._id },
+      { $set: { "scheduledRun.consecutiveFailures": 3 } },
+    );
+
+    const edited = serializeJobFile({
+      name: "Nightly prod build",
+      environment: "prod",
+      commands: ["build --select realadvisor --full-refresh"],
+      schedule: { cron: "30 5 * * *", timezone: "Europe/Zurich" },
+      enabled: true,
+      deferToProduction: false,
+    });
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      { writes: { [jobFilePath(job.slug!)]: edited } },
+      { message: "laptop edit" },
+    );
+    await syncDbtConfigFromRepo(WS.toString());
+
+    const fresh = await DbtJob.findById(job._id);
+    expect(fresh?.commands).toEqual([
+      "build --select realadvisor --full-refresh",
+    ]);
+    expect(fresh?.schedule?.cron).toBe("30 5 * * *");
+    expect(fresh?.scheduledRun?.nextAt).toBeInstanceOf(Date);
+    expect(fresh?.scheduledRun?.consecutiveFailures).toBe(3);
+  });
+
+  it("a removed file removes the job; a disallowed command is skipped", async () => {
+    const project = await seedProject();
+    const job = await seedJob(project, "Doomed job");
+    await commitDbtJobFile(project, job);
+    const evil = serializeJobFile({
+      name: "Evil",
+      environment: "prod",
+      commands: ["run-operation drop_everything"],
+      schedule: null,
+      enabled: true,
+      deferToProduction: false,
+    });
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      {
+        writes: { [jobFilePath("evil")]: evil },
+        deletes: [jobFilePath(job.slug!)],
+      },
+      { message: "laptop mischief" },
+    );
+    await syncDbtConfigFromRepo(WS.toString());
+    expect(await DbtJob.findById(job._id)).toBeNull();
+    expect(await DbtJob.findOne({ slug: "evil" })).toBeNull();
+  });
+
+  it("environments.yml edits reach the project row", async () => {
+    const project = await seedProject();
+    await adoptDbtConfig(WS.toString());
+    const raw = (await fileAt(DBT_ENVIRONMENTS_PATH))!;
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      {
+        writes: {
+          [DBT_ENVIRONMENTS_PATH]: raw.replace(
+            "target_schema: dbt_dev",
+            "target_schema: dbt_dev_v2",
+          ),
+        },
+      },
+      { message: "laptop env edit" },
+    );
+    await syncDbtConfigFromRepo(WS.toString());
+    const fresh = await DbtProject.findById(project._id);
+    expect(fresh?.environments.find(e => e.name === "dev")?.targetSchema).toBe(
+      "dbt_dev_v2",
+    );
+  });
+});
+
+describe("adoption", () => {
+  it("writes files for unstamped jobs + environments once, re-runnable", async () => {
+    const project = await seedProject();
+    await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      name: "Legacy job",
+      environment: "dev",
+      commands: ["build"],
+      enabled: true,
+      createdBy: "u1",
+    });
+    const first = await adoptDbtConfig(WS.toString());
+    expect(first).toEqual({ jobs: 1, written: 2 });
+    const row = await DbtJob.findOne({ name: "Legacy job" });
+    expect(row?.slug).toBe("legacy-job");
+    expect(await fileAt(jobFilePath("legacy-job"))).toContain("Legacy job");
+    expect(await fileAt(DBT_ENVIRONMENTS_PATH)).toContain("dbt_prod");
+    const again = await adoptDbtConfig(WS.toString());
+    expect(again.written).toBe(0);
+  });
+});

--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -1,0 +1,366 @@
+/**
+ * dbt orchestration config in the workspace repo (apps.md §23).
+ *
+ * Files are authoritative for job DEFINITIONS (`dbt/jobs/<slug>.yml`) and
+ * project environments/settings (`dbt/environments.yml`); the Mongo rows
+ * are the derived index the scheduler scans, carrying the runtime fields
+ * (scheduledRun claims, failure counters, lastRun stats) that never enter
+ * git. Every in-product mutation writes through here (a commit on main —
+ * jobs build main, so orchestration config is main-scoped, branch-policy
+ * rule 2), and the push-reaction reconciles external edits, re-registering
+ * schedules the way a push to apps/ deploys.
+ */
+import { Types } from "mongoose";
+import {
+  DbtJob,
+  DbtProject,
+  type IDbtJob,
+  type IDbtProject,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+import { authorForUser } from "../apps/workspace-consoles.service";
+import { ensureLocalRepo, queueMirrorPush } from "../apps/cloud-repo.service";
+import {
+  DEFAULT_BRANCH,
+  repoDirFor,
+  blobOid,
+  commitBlobsOnBranch,
+  listTree,
+  readBlobsBatch,
+  readBlob,
+  repoExists,
+  resolveCommit,
+  type GitAuthor,
+} from "../apps/repository.service";
+import {
+  DBT_ENVIRONMENTS_PATH,
+  jobFilePath,
+  parseEnvironmentsFile,
+  parseJobFile,
+  serializeEnvironmentsFile,
+  serializeJobFile,
+  slugFromJobFilePath,
+  slugifyJobName,
+  type DbtJobFile,
+} from "./dbt-config-files";
+import { parseDbtCommands } from "./commands";
+import { applyJobScheduleChange } from "./dbt-run.service";
+
+const logger = loggers.api("dbt-config");
+
+function jobToFile(job: IDbtJob): DbtJobFile {
+  return {
+    name: job.name,
+    environment: job.environment,
+    commands: [...job.commands],
+    schedule: job.schedule?.cron
+      ? { cron: job.schedule.cron, timezone: job.schedule.timezone || "UTC" }
+      : null,
+    enabled: job.enabled !== false,
+    deferToProduction: !!job.deferToProduction,
+  };
+}
+
+function environmentsToFile(project: IDbtProject) {
+  return {
+    dbtVersion: project.dbtVersion,
+    defaultEnvironment: project.defaultEnvironment,
+    prodEnvironment: project.prodEnvironment,
+    environments: project.environments.map(env => ({
+      name: env.name,
+      connectionId: env.connectionId.toString(),
+      targetSchema: env.targetSchema,
+      threads: env.threads,
+      vars: env.vars as Record<string, unknown> | undefined,
+      ownerUserId: env.ownerUserId,
+    })),
+  };
+}
+
+async function repoDirIfExists(workspaceId: string): Promise<string | null> {
+  await ensureLocalRepo(workspaceId);
+  const repoDir = repoDirFor(workspaceId);
+  return (await repoExists(repoDir)) ? repoDir : null;
+}
+
+async function commitConfig(
+  workspaceId: string,
+  mutation: { writes?: Record<string, string>; deletes?: string[] },
+  message: string,
+  author?: GitAuthor,
+): Promise<void> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  // No repo (pre-§17 workspace): Mongo remains the only home — nothing to
+  // write through. RealAdvisor and every §17-era workspace has one.
+  if (!repoDir) return;
+  const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
+    message,
+    author,
+  });
+  if (!result.unchanged) queueMirrorPush(workspaceId);
+}
+
+/** Reserve a unique slug for a new job and stamp it on the row fields. */
+export async function reserveJobSlug(
+  projectId: Types.ObjectId,
+  name: string,
+): Promise<string> {
+  const base = slugifyJobName(name);
+  let slug = base;
+  for (let i = 2; i < 100; i++) {
+    const taken = await DbtJob.exists({ projectId, slug });
+    if (!taken) return slug;
+    slug = `${base}-${i}`;
+  }
+  throw new Error(`Could not find a free slug for job "${name}"`);
+}
+
+/** Write-through: the job's file mirrors the row's definition fields. */
+export async function commitDbtJobFile(
+  project: Pick<IDbtProject, "workspaceId">,
+  job: IDbtJob,
+  actorUserId?: string,
+  messageOverride?: string,
+): Promise<void> {
+  if (!job.slug) return; // pre-adoption row; the migration stamps slugs
+  const contents = serializeJobFile(jobToFile(job));
+  const sha = blobOid(contents);
+  if (job.sourceBlobSha !== sha) {
+    await DbtJob.updateOne({ _id: job._id }, { $set: { sourceBlobSha: sha } });
+  }
+  await commitConfig(
+    project.workspaceId.toString(),
+    { writes: { [jobFilePath(job.slug)]: contents } },
+    messageOverride ?? `dbt: job "${job.name}" (${job.slug})`,
+    actorUserId ? await authorForUser(actorUserId) : undefined,
+  );
+}
+
+export async function deleteDbtJobFile(
+  project: Pick<IDbtProject, "workspaceId">,
+  slug: string | undefined,
+  actorUserId?: string,
+): Promise<void> {
+  if (!slug) return;
+  await commitConfig(
+    project.workspaceId.toString(),
+    { deletes: [jobFilePath(slug)] },
+    `dbt: delete job ${slug}`,
+    actorUserId ? await authorForUser(actorUserId) : undefined,
+  );
+}
+
+export async function commitDbtEnvironmentsFile(
+  project: IDbtProject,
+  actorUserId?: string,
+): Promise<void> {
+  await commitConfig(
+    project.workspaceId.toString(),
+    {
+      writes: {
+        [DBT_ENVIRONMENTS_PATH]: serializeEnvironmentsFile(
+          environmentsToFile(project),
+        ),
+      },
+    },
+    "dbt: update environments",
+    actorUserId ? await authorForUser(actorUserId) : undefined,
+  );
+}
+
+/**
+ * Reconcile the Mongo index from `dbt/jobs/*.yml` + `dbt/environments.yml`
+ * at main. Runs on every push (notifyRepoPushed). Definition fields follow
+ * the files; runtime fields (scheduledRun, failure counters) are preserved;
+ * schedules are re-registered when they changed. Invalid files are logged
+ * and skipped — a broken YAML must not take a production job down.
+ */
+const syncInFlight = new Map<string, Promise<void>>();
+
+export async function syncDbtConfigFromRepo(
+  workspaceId: string,
+  actorUserId?: string,
+): Promise<void> {
+  const running = syncInFlight.get(workspaceId);
+  if (running) return running;
+  const run = syncDbtConfigNow(workspaceId, actorUserId).finally(() => {
+    syncInFlight.delete(workspaceId);
+  });
+  syncInFlight.set(workspaceId, run);
+  return run;
+}
+
+async function syncDbtConfigNow(
+  workspaceId: string,
+  _actorUserId?: string,
+): Promise<void> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return;
+  const project = await DbtProject.findOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!project) return;
+  const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
+  if (!head) return;
+  const entries = await listTree(repoDir, head);
+  const jobPaths = entries
+    .map(e => e.path)
+    .filter(p => slugFromJobFilePath(p) !== null);
+  // No dbt config in the repo at all → not adopted; leave Mongo alone.
+  const hasEnvFile = entries.some(e => e.path === DBT_ENVIRONMENTS_PATH);
+  if (jobPaths.length === 0 && !hasEnvFile) return;
+
+  // ---- environments.yml → project settings ----
+  if (hasEnvFile) {
+    try {
+      const blob = await readBlob(repoDir, head, DBT_ENVIRONMENTS_PATH);
+      const parsed = blob.isBinary
+        ? null
+        : parseEnvironmentsFile(blob.contents);
+      if (!parsed) {
+        logger.warn("dbt environments.yml is invalid; keeping current config", {
+          workspaceId,
+        });
+      } else {
+        project.environments = parsed.environments.map(env => ({
+          name: env.name,
+          connectionId: new Types.ObjectId(env.connectionId),
+          targetSchema: env.targetSchema,
+          threads: env.threads ?? 4,
+          vars: env.vars,
+          ownerUserId: env.ownerUserId,
+        })) as IDbtProject["environments"];
+        project.defaultEnvironment = parsed.defaultEnvironment;
+        project.prodEnvironment = parsed.prodEnvironment;
+        if (parsed.dbtVersion) project.dbtVersion = parsed.dbtVersion;
+        if (project.isModified()) await project.save();
+      }
+    } catch (error) {
+      logger.warn("dbt environments sync failed", { workspaceId, error });
+    }
+  }
+
+  // ---- jobs/*.yml → job rows ----
+  const blobs = await readBlobsBatch(repoDir, head, jobPaths);
+  const seenSlugs = new Set<string>();
+  for (const [path, buf] of blobs) {
+    const slug = slugFromJobFilePath(path);
+    if (!slug) continue;
+    seenSlugs.add(slug);
+    const contents = buf.toString("utf8");
+    const sha = blobOid(contents);
+    const row = await DbtJob.findOne({ projectId: project._id, slug });
+    if (row && row.sourceBlobSha === sha) continue; // level already
+    const parsed = parseJobFile(contents);
+    if (!parsed) {
+      logger.warn("dbt job file is invalid; keeping current row", {
+        workspaceId,
+        path,
+      });
+      continue;
+    }
+    try {
+      parseDbtCommands(parsed.commands); // allowlist — never index a job we refuse to run
+    } catch (error) {
+      logger.warn("dbt job file has disallowed commands; skipped", {
+        workspaceId,
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    if (!project.environments.some(env => env.name === parsed.environment)) {
+      logger.warn("dbt job file names an unknown environment; skipped", {
+        workspaceId,
+        path,
+        environment: parsed.environment,
+      });
+      continue;
+    }
+    const scheduleChanged =
+      !row ||
+      row.enabled !== parsed.enabled ||
+      (row.schedule?.cron ?? null) !== (parsed.schedule?.cron ?? null) ||
+      (row.schedule?.timezone ?? null) !== (parsed.schedule?.timezone ?? null);
+    const doc =
+      row ??
+      new DbtJob({
+        workspaceId: project.workspaceId,
+        projectId: project._id,
+        slug,
+        createdBy: "sync",
+      });
+    doc.name = parsed.name;
+    doc.environment = parsed.environment;
+    doc.commands = parsed.commands;
+    doc.schedule = parsed.schedule
+      ? { cron: parsed.schedule.cron, timezone: parsed.schedule.timezone }
+      : undefined;
+    doc.enabled = parsed.enabled;
+    doc.deferToProduction = parsed.deferToProduction;
+    doc.sourceBlobSha = sha;
+    await doc.save();
+    if (scheduleChanged) await applyJobScheduleChange(doc);
+    logger.info("dbt job synced from repo", { workspaceId, slug });
+  }
+
+  // A job file removed on main removes the job (runs keep their history).
+  const stale = await DbtJob.find({
+    projectId: project._id,
+    slug: { $exists: true, $nin: [...seenSlugs] },
+  }).select("slug name");
+  for (const doc of stale) {
+    await DbtJob.deleteOne({ _id: doc._id });
+    logger.info("dbt job removed (file deleted on main)", {
+      workspaceId,
+      slug: doc.slug,
+    });
+  }
+}
+
+/**
+ * Adoption (migration path): write files for every job + the environments
+ * of a repo-holding workspace, stamping slugs. Only missing files are
+ * written, in ONE commit. Re-runnable.
+ */
+export async function adoptDbtConfig(workspaceId: string): Promise<{
+  jobs: number;
+  written: number;
+}> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return { jobs: 0, written: 0 };
+  const project = await DbtProject.findOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!project) return { jobs: 0, written: 0 };
+  const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
+  const existing = new Set(
+    head ? (await listTree(repoDir, head)).map(e => e.path) : [],
+  );
+
+  const writes: Record<string, string> = {};
+  const jobs = await DbtJob.find({ projectId: project._id });
+  for (const job of jobs) {
+    if (!job.slug) {
+      job.slug = await reserveJobSlug(project._id, job.name);
+    }
+    const path = jobFilePath(job.slug);
+    const contents = serializeJobFile(jobToFile(job));
+    job.sourceBlobSha = blobOid(contents);
+    await job.save();
+    if (!existing.has(path)) writes[path] = contents;
+  }
+  if (!existing.has(DBT_ENVIRONMENTS_PATH)) {
+    writes[DBT_ENVIRONMENTS_PATH] = serializeEnvironmentsFile(
+      environmentsToFile(project),
+    );
+  }
+  if (Object.keys(writes).length > 0) {
+    await commitConfig(
+      workspaceId,
+      { writes },
+      `dbt: adopt orchestration config into git (${jobs.length} jobs + environments)`,
+    );
+  }
+  return { jobs: jobs.length, written: Object.keys(writes).length };
+}

--- a/api/src/dbt/dbt-environments.service.ts
+++ b/api/src/dbt/dbt-environments.service.ts
@@ -271,6 +271,11 @@ export async function ensurePersonalDbtEnvironment(params: {
   project.environments.push(environment);
   project.markModified("environments");
   await project.save();
+  // Environments live in dbt/environments.yml — write the provisioned one
+  // through so the file and the row never diverge (apps.md §23). Lazy
+  // import: dbt-config.service imports this module for prod-env resolution.
+  const { commitDbtEnvironmentsFile } = await import("./dbt-config.service");
+  await commitDbtEnvironmentsFile(project, params.userId);
 
   return { environment, created: true };
 }

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -603,6 +603,21 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             jobId: updatedJob._id.toString(),
             consecutiveFailures: failures,
           });
+          // enabled is authored state in dbt/jobs/<slug>.yml — flip the
+          // file too or the next push-sync would re-enable the job.
+          try {
+            const { commitDbtJobFile } = await import(
+              "../../dbt/dbt-config.service"
+            );
+            await commitDbtJobFile(
+              { workspaceId: updatedJob.workspaceId },
+              updatedJob,
+              undefined,
+              `dbt: auto-disable job "${updatedJob.name}" after ${failures} failures`,
+            );
+          } catch (error) {
+            logger.warn("Auto-disable file write-through failed", { error });
+          }
         }
       }
 

--- a/api/src/migrations/2026-09-01-120000_dbt_config_to_git.ts
+++ b/api/src/migrations/2026-09-01-120000_dbt_config_to_git.ts
@@ -1,0 +1,58 @@
+/**
+ * dbt orchestration config into the workspace repo (apps.md §23): every
+ * job becomes `dbt/jobs/<slug>.yml`, environments + settings become
+ * `dbt/environments.yml`. Rows stay as the scheduler's derived index
+ * (runtime fields never enter git); slugs + blob shas are stamped.
+ *
+ * Mongoose is connected FIRST — repo helpers use mongoose models, and the
+ * dbt cutover proved that skipping this turns every lookup into a silently
+ * swallowed 10s buffering timeout (apps.md §21 post-mortem).
+ */
+import { Db } from "mongodb";
+import mongoose from "mongoose";
+import { loggers } from "../logging";
+import { adoptDbtConfig } from "../dbt/dbt-config.service";
+import { mirrorPushNow } from "../apps/cloud-repo.service";
+
+const log = loggers.migration();
+
+export const description =
+  "dbt jobs + environments become YAML files in the workspace repo (dbt/jobs/*.yml, dbt/environments.yml)";
+
+export async function up(db: Db): Promise<void> {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      (db as unknown as { client: { s: { url: string } } }).client.s.url,
+      { dbName: db.databaseName },
+    );
+  }
+  const workspaceIds = (await db
+    .collection("dbt_projects")
+    .distinct("workspaceId")) as Array<{ toString(): string }>;
+  let adopted = 0;
+  let failed = 0;
+  for (const raw of workspaceIds) {
+    const workspaceId = raw.toString();
+    try {
+      const report = await adoptDbtConfig(workspaceId);
+      if (report.written > 0) {
+        await mirrorPushNow(workspaceId);
+        adopted++;
+        log.info("dbt config adopted", { workspaceId, ...report });
+      }
+    } catch (error) {
+      failed++;
+      log.error("dbt config adoption failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  if (failed > 0) {
+    throw new Error(`dbt config adoption failed for ${failed} workspace(s)`);
+  }
+  log.info("dbt_config_to_git done", {
+    workspaces: workspaceIds.length,
+    adopted,
+  });
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -45,6 +45,12 @@ import {
 } from "../dbt/commands";
 import { buildStarterScaffold } from "../dbt/scaffold";
 import {
+  commitDbtEnvironmentsFile,
+  commitDbtJobFile,
+  deleteDbtJobFile,
+  reserveJobSlug,
+} from "../dbt/dbt-config.service";
+import {
   DBT_PREVIEW_DEFAULT_LIMIT,
   DBT_PREVIEW_MAX_LIMIT,
   parseDbtShowPreview,
@@ -484,6 +490,8 @@ dbtRoutes.patch("/projects/:projectId", async (c: AuthenticatedContext) => {
       if (personalError) return badRequest(c, personalError);
     }
     await project.save();
+    // Environments/settings live in dbt/environments.yml (apps.md §23).
+    await commitDbtEnvironmentsFile(project, getUserId(c));
     publishDbtEvent(c, {
       type: "dbt.project.updated",
       projectId: project._id.toString(),
@@ -869,6 +877,7 @@ dbtRoutes.post("/projects/:projectId/jobs", async (c: AuthenticatedContext) => {
     const job = await DbtJob.create({
       workspaceId: project.workspaceId,
       projectId: project._id,
+      slug: await reserveJobSlug(project._id, parsed.data.name),
       name: parsed.data.name,
       environment: parsed.data.environment,
       commands: parsed.data.commands,
@@ -878,6 +887,8 @@ dbtRoutes.post("/projects/:projectId/jobs", async (c: AuthenticatedContext) => {
       createdBy: getUserId(c),
     });
     await applyJobScheduleChange(job);
+    // The definition is a file: dbt/jobs/<slug>.yml (apps.md §23).
+    await commitDbtJobFile(project, job, getUserId(c));
     const fresh = await DbtJob.findById(job._id).lean();
     publishDbtEvent(c, {
       type: "dbt.job.updated",
@@ -935,6 +946,7 @@ dbtRoutes.patch(
       job.deferToProduction = merged.deferToProduction;
       await job.save();
       await applyJobScheduleChange(job);
+      await commitDbtJobFile(project, job, getUserId(c));
       const fresh = await DbtJob.findById(job._id).lean();
       publishDbtEvent(c, {
         type: "dbt.job.updated",
@@ -959,13 +971,15 @@ dbtRoutes.delete(
       if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
       }
-      const result = await DbtJob.deleteOne({
+      const doomed = await DbtJob.findOne({
         _id: new Types.ObjectId(jobId),
         projectId: project._id,
-      });
-      if (result.deletedCount === 0) {
+      }).select("slug");
+      if (!doomed) {
         return c.json({ success: false, error: "Job not found" }, 404);
       }
+      await DbtJob.deleteOne({ _id: doomed._id });
+      await deleteDbtJobFile(project, doomed.slug, getUserId(c));
       publishDbtEvent(c, {
         type: "dbt.job.updated",
         projectId: project._id.toString(),

--- a/apps.md
+++ b/apps.md
@@ -2828,3 +2828,35 @@ Curation of the existing 202 is a separate reviewed commit (skills-triage
 branch): delete stale-machinery gotchas, fold app-specific knowledge into
 the apps' own AGENTS.md, merge duplicate families. The push-sync makes the
 merge self-applying — deleted files drop their index rows, no migration.
+
+## 23. dbt orchestration config as code: jobs + environments YAML (2026-09-01)
+
+The asterisk left on §20 ("the code moved, the orchestration config
+didn't"): the 16 job definitions and 5 environments were still Mongo rows
+behind a UI form. Now:
+
+- `dbt/jobs/<slug>.yml` — ONE file per job (name, environment, commands,
+  schedule, enabled, defer_to_production). Per-file, not a registry: the
+  bindings[] scar (§10 Block 1) stands — central metadata files are
+  merge-conflict magnets. The filename slug is the identity; rows carry
+  `slug` + `sourceBlobSha`.
+- `dbt/environments.yml` — environments (connection REFERENCES, never
+  credentials), default/prod environment, dbt version. A per-project
+  singleton, so one file is not a registry-of-many.
+- Rows stay as the scheduler's derived index with the runtime fields
+  (scheduledRun claims, failure counters) that never enter git.
+- Write-through everywhere the config mutates: job routes, agent job tools,
+  the PATCH-project environments path, personal-env auto-provisioning, and
+  the failure auto-disable (which must flip the FILE or the next push-sync
+  would re-enable the job).
+- Push-sync (`syncDbtConfigFromRepo`, chained into notifyRepoPushed)
+  reconciles external edits and re-registers schedules — editing a cron
+  from a laptop clone is now a reviewable commit that takes effect on push.
+  Fail-safe: invalid YAML, unknown environments, and allowlist-refused
+  commands are logged and skipped, never indexed — a broken or malicious
+  file cannot take down or hijack a production job.
+
+Migration adopts existing jobs/environments into the repo (one commit,
+re-runnable, mongoose connected per the §21 rule) and pushes the mirror.
+With this, "dbt is in git" carries no asterisk: source, rules, jobs,
+environments — all files; Mongo keeps runs and claims.


### PR DESCRIPTION
Closes the §20 asterisk: the 16 job definitions and the environments were
still Mongo rows behind a UI form. Now dbt/jobs/<slug>.yml (one file per
job — per-file, never a central registry, per the bindings[] scar) and
dbt/environments.yml (connection REFERENCES only, never credentials) are
authoritative; rows stay as the scheduler's derived index carrying the
runtime fields (scheduledRun claims, failure counters).

Write-through at every mutation point: job routes, agent job tools, the
environments PATCH, personal-env auto-provisioning, and the failure
auto-disable (which flips the FILE so push-sync can't re-enable the job).
Push-sync reconciles external edits and re-registers schedules — a cron
edit from a laptop is a reviewable commit that takes effect on push.
Fail-safe: invalid YAML, unknown environments, and allowlist-refused
commands are logged and skipped, never indexed.

Migration adopts existing jobs + environments (one commit, re-runnable,
mongoose connected per the §21 rule) and pushes the mirror. apps.md §23.

Tests: 7 new specs (round-trip, write-through, external-edit sync with
runtime-field preservation + schedule re-registration, delete-on-removal,
disallowed-command skip, environments sync, adoption). dbt suite 227
green, apps suite 129 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat
