### PR TITLE
fix(apps): main writes freshen from the mirror first; a diverged cache resets to the mirror

### DIFF
--- a/api/src/apps/cloud-repo.service.test.ts
+++ b/api/src/apps/cloud-repo.service.test.ts
@@ -11,8 +11,9 @@
  *    an empty workspace, refuse when both sides have content
  *  - a customer remote is NEVER force-pushed: a diverged remote branch
  *    survives our push attempt; only refs/mako/* may move non-fast-forward
- *  - webhook fetch fast-forwards the local branch and stands still on
- *    divergence instead of dropping either side
+ *  - webhook fetch fast-forwards the local branch, leaves a merely-ahead
+ *    branch alone, and on divergence resets to the mirror with the local
+ *    tip parked under refs/mako/diverged/* (nothing dropped, cache honest)
  */
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -366,12 +367,32 @@ describe("fetchFromCloud on a connected repo", () => {
     expect(await headOf(repoDirFor(workspaceId))).toBe(theirCommit);
   });
 
-  it("stands still on divergence instead of dropping either side", async () => {
+  it("leaves a local branch that is merely ahead alone (its push is pending)", async () => {
+    const remoteDir = await makeBareRemote("acme", "ahead-local");
+    state.binding = { owner: "acme", repo: "ahead-local" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await adoptConnectedRepo(workspaceId, state.binding);
+    const ourCommit = await commitFiles(
+      repoDirFor(workspaceId),
+      { "l.txt": "local" },
+      "committed here, not pushed yet",
+    );
+
+    await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
+    expect(await headOf(repoDirFor(workspaceId))).toBe(ourCommit);
+    expect(await headOf(remoteDir)).not.toBe(ourCommit);
+  });
+
+  it("on divergence the mirror wins and the local tip is parked under refs/mako/diverged", async () => {
     const remoteDir = await makeBareRemote("acme", "split");
     state.binding = { owner: "acme", repo: "split" };
     await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
     await adoptConnectedRepo(workspaceId, state.binding);
-    await commitFiles(remoteDir, { "r.txt": "remote" }, "remote side");
+    const theirCommit = await commitFiles(
+      remoteDir,
+      { "r.txt": "remote" },
+      "remote side",
+    );
     const ourCommit = await commitFiles(
       repoDirFor(workspaceId),
       { "l.txt": "local" },
@@ -379,7 +400,24 @@ describe("fetchFromCloud on a connected repo", () => {
     );
 
     await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
-    expect(await headOf(repoDirFor(workspaceId))).toBe(ourCommit);
+    // The cache agrees with its source again…
+    expect(await headOf(repoDirFor(workspaceId))).toBe(theirCommit);
+    // …and nothing was dropped: the local tip is parked, here and — via the
+    // forced refs/mako/* namespace — on the mirror, where it can be recovered.
+    const parked = `refs/mako/diverged/${DEFAULT_BRANCH}/${ourCommit.slice(0, 12)}`;
+    const localParked = await runGit([
+      "-C",
+      repoDirFor(workspaceId),
+      "rev-parse",
+      parked,
+    ]);
+    expect(localParked.stdout.trim()).toBe(ourCommit);
+    // fetchFromCloud queued the push; a push scheduled now starts after it.
+    await mirrorPushNow(workspaceId);
+    const remoteParked = await runGit(["-C", remoteDir, "rev-parse", parked]);
+    expect(remoteParked.stdout.trim()).toBe(ourCommit);
+    // The mirror's own main was never touched.
+    expect(await headOf(remoteDir)).toBe(theirCommit);
   });
 });
 

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -4,9 +4,13 @@
  * ONE tier (apps.md §17): the workspace's CONNECTED GitHub repo (Settings →
  * GitHub, `workspaceRepos[]`). That repo IS the durable mirror — commits push
  * there, restores clone from there. A customer remote is never force-pushed:
- * heads and tags go without force (a direct GitHub-side push stalls our
- * mirror with a logged non-fast-forward error instead of being clobbered),
- * and only Mako's own `refs/mako/*` WIP namespace is forced.
+ * heads and tags go without force (a direct GitHub-side push is never
+ * clobbered), and only Mako's own `refs/mako/*` WIP namespace is forced.
+ * The mirror is the source of truth and the local repo its cache: every
+ * write onto `main` here freshens from the mirror first
+ * (`freshenBeforeMainWrite`), and a local branch found diverged from the
+ * mirror is reset to it with its commits parked under `refs/mako/diverged/*`
+ * (`fetchFromCloud`).
  *
  * The connected tier only engages on production (APPS_REQUIRE_CONNECTED_REPO)
  * or under the explicit APPS_CONNECTED_REPO_PUSH=allow opt-in. Previews and
@@ -272,10 +276,9 @@ export async function mirrorPushNow(workspaceId: string): Promise<void> {
  *
  * A push from someone's checkout lands on GitHub, not here — the bare repo is
  * a cache. Before anything can be built from that commit it has to arrive, so
- * a deploy triggered by a webhook fetches first. The local branch advances
- * only when it fast-forwards: on divergence (Mako-side
- * commits that failed to push, plus direct GitHub commits) we log and stand
- * still rather than silently drop either side.
+ * a deploy triggered by a webhook fetches first. Remote ahead → fast-forward;
+ * local ahead → leave it (a mirror push is pending); diverged → the mirror
+ * wins and the local tip is parked under refs/mako/diverged/* (see below).
  */
 /**
  * Make sure `sha` exists in this instance's local repo, fetching it if not.
@@ -413,17 +416,12 @@ export async function fetchFromCloud(
     return;
   }
   if (localOid === remoteOid) return;
-  const fastForwards = await runGit([
-    "-C",
-    repoDir,
-    "merge-base",
-    "--is-ancestor",
-    localOid,
-    remoteOid,
-  ])
-    .then(() => true)
-    .catch(() => false);
-  if (fastForwards) {
+  const isAncestor = (ancestor: string, descendant: string) =>
+    runGit(["-C", repoDir, "merge-base", "--is-ancestor", ancestor, descendant])
+      .then(() => true)
+      .catch(() => false);
+  if (await isAncestor(localOid, remoteOid)) {
+    // Remote is ahead: plain fast-forward.
     await runGit([
       "-C",
       repoDir,
@@ -432,12 +430,55 @@ export async function fetchFromCloud(
       remoteOid,
       localOid,
     ]);
-  } else {
-    logger.warn(
-      "Apps connected-repo fetch skipped: local branch has diverged from the remote",
-      { workspaceId, branch, localOid, remoteOid },
-    );
+    return;
   }
+  if (await isAncestor(remoteOid, localOid)) {
+    // Local is ahead: commits made here whose mirror push has not landed yet
+    // (or is in flight). Nothing to reconcile — the push carries them up.
+    return;
+  }
+  // DIVERGED: both sides have commits the other lacks. The local repo is a
+  // cache of the mirror, and a cache that disagrees with its source is wrong
+  // by definition — leaving it be is what made a whole instance's publishes
+  // fail for hours in prod (every mirror push rejected non-fast-forward until
+  // the instance was recycled, and its local-only commits died with the
+  // tmpfs). So the mirror wins, and nothing is dropped: the local tip is
+  // parked under refs/mako/diverged/* — Mako's own forced namespace, so the
+  // next mirror push carries it to GitHub where it can be recovered — and the
+  // branch is reset to the mirror. Whoever made those commits still has them
+  // in their box/clone; their next push is judged against the real branch
+  // and the pre-receive hook tells them to merge.
+  const parkedRef = `refs/mako/diverged/${branch}/${localOid.slice(0, 12)}`;
+  await runGit(["-C", repoDir, "update-ref", parkedRef, localOid]);
+  const swapped = await runGit([
+    "-C",
+    repoDir,
+    "update-ref",
+    `refs/heads/${branch}`,
+    remoteOid,
+    localOid,
+  ])
+    .then(() => true)
+    .catch(() => false);
+  logger.warn(
+    "Apps connected-repo branch had diverged from the mirror; reset to the mirror, local commits parked",
+    { workspaceId, branch, localOid, remoteOid, parkedRef, swapped },
+  );
+  queueMirrorPush(workspaceId);
+}
+
+/**
+ * Bring `main` up to date with the mirror BEFORE something is committed or
+ * pushed onto it here. Un-throttled (coalesced only), because a write judged
+ * against a stale main is exactly how divergence starts: a laptop pushes to
+ * GitHub, and moments later a skill save, a branch merge, a publish or a
+ * box's `git push` lands on an instance whose main predates it — accepted
+ * locally (it fast-forwards the STALE tip), unmirrorable forever after.
+ * Failures are logged and swallowed: a mirror that is briefly unreachable
+ * must not block the user's write; the mirror push simply retries later.
+ */
+export function freshenBeforeMainWrite(workspaceId: string): Promise<void> {
+  return freshenForServe(workspaceId, 0);
 }
 
 export type ConnectedRepoAdoption =

--- a/api/src/apps/git-endpoint.test.ts
+++ b/api/src/apps/git-endpoint.test.ts
@@ -18,6 +18,19 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 const pushed = vi.hoisted(() => vi.fn());
 vi.mock("./worktree.service", () => ({ notifyRepoPushed: pushed }));
 
+// The connected mirror, when a case wants one (null = local-only workspace,
+// which is what every case but the last runs against).
+const mirror = vi.hoisted(() => ({
+  binding: null as null | { owner: string; repo: string },
+}));
+vi.mock("../services/workspace-repos.service", () => ({
+  getWorkspaceRepo: vi.fn(async () => mirror.binding),
+  findWorkspaceIdByRepoBinding: vi.fn(async () => null),
+}));
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: async () => undefined,
+}));
+
 import {
   GitTokenError,
   mintGitToken,
@@ -437,5 +450,107 @@ describe("commit authorship enforcement", () => {
     await expect(
       run("git", ["-C", repoDir, "rev-parse", "--verify", "refs/heads/legacy"]),
     ).resolves.toBeTruthy();
+  });
+});
+
+/**
+ * The bare repo here is a CACHE of the workspace's connected mirror. A push
+ * must be judged against the mirror's main, not against whatever tip this
+ * instance last saw — otherwise a box pushing after a laptop pushed to GitHub
+ * fast-forwards the stale tip, the server accepts it, and the commit can never
+ * be mirrored (the mirror rejects it non-fast-forward). That is the failure
+ * that took prod publishing down on 2026-09-01.
+ */
+describe("pushes against a connected mirror", () => {
+  const token = () => mintGitToken({ workspaceId: WS, userId: "u1" });
+
+  it("a push is judged against the mirror's main, not this instance's cached copy", async () => {
+    const remotesRoot = path.join(tmpRoot, "remotes");
+    const remoteDir = path.join(remotesRoot, "acme", "mirror.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await run("git", ["init", "-q", "--bare", "-b", "main", remoteDir]);
+    await run("git", [
+      "-C",
+      repoDir,
+      "push",
+      "-q",
+      remoteDir,
+      "refs/heads/*:refs/heads/*",
+    ]);
+    process.env.APPS_GITHUB_REMOTE_BASE = `file://${remotesRoot}`;
+    process.env.APPS_CONNECTED_REPO_PUSH = "allow";
+    mirror.binding = { owner: "acme", repo: "mirror" };
+    try {
+      // A box clones while main is at M0…
+      const box = await freshClone(token());
+      // …then someone pushes straight to GitHub: main → M1.
+      const laptop = await fs.mkdtemp(path.join(tmpRoot, "laptop-"));
+      await run("git", ["clone", "-q", remoteDir, laptop]);
+      await run("git", ["-C", laptop, "config", "user.email", "l@l"]);
+      await run("git", ["-C", laptop, "config", "user.name", "L"]);
+      await fs.writeFile(path.join(laptop, "gh.txt"), "from GitHub\n");
+      await run("git", ["-C", laptop, "add", "-A"]);
+      await run("git", ["-C", laptop, "commit", "-qm", "pushed on GitHub"]);
+      await run("git", ["-C", laptop, "push", "-q", "origin", "HEAD:main"]);
+      const m1 = (
+        await run("git", ["-C", laptop, "rev-parse", "HEAD"])
+      ).stdout.trim();
+
+      // The box commits on its stale main and pushes. The server advertises
+      // the MIRROR's main (M1), so git itself refuses: not a fast-forward.
+      await fs.writeFile(path.join(box, "box.txt"), "from the box\n");
+      await run("git", ["-C", box, "add", "-A"]);
+      await run("git", ["-C", box, "commit", "-qm", "from the box"]);
+      await expect(
+        run(
+          "git",
+          ["-C", box, "push", "-q", "origin", "HEAD:refs/heads/main"],
+          {
+            env: gitEnv(token()),
+          },
+        ),
+      ).rejects.toThrow(/rejected|fetch first|non-fast-forward/i);
+      const serverMain = await run("git", [
+        "-C",
+        repoDir,
+        "rev-parse",
+        "refs/heads/main",
+      ]);
+      expect(serverMain.stdout.trim()).toBe(m1);
+
+      // The box does what git says — merge, then push — and that lands.
+      await run(
+        "git",
+        ["-C", box, "-c", "pull.rebase=false", "pull", "-q", "origin", "main"],
+        { env: { ...gitEnv(token()), GIT_MERGE_AUTOEDIT: "no" } },
+      );
+      await run(
+        "git",
+        ["-C", box, "push", "-q", "origin", "HEAD:refs/heads/main"],
+        { env: gitEnv(token()) },
+      );
+      const merged = (
+        await run("git", ["-C", box, "rev-parse", "HEAD"])
+      ).stdout.trim();
+      const after = await run("git", [
+        "-C",
+        repoDir,
+        "rev-parse",
+        "refs/heads/main",
+      ]);
+      expect(after.stdout.trim()).toBe(merged);
+      const parents = await run("git", [
+        "-C",
+        repoDir,
+        "rev-parse",
+        `${merged}^1`,
+        `${merged}^2`,
+      ]);
+      expect(parents.stdout).toContain(m1);
+    } finally {
+      mirror.binding = null;
+      delete process.env.APPS_GITHUB_REMOTE_BASE;
+      delete process.env.APPS_CONNECTED_REPO_PUSH;
+    }
   });
 });

--- a/api/src/apps/workspace-consoles.service.ts
+++ b/api/src/apps/workspace-consoles.service.ts
@@ -55,6 +55,7 @@ import {
 } from "../services/scheduled-query-schedule.service";
 import {
   ensureWorkspaceRepo,
+  freshenBeforeMainWrite,
   mirrorPushNow,
   queueMirrorPush,
   resolveMirrorTarget,
@@ -386,6 +387,9 @@ export async function commitConsoleBatch(input: {
     throw new RepoRequiredError();
   }
   const repoDir = await ensureConsolesRepo(input.workspaceId);
+  // Commit onto the mirror's main, not a stale cached tip (consoles pin to
+  // the default branch — see branch-policy.ts).
+  await freshenBeforeMainWrite(input.workspaceId);
   if (!input.skipAdoption && !(await consolesAdopted(repoDir))) {
     // First console write on a workspace that never adopted: bring every
     // saved console in (snapshot; the CLI replays history).

--- a/api/src/apps/workspace-prompt.ts
+++ b/api/src/apps/workspace-prompt.ts
@@ -17,6 +17,7 @@ import { RepoRequiredError, appsRequireConnectedRepo } from "./config";
 import { authorForUser } from "./workspace-consoles.service";
 import {
   ensureWorkspaceRepo,
+  freshenBeforeMainWrite,
   queueMirrorPush,
   resolveMirrorTarget,
 } from "./cloud-repo.service";
@@ -63,6 +64,8 @@ export async function commitWorkspacePrompt(
   }
   const repoDir = await ensureWorkspaceRepo(workspaceId);
   if (!(await repoExists(repoDir))) throw new RepoRequiredError();
+  // Commit onto the mirror's main, not a stale cached tip.
+  await freshenBeforeMainWrite(workspaceId);
   const author = actorUserId ? await authorForUser(actorUserId) : undefined;
   const trimmed = content.trim();
   const result = await commitBlobsOnBranch(

--- a/api/src/apps/workspace-skills.service.ts
+++ b/api/src/apps/workspace-skills.service.ts
@@ -25,6 +25,7 @@ import { extractEntities } from "../agent-lib/entity-extraction";
 import { loggers } from "../logging";
 import {
   ensureWorkspaceRepo,
+  freshenBeforeMainWrite,
   queueMirrorPush,
   resolveMirrorTarget,
 } from "./cloud-repo.service";
@@ -131,6 +132,8 @@ export async function commitSkillSave(
 ): Promise<void> {
   await assertDurableWritable(workspaceId);
   const repoDir = await ensureWorkspaceRepo(workspaceId, options.author);
+  // Commit onto the mirror's main, not a stale cached tip.
+  await freshenBeforeMainWrite(workspaceId);
   const writes: Record<string, string> = {};
   let message = `Save skill "${skill.name}"`;
   if (!(await skillsAdopted(repoDir))) {
@@ -180,6 +183,7 @@ export async function commitSkillDelete(
   if (!SKILL_NAME_RE.test(name)) return false;
   const repoDir = repoDirFor(workspaceId);
   if (!(await repoExists(repoDir))) return false;
+  await freshenBeforeMainWrite(workspaceId);
   const deletes = await skillFolderPaths(repoDir, name);
   if (deletes.length === 0) return false;
   await commitBlobsOnBranch(
@@ -205,6 +209,7 @@ export async function commitSkillSuppressed(
   if (!SKILL_NAME_RE.test(name)) return false;
   const repoDir = repoDirFor(workspaceId);
   if (!(await repoExists(repoDir))) return false;
+  await freshenBeforeMainWrite(workspaceId);
   const path = skillFilePath(name);
   const raw = await readRepoFile(repoDir, path);
   const parsed = raw === null ? null : parseSkillFile(name, raw);

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -103,6 +103,7 @@ import { createAppsScaffold } from "./scaffold";
 import {
   ensureCommitLocally,
   ensureLocalRepo,
+  freshenBeforeMainWrite,
   mirrorPushNow,
   resolveMirrorTarget,
   queueMirrorPush,
@@ -1839,6 +1840,9 @@ export async function mergeBranchToMain(
       reason: "Cannot merge the default branch into itself",
     };
   }
+  // Merge onto the mirror's main, not a stale cached tip (see
+  // freshenBeforeMainWrite for why that would be unmirrorable).
+  await freshenBeforeMainWrite(scope.workspaceId);
   const mainRef = `refs/heads/${defaultBranch}`;
   const branchHead = await resolveCommit(repoDir, `refs/heads/${branch}`);
   const mainHead = await resolveCommit(repoDir, mainRef);

--- a/api/src/routes/apps-git.ts
+++ b/api/src/routes/apps-git.ts
@@ -30,7 +30,11 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import type { Context } from "hono";
 import { appsReposRoot } from "../apps/config";
-import { ensureLocalRepo, freshenForServe } from "../apps/cloud-repo.service";
+import {
+  ensureLocalRepo,
+  freshenBeforeMainWrite,
+  freshenForServe,
+} from "../apps/cloud-repo.service";
 import { DEFAULT_BRANCH, repoExists } from "../apps/repository.service";
 import { GitTokenError, verifyGitToken } from "../apps/git-token.service";
 import { notifyRepoPushed } from "../apps/worktree.service";
@@ -222,13 +226,21 @@ async function serveGit(c: Context): Promise<Response> {
   // (GitHub webhook, publish, another window's push): pull the mirror —
   // throttled — before advertising refs or answering upload-pack, or a
   // just-pushed sha is `not our ref` here even though the workspace has it.
-  // Pushes skip this: receive-pack only appends, and the post-receive hook
-  // mirrors outward.
+  // A PUSH is judged against the refs advertised here, so they must be the
+  // mirror's, un-throttled: a push accepted against a stale main is a
+  // fast-forward of the WRONG tip — locally fine, unmirrorable forever after
+  // (the mirror rejects it non-fast-forward), and the instance's publishes
+  // die with it (seen in prod, 2026-09-01). The receive-pack POST itself
+  // needs no freshen: git checks the client's reported old tips against the
+  // refs as they are, so a ref that moved in between is refused, not clobbered.
   const service = new URL(c.req.url).searchParams.get("service");
   const isUploadPack =
     parts.rest === "/git-upload-pack" ||
     (parts.rest === "/info/refs" && service === "git-upload-pack");
+  const isReceiveAdvert =
+    parts.rest === "/info/refs" && service === "git-receive-pack";
   if (isUploadPack) await freshenForServe(payload.wsId);
+  else if (isReceiveAdvert) await freshenBeforeMainWrite(payload.wsId);
   return runHttpBackend({
     repoRoot: appsReposRoot(),
     hooksDir: await hooksDir(),

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -103,6 +103,7 @@ import {
 import {
   adoptConnectedRepo,
   type ConnectedRepoAdoption,
+  freshenBeforeMainWrite,
   mirrorPushNow,
 } from "../apps/cloud-repo.service";
 import { updateRefCas } from "../apps/repository.service";
@@ -2068,6 +2069,11 @@ appsRoutes.openapi(
       );
       const body = c.req.valid("json") ?? {};
       const user = c.get("user");
+      // Merge onto the mirror's main, not this instance's cached copy of it.
+      // A laptop push or a PR merge on GitHub that this instance has not seen
+      // yet would otherwise make the promoted main unmirrorable (non-fast-
+      // forward) and the publish fail with "could not save durably".
+      await freshenBeforeMainWrite(loaded.project.workspaceId.toString());
       // Publishing means "ship MY work" — the branch the caller is actually
       // on (their worktree doc remembers it; checkout keeps it current),
       // not a computed name. On main, publish simply builds main's head.


### PR DESCRIPTION
## Why

Prod incident 2026-09-01 06:40–07:05Z ("apps seems to be down"): every publish that landed on one long-lived Cloud Run instance returned **502 "Could not save the change durably — the push to the git mirror failed"**. That instance's local `main` had diverged from the GitHub mirror (`realadvisor/mako-workspace`): people pushed straight to GitHub (laptop pushes, a PR merge, box merges) while the instance had accepted commits against its stale tip. `fetchFromCloud` logged `local branch has diverged` and stood still by design; from then on every mirror push from that instance was rejected `! [rejected] main -> main (fetch first)` — 43 failures in an hour — until the next deploy recycled it, and its unmirrored commits (`5728725a`, never on GitHub) died with the tmpfs.

## What

The mirror is the source of truth; the local bare repo is its cache. Two changes make the code behave that way:

1. **`freshenBeforeMainWrite`** — an un-throttled (coalesced) fetch of `main` from the mirror, called before every server-side write onto `main`:
   - `apps-git` **receive-pack ref advertisement** — a box's push is now judged against the *mirror's* main, so a stale-tip push is refused by git itself (non-fast-forward, "merge instead") instead of being accepted locally and stranded forever. The POST needs no freshen: git refuses a ref that moved between advertisement and push.
   - **publish** (`POST /apps/:id/publish`) — merges onto the real main, so `promoteToMain` + `mirrorPushNow` can't be rejected for a reason the caller can't fix.
   - `mergeBranchToMain`, `commitSkillSave/Delete/Suppressed`, `commitConsoleBatch`, `commitWorkspacePrompt`.
2. **`fetchFromCloud` heals divergence.** It now distinguishes *local ahead* (a mirror push is pending — leave it alone; previously mis-logged as "diverged") from *true divergence*. On divergence the mirror wins: the local tip is parked under `refs/mako/diverged/<branch>/<sha12>` (Mako's forced namespace, so the next mirror push carries it to GitHub for recovery) and the branch is reset to the mirror. Nothing is dropped, the cache is honest again, and the box that made those commits gets an ordinary non-fast-forward on its next push.

No route/schema changes (no `openapi:sync` needed).

## Tests

- `git-endpoint.test.ts` — new real-git case against a file:// mirror: box clones at M0, laptop pushes M1 to the mirror, box's push of a commit on M0 is **refused**, server main == M1; box merges and pushes again → lands as a merge whose parents include M1.
- `cloud-repo.service.test.ts` — "local ahead is left alone" and "on divergence the mirror wins, local tip parked locally and on the mirror, mirror main untouched" (replaces the old "stands still" case).
- Full apps suite: 13 files / 133 tests green.

## Not in this PR

The same window also had ~30s of Cloud Run `no available instance` (07:02:44–07:03:14) — a Close CDC webhook burst (~810 req/min) hitting 2 warm instances (minScale 1) with ~30s boot. That's infra (minScale 2–3 / faster boot), not code; `apps-deploy` fan-out was already capped at 2/workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
