### PR TITLE
fix(onboarding): "start with demo data" has 500'd on every browser for two weeks

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { serve } from "@hono/node-server";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
 import { secureHeaders } from "hono/secure-headers";
 import { serve as serveInngest } from "inngest/hono";
 import { Scalar } from "@scalar/hono-api-reference";
@@ -126,6 +127,19 @@ app.use(
 
 // Global JSON error handler – ensures errors are returned as JSON
 app.onError((err, c) => {
+  // Hono's own exceptions carry their status (the JSON validator throws a 400
+  // "Malformed JSON in request body", for one). A client mistake is not a
+  // server failure: answer with that status and log it as a warning, so the
+  // error log stays a list of things that are actually broken here.
+  if (err instanceof HTTPException) {
+    logger.warn("Rejected API request", {
+      status: err.status,
+      error: err.message,
+      path: c.req.path,
+      method: c.req.method,
+    });
+    return c.json({ success: false, error: err.message }, err.status);
+  }
   logger.error("Unhandled API error", {
     error: err,
     path: c.req.path,

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -94,10 +94,19 @@ class ApiClient {
       workspaceHeaders["x-workspace-id"] = workspaceId;
     }
 
+    // Only claim a JSON body when there IS one. `post(path)` with no data sends
+    // an empty body, and a `Content-Type: application/json` on an empty body
+    // makes the server's JSON validator try to parse it — "Malformed JSON in
+    // request body", a 500 on every route that accepts an optional body. That
+    // is what broke "start with demo data" in onboarding for two weeks.
+    const contentType: Record<string, string> =
+      restOptions.body === undefined || restOptions.body === null
+        ? {}
+        : { "Content-Type": "application/json" };
     const response = await fetch(url, {
       ...restOptions,
       headers: {
-        "Content-Type": "application/json",
+        ...contentType,
         ...workspaceHeaders,
         ...headers,
       },


### PR DESCRIPTION
## Why

Found while checking prod after today's apps incident: `POST /workspaces/:id/databases/demo` — the "start with demo data" step of onboarding — has returned **500 "Malformed JSON in request body" for 100% of browser requests for at least 29 days** — the full retention window. Measured over 30 days of Cloud Run request logs:

| | |
|---|---|
| Browser requests | **1,993 — every one a 500** |
| Browser successes | **zero, ever** |
| Days with a 500 | 29 (2026-08-04 → 2026-09-01, i.e. as far back as logs go) |
| Non-500 responses | one 201 (a curl of mine) and six 403s |


## Root cause

The route declares an *optional* JSON body (`required: false`), and `OnboardingFlow` calls `apiClient.post(path)` with no data. But `app/src/lib/api-client.ts` always sent `Content-Type: application/json` — so Hono's JSON validator, seeing the header, called `c.req.json()` on an empty body and threw `HTTPException(400, "Malformed JSON in request body")`. The API's `onError` then reported that 400 as an unhandled 500.

Verified in isolation with `@hono/zod-openapi`: header + empty body → 400 "Malformed JSON"; no header → 200.

## What

- `api-client.ts` — claim a JSON content type **only when there is a body**. `post(path)` with no data now sends no `Content-Type`, and the validator correctly skips a body that was never sent. One body-less caller exists today (the demo step); every optional-body route benefits.
- `api/src/index.ts` `onError` — Hono's `HTTPException` keeps its own status and is logged as a **warning** ("Rejected API request"), not as "Unhandled API error" 500. A client mistake is not a server failure, and the error log should stay a list of things actually broken.

No route/schema changes.

## Verify after deploy

`gcloud logging read 'logName:"requests" AND httpRequest.requestUrl:"databases/demo"' --project=mako-ai-prod --freshness=1h` should show 201s from browsers again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1

