### PR TITLE
Apps: per-app environment variables (encrypted vault, secret/non-secret tiers)

### DIFF
--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -28,6 +28,7 @@ import { AppProject, type IAppProject } from "../database/workspace-schema";
 import { loggers } from "../logging";
 import { boxCtx, handleProject, type WorktreeHandle } from "./worktree.service";
 import { readBoxDir } from "./box";
+import { resolveAppEnv } from "./env.service";
 
 const logger = loggers.api("apps-deployment");
 
@@ -261,10 +262,15 @@ export async function buildApp(
   exec: (
     handle: WorktreeHandle,
     command: string,
-    options: { timeoutMs: number },
+    options: { timeoutMs: number; env?: Record<string, string> },
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>,
 ): Promise<{ ok: boolean; output: string }> {
   const log = buildLogPath(handle);
+  // The app's NON-SECRET env vars (env.service): `vite build` inlines the
+  // `VITE_*` ones into the bundle — which is the point, that class of key is
+  // publishable — and the build target excludes secrets by construction, so
+  // nothing secret can ever influence a published artifact.
+  const env = await resolveAppEnv(handleProject(handle), "build");
   // Fresh log per build; `pipefail` so a failing step's exit code survives the
   // `tee`, and `2>&1 | tee` puts the whole stream both on the wire (for the
   // final payload) and in the file the client tails live.
@@ -294,7 +300,7 @@ export async function buildApp(
   const build = await exec(
     handle,
     `set -o pipefail; npm run build -- --base=./ 2>&1 | tee -a ${log}`,
-    { timeoutMs: 300_000 },
+    { timeoutMs: 300_000, env },
   );
   return {
     ok: build.exitCode === 0,

--- a/api/src/apps/dev-server.service.ts
+++ b/api/src/apps/dev-server.service.ts
@@ -188,11 +188,19 @@ function launcherSource(
   stagedDataDir: string,
   slug: string,
   boxEnv: string,
+  appEnv: Record<string, string>,
 ): string {
   return `
 import { createServer } from "${appDir}/node_modules/vite/dist/node/index.js";
 import { appendFileSync, createReadStream, existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+
+// The app's env vault (env.service, dev tier — secrets included), baked into
+// the launcher rather than inherited: inheritance survives dtach and nohup
+// but NOT the tmux fallback, whose sessions take the tmux server's
+// environment instead of the client's. Assigned before createServer() runs,
+// so Vite's env resolution sees it and VITE_* reaches import.meta.env.
+Object.assign(process.env, ${JSON.stringify(appEnv)});
 
 // Tell Mako the moment this server is up or gone, instead of leaving the UI
 // to discover it on a poll. Best effort: the API address and token are read
@@ -861,7 +869,10 @@ async function ensureDevServerLaunch(
 ): Promise<DevPreview> {
   const provider = getSandboxProvider();
   const ctx = await ensureBox(handle);
-  const appDir = `/home/user/app/${handle.appRoot}`;
+  // The provider knows where the working copy lives — hardcoding the E2B
+  // path here made every local-provider dev preview die on a launcher that
+  // imported vite from a directory that only exists in a microVM.
+  const appDir = `${provider.root(ctx)}/${handle.appRoot}`;
 
   await provider.keepAlive(ctx, DEV_SESSION_KEEPALIVE_MS);
 
@@ -948,7 +959,7 @@ async function ensureDevServerLaunch(
     }
     const write = await provider.exec(
       ctx,
-      `cat > ${launcher} <<'MAKO_LAUNCHER_EOF'\n${launcherSource(appDir, port, dataDir(handle), appSlug(handle), boxEnvPath(ctx))}\nMAKO_LAUNCHER_EOF\necho written`,
+      `cat > ${launcher} <<'MAKO_LAUNCHER_EOF'\n${launcherSource(appDir, port, dataDir(handle), appSlug(handle), boxEnvPath(ctx), appEnv)}\nMAKO_LAUNCHER_EOF\necho written`,
       { timeoutMs: 30_000 },
     );
     if (write.exitCode !== 0) {
@@ -975,7 +986,11 @@ async function ensureDevServerLaunch(
       // reported as down forever. With the guard, the loser's dtach -n just
       // fails against the existing socket and the winner is untouched.
       `if command -v dtach >/dev/null && command -v script >/dev/null; then if ! pgrep -f "dtach -n ${devSock}" >/dev/null 2>&1; then rm -f ${devSock}; fi; dtach -n ${devSock} script -qfa -c 'node ${launcher} 2>&1' ${logPath} || true; ` +
-      `elif command -v tmux >/dev/null; then tmux new-session -d -s ${devSession} 'node ${launcher} 2>&1 | tee -a ${logPath}' 2>/dev/null || true; ` +
+      // A stale same-name session (its process reaped, tmux shell lingering)
+      // makes new-session fail SILENTLY under the `|| true` — the launch
+      // no-ops and the poll below times out. Clear it first; the port's
+      // owner was already reaped by the caller.
+      `elif command -v tmux >/dev/null; then tmux kill-session -t ${devSession} 2>/dev/null; tmux new-session -d -s ${devSession} 'node ${launcher} 2>&1 | tee -a ${logPath}' 2>/dev/null || true; ` +
       `else nohup node ${launcher} >> ${logPath} 2>&1 & fi; echo started`;
     try {
       await provider.execDetached(ctx, launchCmd, {

--- a/api/src/apps/dev-server.service.ts
+++ b/api/src/apps/dev-server.service.ts
@@ -41,6 +41,7 @@ import { boxEnvPath, sh } from "./box";
 import { ensureBoxAgent } from "./box-agent";
 import { getBoxState, probeReachable } from "./box-state.service";
 import { readBindings, bindingArtifactKey } from "./bindings.service";
+import { resolveAppEnv } from "./env.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 
 const logger = loggers.api("apps-dev-server");
@@ -930,6 +931,21 @@ async function ensureDevServerLaunch(
   if (!wasListening) {
     // Make room BEFORE launching: never let this box exceed the running cap.
     evicted = await enforceRunningCap(provider, ctx, appSlug(handle));
+    // The app's own env vars (env.service), applied at LAUNCH: dtach → script
+    // → node → vite inherit them, so `VITE_*` reaches import.meta.env and the
+    // rest reaches the dev-server process. dev target = secrets included;
+    // this launch env is the only place a secret ever exists in the box.
+    // Edits made while a server runs apply on its next (re)start.
+    let appEnv: Record<string, string> = {};
+    try {
+      appEnv = await resolveAppEnv(handleProject(handle), "dev");
+    } catch (error) {
+      // A missing vault must not take dev mode down with it.
+      logger.warn("Apps env resolution failed; launching without app env", {
+        appRoot: handle.appRoot,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     const write = await provider.exec(
       ctx,
       `cat > ${launcher} <<'MAKO_LAUNCHER_EOF'\n${launcherSource(appDir, port, dataDir(handle), appSlug(handle), boxEnvPath(ctx))}\nMAKO_LAUNCHER_EOF\necho written`,
@@ -965,6 +981,7 @@ async function ensureDevServerLaunch(
       await provider.execDetached(ctx, launchCmd, {
         cwd: handle.appRoot,
         timeoutMs: 60_000,
+        env: appEnv,
       });
     } catch (error) {
       if (!isMissingCwd(error)) throw error;
@@ -973,6 +990,7 @@ async function ensureDevServerLaunch(
       await provider.execDetached(ctx, launchCmd, {
         cwd: handle.appRoot,
         timeoutMs: 60_000,
+        env: appEnv,
       });
     }
 

--- a/api/src/apps/env.service.test.ts
+++ b/api/src/apps/env.service.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Apps env vault — the properties that make it safe to exist.
+ *
+ * The vault holds tenant credentials, so the specs pin the security posture
+ * rather than CRUD mechanics: values are encrypted at rest, secrets never
+ * echo back through the list, the build target can never see a secret, and
+ * the VITE_/secret contradiction is refused at the door. Real mongoose against
+ * mongodb-memory-server — encryption and persistence are the subject here,
+ * not something to mock away.
+ */
+import crypto from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  AppEnvValidationError,
+  deleteAppEnvVar,
+  listAppEnvVars,
+  resolveAppEnv,
+  setAppEnvVar,
+  validateAppEnvInput,
+} from "./env.service";
+import { AppProject, type IAppProject } from "../database/workspace-schema";
+import { isEncryptedValue } from "../services/crypto.service";
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  process.env.ENCRYPTION_KEY =
+    process.env.ENCRYPTION_KEY || crypto.randomBytes(32).toString("hex");
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+async function makeProject(): Promise<IAppProject> {
+  return AppProject.create({
+    workspaceId: new Types.ObjectId(),
+    title: "Env test app",
+    slug: `env-test-${new Types.ObjectId().toString().slice(-8)}`,
+    access: "workspace",
+    createdBy: "tester",
+  });
+}
+
+describe("validateAppEnvInput", () => {
+  it("accepts ordinary env-shaped keys, secret or not", () => {
+    validateAppEnvInput({ key: "API_BASE_URL", value: "x", secret: false });
+    validateAppEnvInput({ key: "_private", value: "x", secret: true });
+    validateAppEnvInput({
+      key: "VITE_GOOGLE_MAPS_API_KEY",
+      value: "AIza...",
+      secret: false,
+    });
+  });
+
+  it("rejects names that are not env-var-shaped", () => {
+    for (const key of ["1BAD", "has space", "has-dash", "", "a.b"]) {
+      expect(() =>
+        validateAppEnvInput({ key, value: "x", secret: false }),
+      ).toThrow(AppEnvValidationError);
+    }
+  });
+
+  it("rejects the sandbox's reserved names and the MAKO_ prefix", () => {
+    for (const key of ["PATH", "HOME", "GIT_TERMINAL_PROMPT", "MAKO_API"]) {
+      expect(() =>
+        validateAppEnvInput({ key, value: "x", secret: false }),
+      ).toThrow(/reserved/);
+    }
+  });
+
+  it("refuses a secret with the VITE_ prefix — Vite would publish it", () => {
+    expect(() =>
+      validateAppEnvInput({
+        key: "VITE_STRIPE_SECRET",
+        value: "x",
+        secret: true,
+      }),
+    ).toThrow(/public client bundle/);
+    // Case games do not smuggle it through.
+    expect(() =>
+      validateAppEnvInput({ key: "vite_secretish", value: "x", secret: true }),
+    ).toThrow(AppEnvValidationError);
+  });
+
+  it("caps value size", () => {
+    expect(() =>
+      validateAppEnvInput({
+        key: "BIG",
+        value: "x".repeat(8193),
+        secret: false,
+      }),
+    ).toThrow(/limited/);
+  });
+});
+
+describe("set / list / delete", () => {
+  it("stores values encrypted at rest and lists non-secret values back", async () => {
+    const project = await makeProject();
+    await setAppEnvVar(project, {
+      key: "VITE_MAPS_KEY",
+      value: "AIzaPlainlyVisible",
+      secret: false,
+    });
+
+    const row = await AppProject.findById(project._id);
+    expect(row?.env).toHaveLength(1);
+    expect(row?.env?.[0].valueEncrypted).not.toContain("AIzaPlainlyVisible");
+    expect(isEncryptedValue(row?.env?.[0].valueEncrypted ?? "")).toBe(true);
+
+    const listed = await listAppEnvVars(project);
+    expect(listed).toEqual([
+      { key: "VITE_MAPS_KEY", secret: false, value: "AIzaPlainlyVisible" },
+    ]);
+  });
+
+  it("never echoes a secret's value back through the list", async () => {
+    const project = await makeProject();
+    await setAppEnvVar(project, {
+      key: "GEOCODING_SERVER_KEY",
+      value: "hunter2",
+      secret: true,
+    });
+    const listed = await listAppEnvVars(project);
+    expect(listed).toEqual([{ key: "GEOCODING_SERVER_KEY", secret: true }]);
+    expect(JSON.stringify(listed)).not.toContain("hunter2");
+  });
+
+  it("upserts by key, including flipping the secret flag", async () => {
+    const project = await makeProject();
+    await setAppEnvVar(project, { key: "K", value: "v1", secret: false });
+    await setAppEnvVar(project, { key: "K", value: "v2", secret: true });
+    const listed = await listAppEnvVars(project);
+    expect(listed).toEqual([{ key: "K", secret: true }]);
+    const dev = await resolveAppEnv(project, "dev");
+    expect(dev).toEqual({ K: "v2" });
+  });
+
+  it("deletes idempotently", async () => {
+    const project = await makeProject();
+    await setAppEnvVar(project, { key: "GONE", value: "x", secret: false });
+    expect(await deleteAppEnvVar(project, "GONE")).toBe(true);
+    expect(await deleteAppEnvVar(project, "GONE")).toBe(false);
+    expect(await listAppEnvVars(project)).toEqual([]);
+  });
+
+  it("rejects invalid input at the service door too", async () => {
+    const project = await makeProject();
+    await expect(
+      setAppEnvVar(project, { key: "PATH", value: "x", secret: false }),
+    ).rejects.toThrow(AppEnvValidationError);
+  });
+});
+
+describe("resolveAppEnv", () => {
+  it("dev gets everything; build can never see a secret", async () => {
+    const project = await makeProject();
+    await setAppEnvVar(project, {
+      key: "VITE_PUBLIC",
+      value: "pub",
+      secret: false,
+    });
+    await setAppEnvVar(project, { key: "SECRET", value: "shh", secret: true });
+
+    expect(await resolveAppEnv(project, "dev")).toEqual({
+      VITE_PUBLIC: "pub",
+      SECRET: "shh",
+    });
+    expect(await resolveAppEnv(project, "build")).toEqual({
+      VITE_PUBLIC: "pub",
+    });
+  });
+
+  it("reads the vault, not the caller's stale copy of the project", async () => {
+    const project = await makeProject();
+    // A handle can hold a project loaded long before an env edit — resolving
+    // through that stale doc must still see the current vault.
+    const stale = await AppProject.findById(project._id);
+    await setAppEnvVar(project, {
+      key: "ADDED_LATER",
+      value: "v",
+      secret: false,
+    });
+    expect(await resolveAppEnv(stale as IAppProject, "dev")).toEqual({
+      ADDED_LATER: "v",
+    });
+  });
+});

--- a/api/src/apps/env.service.ts
+++ b/api/src/apps/env.service.ts
@@ -1,0 +1,206 @@
+/**
+ * Apps environment variables — the per-app env vault.
+ *
+ * An app often needs a vendor key the moment it grows past a dashboard: a
+ * Google Maps browser key, a Supabase URL + anon key, a PostHog project key.
+ * Those belong to the app, not to its git tree — committed keys are painful to
+ * rotate and survive forks — so they live here, on the AppProject row, values
+ * encrypted at rest with the same crypto.service every other credential uses.
+ *
+ * One boolean decides where a value may flow, and it encodes the publish
+ * model's hard boundary (apps.md §13.4.6 — a published app is a static
+ * bundle, there is no server and no runtime env):
+ *
+ *   secret: false — injected into the sandbox dev server AND the publish
+ *     build. A `VITE_`-prefixed var is inlined into the public bundle, which
+ *     is exactly right for the publishable-credential class (Maps keys,
+ *     Supabase anon keys, Stripe publishable keys — public by design,
+ *     protected by referrer restrictions/RLS, not secrecy).
+ *
+ *   secret: true — injected into sandbox DEV processes only, never into the
+ *     publish build, and the `VITE_` prefix is refused outright: Vite inlines
+ *     `VITE_*` into the client bundle, so a "secret" with that prefix is a
+ *     contradiction we fail loudly rather than ship.
+ *
+ * Values reach processes as plain env at launch time only — nothing here is
+ * ever written into the working tree, committed, or served.
+ */
+import { Types } from "mongoose";
+import {
+  AppProject,
+  type IAppEnvVar,
+  type IAppProject,
+} from "../database/workspace-schema";
+import { decryptString, encryptString } from "../services/crypto.service";
+
+/** Invalid input, told apart from infrastructure failure for a clean 400. */
+export class AppEnvValidationError extends Error {}
+
+const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const MAX_KEY_LENGTH = 128;
+const MAX_VALUE_LENGTH = 8192;
+const MAX_VARS_PER_APP = 64;
+
+/**
+ * Names the sandbox contract owns. Letting an app var shadow these would not
+ * leak anything, but it would break the box in ways that look like anything
+ * except an env var (PATH → nothing runs; HOME → npm writes caches into the
+ * tree and the next commit ships them).
+ */
+const RESERVED_KEYS = new Set([
+  "PATH",
+  "HOME",
+  "LANG",
+  "TERM",
+  "CI",
+  "NO_UPDATE_NOTIFIER",
+  "GIT_TERMINAL_PROMPT",
+  "npm_config_yes",
+]);
+
+/** `MAKO_*` is the box↔API contract (box.ts) — never user-assignable. */
+const RESERVED_PREFIX = "MAKO_";
+
+/** Vite inlines `VITE_*` into the served client bundle. */
+const CLIENT_EXPOSED_PREFIX = "VITE_";
+
+export interface AppEnvVarInput {
+  key: string;
+  value: string;
+  secret: boolean;
+}
+
+/** A var as the API returns it: secrets never echo their value back. */
+export interface AppEnvVarView {
+  key: string;
+  secret: boolean;
+  /** Decrypted value for non-secret vars; absent for secrets. */
+  value?: string;
+}
+
+/** Where a resolved env is about to be injected. */
+export type AppEnvTarget = "dev" | "build";
+
+export function validateAppEnvInput(input: AppEnvVarInput): void {
+  const { key, value, secret } = input;
+  if (!KEY_PATTERN.test(key)) {
+    throw new AppEnvValidationError(
+      "Keys must look like environment variable names: letters, digits and underscores, not starting with a digit.",
+    );
+  }
+  if (key.length > MAX_KEY_LENGTH) {
+    throw new AppEnvValidationError(
+      `Keys are limited to ${MAX_KEY_LENGTH} characters.`,
+    );
+  }
+  if (value.length > MAX_VALUE_LENGTH) {
+    throw new AppEnvValidationError(
+      `Values are limited to ${MAX_VALUE_LENGTH} characters.`,
+    );
+  }
+  if (RESERVED_KEYS.has(key) || key.toUpperCase().startsWith(RESERVED_PREFIX)) {
+    throw new AppEnvValidationError(
+      `"${key}" is reserved by the sandbox and cannot be set per app.`,
+    );
+  }
+  if (secret && key.toUpperCase().startsWith(CLIENT_EXPOSED_PREFIX)) {
+    throw new AppEnvValidationError(
+      `Vite inlines ${CLIENT_EXPOSED_PREFIX}* variables into the public client bundle, so a secret cannot use that prefix. Mark it non-secret if the value is publishable (Maps keys, anon keys), or rename it if it is truly secret.`,
+    );
+  }
+}
+
+/**
+ * The app's CURRENT vars, from Mongo — not from whatever copy of the project
+ * the caller happens to hold. Handles are long-lived and projects can be
+ * synthesized from repo folders (no row at all), so the doc on a handle can
+ * predate any number of env edits; env must reflect the vault, not the cache.
+ */
+async function freshEnv(project: IAppProject): Promise<IAppEnvVar[]> {
+  const row =
+    (await AppProject.findById(project._id).select("env")) ??
+    (project.slug
+      ? await AppProject.findOne({
+          workspaceId: new Types.ObjectId(project.workspaceId.toString()),
+          slug: project.slug,
+        }).select("env")
+      : null);
+  return row?.env ?? [];
+}
+
+export async function listAppEnvVars(
+  project: IAppProject,
+): Promise<AppEnvVarView[]> {
+  const vars = await freshEnv(project);
+  return vars.map(v => ({
+    key: v.key,
+    secret: v.secret,
+    ...(v.secret ? {} : { value: decryptString(v.valueEncrypted) }),
+  }));
+}
+
+/**
+ * Upsert one var on a REAL project row (callers materialize synthesized
+ * projects with ensureProjectRow first — a vault needs somewhere to live).
+ */
+export async function setAppEnvVar(
+  project: IAppProject,
+  input: AppEnvVarInput,
+): Promise<AppEnvVarView[]> {
+  validateAppEnvInput(input);
+  const row = await AppProject.findById(project._id);
+  if (!row) throw new Error("App project row not found");
+  const vars = row.env ?? [];
+  const next: IAppEnvVar = {
+    key: input.key,
+    valueEncrypted: encryptString(input.value),
+    secret: input.secret,
+  };
+  const at = vars.findIndex(v => v.key === input.key);
+  if (at >= 0) {
+    vars[at] = next;
+  } else {
+    if (vars.length >= MAX_VARS_PER_APP) {
+      throw new AppEnvValidationError(
+        `An app can hold at most ${MAX_VARS_PER_APP} environment variables.`,
+      );
+    }
+    vars.push(next);
+  }
+  row.env = vars;
+  await row.save();
+  return listAppEnvVars(row);
+}
+
+/** Remove one var. False when it was not there — idempotent for the caller. */
+export async function deleteAppEnvVar(
+  project: IAppProject,
+  key: string,
+): Promise<boolean> {
+  const row = await AppProject.findById(project._id);
+  if (!row?.env?.some(v => v.key === key)) return false;
+  row.env = row.env.filter(v => v.key !== key);
+  await row.save();
+  return true;
+}
+
+/**
+ * The env record to inject for a target, decrypted.
+ *
+ * `dev` gets everything — the sandbox dev server is the one place a secret
+ * may exist as a process env var. `build` gets only non-secret vars, so
+ * nothing secret can influence a published artifact, ever: the publish build
+ * IS the public bundle, and the clean invariant beats a plausible exception.
+ */
+export async function resolveAppEnv(
+  project: IAppProject,
+  target: AppEnvTarget,
+): Promise<Record<string, string>> {
+  const vars = await freshEnv(project);
+  const included = vars.filter(v => (target === "build" ? !v.secret : true));
+  // Sorted so the launch command's env is deterministic run to run.
+  included.sort((a, b) => a.key.localeCompare(b.key));
+  return Object.fromEntries(
+    included.map(v => [v.key, decryptString(v.valueEncrypted)]),
+  );
+}

--- a/api/src/apps/sandbox/local-provider.ts
+++ b/api/src/apps/sandbox/local-provider.ts
@@ -60,12 +60,28 @@ function assertNotProduction(): void {
   }
 }
 
+/**
+ * Session keys are `<workspaceId>:<userId>` — and that colon must not reach a
+ * directory name. npm prepends every ancestor `node_modules/.bin` to a
+ * script's PATH, PATH is colon-separated, and a colon in the session path
+ * split each of those entries into two garbage halves: every `npm run` under
+ * this provider failed with "vite: not found" while the binary sat right
+ * there. (E2B never sees this — the microVM's working copy is a fixed path.)
+ */
+function dirNameFor(sessionKey: string): string {
+  return sessionKey.replace(/[^A-Za-z0-9._-]+/g, "_");
+}
+
 function rootFor(ctx: SandboxExecContext): string {
-  return path.join(appsSessionsRoot(), "local", ctx.sessionKey);
+  return path.join(appsSessionsRoot(), "local", dirNameFor(ctx.sessionKey));
 }
 
 function scratchFor(ctx: SandboxExecContext): string {
-  return path.join(os.tmpdir(), "mako-local-sandbox", ctx.sessionKey);
+  return path.join(
+    os.tmpdir(),
+    "mako-local-sandbox",
+    dirNameFor(ctx.sessionKey),
+  );
 }
 
 /**

--- a/api/src/apps/sandbox/local-provider.ts
+++ b/api/src/apps/sandbox/local-provider.ts
@@ -106,6 +106,27 @@ function truncate(text: string): { text: string; truncated: boolean } {
   };
 }
 
+/**
+ * The allowlisted base env plus the caller's extras — the same contract the
+ * E2B provider keeps. Deliberately minimal: a local sandbox must not become
+ * the one place where an app can read the API's secrets.
+ */
+function sandboxEnv(extra?: Record<string, string>): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    // OUTSIDE the working tree, and not the developer's real home either.
+    // npm and friends write caches into $HOME; pointed at the tree, every
+    // one of them would land in the next commit.
+    HOME: SANDBOX_HOME,
+    LANG: "C.UTF-8",
+    TERM: "xterm-256color",
+    // There is no human at this end. Without it git blocks on a credential
+    // prompt until the timeout and reports nothing.
+    GIT_TERMINAL_PROMPT: "0",
+    ...(extra ?? {}),
+  };
+}
+
 async function execLocal(
   ctx: SandboxExecContext,
   command: string,
@@ -129,20 +150,7 @@ async function execLocal(
         timeout: options.timeoutMs ?? 120_000,
         maxBuffer: MAX_OUTPUT_BYTES * 4,
         encoding: "utf8",
-        env: {
-          // Deliberately minimal, like the microVM's: a local sandbox must not
-          // become the one place where an app can read the API's secrets.
-          PATH: process.env.PATH ?? "/usr/bin:/bin",
-          // OUTSIDE the working tree, and not the developer's real home
-          // either. npm and friends write caches into $HOME; pointed at the
-          // tree, every one of them would land in the next commit.
-          HOME: SANDBOX_HOME,
-          LANG: "C.UTF-8",
-          TERM: "xterm-256color",
-          // There is no human at this end. Without it git blocks on a
-          // credential prompt until the timeout and reports nothing.
-          GIT_TERMINAL_PROMPT: "0",
-        },
+        env: sandboxEnv(options.env),
       },
       (error, stdout, stderr) => {
         const out = truncate(String(stdout ?? ""));
@@ -192,10 +200,13 @@ export const localSandboxProvider: SandboxProvider = {
     assertNotProduction();
     await ensureDirs(ctx);
     const cwd = path.resolve(rootFor(ctx), options.cwd ?? ".");
+    // Same allowlisted env as exec — inheriting the API process env here
+    // would hand a detached dev server every secret this process holds.
     const child = spawn("bash", ["-lc", command], {
       cwd,
       detached: true,
       stdio: "ignore",
+      env: sandboxEnv(options.env),
     });
     child.unref();
   },

--- a/api/src/apps/sandbox/provider.ts
+++ b/api/src/apps/sandbox/provider.ts
@@ -27,7 +27,11 @@ export interface SandboxExecOptions {
   /** Working directory relative to the session root ("" = root). */
   cwd?: string;
   timeoutMs?: number;
-  /** Extra env vars visible to the command (non-secret only). */
+  /**
+   * Extra env vars visible to the command. Never a Mako API secret — the
+   * only credentials that may enter a box are the tenant's own (the git
+   * token file, and per-app env vars from env.service).
+   */
   env?: Record<string, string>;
 }
 

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -5181,6 +5181,32 @@ export const McpToolGrant = mongoose.model<IMcpToolGrant>(
 // ---------------------------------------------------------------------------
 
 /**
+ * One environment variable of an app (apps.md §13.21).
+ *
+ * The value is ALWAYS stored encrypted (crypto.service), like connection
+ * credentials. `secret` decides where the value may flow: non-secret vars
+ * reach the sandbox dev server AND the publish build (a `VITE_`-prefixed one
+ * is inlined into the public bundle — Maps keys, Supabase anon keys, and the
+ * rest of the publishable-credential class); secret vars reach only sandbox
+ * dev processes and are refused the `VITE_` prefix outright, because a
+ * published app is a static bundle and anything Vite inlines is public.
+ */
+export interface IAppEnvVar {
+  key: string;
+  valueEncrypted: string;
+  secret: boolean;
+}
+
+const AppEnvVarSchema = new Schema<IAppEnvVar>(
+  {
+    key: { type: String, required: true },
+    valueEncrypted: { type: String, required: true },
+    secret: { type: Boolean, required: true, default: false },
+  },
+  { _id: false },
+);
+
+/**
  * An Apps project: control-plane record for one git-backed app.
  * One bare repo per project (per-app ACLs make the repo the authorization
  * boundary); source contents are never stored in Mongo.
@@ -5220,6 +5246,8 @@ export interface IAppProject extends Document {
    * routes and the /api/share/:token consumption side are shared verbatim.
    */
   publicShare?: IPublicShare;
+  /** Per-app environment variables, values encrypted at rest (env.service). */
+  env?: IAppEnvVar[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -5257,6 +5285,7 @@ const AppProjectSchema = new Schema<IAppProject>(
     publishedSha: { type: String },
     publishedAt: { type: Date },
     publicShare: { type: PublicShareSchema, default: undefined },
+    env: { type: [AppEnvVarSchema], default: undefined },
   },
   { collection: "app_projects", timestamps: true },
 );

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -131,6 +131,12 @@ import {
   materializeAppBinding,
   readBindings,
 } from "../apps/bindings.service";
+import {
+  AppEnvValidationError,
+  deleteAppEnvVar,
+  listAppEnvVars,
+  setAppEnvVar,
+} from "../apps/env.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 import { serveParquetArtifact } from "../services/artifact-delivery.service";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
@@ -2366,6 +2372,120 @@ appsRoutes.openapi(
       );
       await AppProject.updateOne({ _id: project._id }, { $set: { access } });
       return c.json({ success: true as const, access }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Environment variables — the per-app env vault (env.service).
+//
+// Editor-gated end to end: env is a build/dev concern, and gating the list at
+// write access means there is never a question of who may see which value.
+// Secrets never echo their value back even to editors — the API accepts them
+// and injects them, it does not retrieve them.
+// ---------------------------------------------------------------------------
+
+appsRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/env",
+    tags: ["Apps"],
+    summary: "List the app's environment variables",
+    description:
+      "Non-secret vars include their value; secret vars return only their key. Values reach the sandbox dev server (all vars) and the publish build (non-secret only) at process launch.",
+    security: AUTH_SECURITY,
+    request: { params: ProjectParam },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: true });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const vars = await listAppEnvVars(loaded.project);
+      return c.json({ success: true as const, vars }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+appsRoutes.openapi(
+  createRoute({
+    method: "put",
+    path: "/{id}/env",
+    tags: ["Apps"],
+    summary: "Set (upsert) one environment variable on the app",
+    description:
+      "Values are encrypted at rest. `secret: true` keeps the value out of the publish build and forbids the VITE_ prefix (Vite inlines VITE_* into the public bundle). A running dev server picks the change up on its next restart.",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam,
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: z.object({
+              key: z.string().min(1).max(128),
+              value: z.string().max(8192),
+              secret: z.boolean().default(false),
+            }),
+          },
+        },
+      },
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: true });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const { key, value, secret } = c.req.valid("json");
+      // The vault lives on the project row; folder-only apps get theirs now
+      // (a fourth row-creating act alongside restrict/publish/share, §13.6).
+      const project = await ensureProjectRow(
+        loaded.project,
+        loaded.userId ?? "api-key",
+      );
+      const vars = await setAppEnvVar(project, { key, value, secret });
+      return c.json({ success: true as const, vars }, 200);
+    } catch (error) {
+      if (error instanceof AppEnvValidationError) {
+        return c.json({ success: false, error: error.message }, 400);
+      }
+      return handleError(c, error);
+    }
+  },
+);
+
+appsRoutes.openapi(
+  createRoute({
+    method: "delete",
+    path: "/{id}/env/{key}",
+    tags: ["Apps"],
+    summary: "Delete one environment variable from the app",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam.extend({
+        key: z
+          .string()
+          .regex(/^[A-Za-z_][A-Za-z0-9_]*$/)
+          .openapi({ param: { name: "key", in: "path" } }),
+      }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: true });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const { key } = c.req.valid("param");
+      const removed = await deleteAppEnvVar(loaded.project, key);
+      if (!removed) {
+        return c.json({ success: false, error: "Variable not found" }, 404);
+      }
+      return c.json({ success: true as const }, 200);
     } catch (error) {
       return handleError(c, error);
     }

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       "src/apps/workspace-repo.test.ts",
       "src/apps/workspace-prompt.test.ts",
       "src/apps/bindings.service.test.ts",
+      "src/apps/env.service.test.ts",
       "src/apps/cloud-repo.service.test.ts",
       "src/apps/adversarial.test.ts",
       "src/apps/git-endpoint.test.ts",

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -4257,6 +4257,47 @@ export interface paths {
         patch: operations["patch_api_workspaces_workspaceId_apps_id_access"];
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/env": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the app's environment variables
+         * @description Non-secret vars include their value; secret vars return only their key. Values reach the sandbox dev server (all vars) and the publish build (non-secret only) at process launch.
+         */
+        get: operations["get_api_workspaces_workspaceId_apps_id_env"];
+        /**
+         * Set (upsert) one environment variable on the app
+         * @description Values are encrypted at rest. `secret: true` keeps the value out of the publish build and forbids the VITE_ prefix (Vite inlines VITE_* into the public bundle). A running dev server picks the change up on its next restart.
+         */
+        put: operations["put_api_workspaces_workspaceId_apps_id_env"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/env/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete one environment variable from the app */
+        delete: operations["delete_api_workspaces_workspaceId_apps_id_env_key"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/eyes-shots/{shot}": {
         parameters: {
             query?: never;
@@ -19205,6 +19246,139 @@ export interface operations {
                 };
             };
         };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_env: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    put_api_workspaces_workspaceId_apps_id_env: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    key: string;
+                    value: string;
+                    /** @default false */
+                    secret?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    delete_api_workspaces_workspaceId_apps_id_env_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/components/AppEnvDialog.tsx
+++ b/app/src/components/AppEnvDialog.tsx
@@ -1,0 +1,277 @@
+/**
+ * App environment variables dialog — the UI over the per-app env vault
+ * (api/src/apps/env.service.ts).
+ *
+ * The one concept a user must get right is the secret flag, so the dialog
+ * teaches it where the choice is made: non-secret values reach the dev server
+ * AND the published build (`VITE_*` ones are inlined into the public bundle —
+ * correct for Maps keys, Supabase anon keys and the rest of the publishable
+ * class), while secrets exist only in sandbox dev processes and never touch
+ * a build. The server refuses a secret with the `VITE_` prefix; this dialog
+ * surfaces that refusal rather than pre-hiding the combination, so the user
+ * reads WHY instead of wondering where the checkbox went.
+ *
+ * Secrets never echo their value back (the list returns only their key), so
+ * a stored secret renders as dots and can be overwritten or deleted, never
+ * revealed.
+ */
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Pencil as EditIcon, Trash2 as DeleteIcon } from "lucide-react";
+import { useAppsStore, type AppEnvVar } from "../store/appsStore";
+import { useConfirm } from "./ConfirmDialog";
+
+interface AppEnvDialogProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceId: string;
+  appId: string;
+  appTitle?: string;
+}
+
+export default function AppEnvDialog({
+  open,
+  onClose,
+  workspaceId,
+  appId,
+  appTitle,
+}: AppEnvDialogProps) {
+  const fetchAppEnv = useAppsStore(s => s.fetchAppEnv);
+  const setAppEnvVar = useAppsStore(s => s.setAppEnvVar);
+  const deleteAppEnvVar = useAppsStore(s => s.deleteAppEnvVar);
+  const confirm = useConfirm();
+
+  const [vars, setVars] = useState<AppEnvVar[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+  const [secret, setSecret] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setVars(null);
+    setError(null);
+    setKey("");
+    setValue("");
+    setSecret(false);
+    fetchAppEnv(workspaceId, appId)
+      .then(setVars)
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Could not load variables");
+        setVars([]);
+      });
+  }, [open, workspaceId, appId, fetchAppEnv]);
+
+  const handleSave = useCallback(async () => {
+    if (!key.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const next = await setAppEnvVar(workspaceId, appId, {
+        key: key.trim(),
+        value,
+        secret,
+      });
+      setVars(next);
+      setKey("");
+      setValue("");
+      setSecret(false);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not save the variable");
+    } finally {
+      setSaving(false);
+    }
+  }, [workspaceId, appId, key, value, secret, setAppEnvVar]);
+
+  const handleDelete = useCallback(
+    async (varKey: string, isSecret: boolean) => {
+      if (
+        isSecret &&
+        !(await confirm({
+          title: `Delete ${varKey}?`,
+          body: "Secret values are never shown again — deleting one means re-entering it to get it back.",
+          confirmLabel: "Delete",
+          destructive: true,
+        }))
+      ) {
+        return;
+      }
+      setError(null);
+      try {
+        await deleteAppEnvVar(workspaceId, appId, varKey);
+        setVars(v => (v ? v.filter(item => item.key !== varKey) : v));
+      } catch (e: unknown) {
+        setError(
+          e instanceof Error ? e.message : "Could not delete the variable",
+        );
+      }
+    },
+    [workspaceId, appId, deleteAppEnvVar, confirm],
+  );
+
+  // Prefill the form from a row: non-secret vars bring their value along;
+  // a secret brings only its name (there is no value to bring).
+  const handleEdit = useCallback((v: AppEnvVar) => {
+    setKey(v.key);
+    setValue(v.value ?? "");
+    setSecret(v.secret);
+  }, []);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Environment variables{appTitle ? ` — ${appTitle}` : ""}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Values are encrypted at rest and injected when a process starts.
+          Regular variables reach the dev server and the published build —{" "}
+          <code>VITE_*</code> ones become part of the public bundle, which is
+          right for publishable keys (Google Maps, Supabase anon keys). Secrets
+          stay in dev only and are never built into a published app. A running
+          dev server picks changes up on its next restart.
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {vars === null ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+            <CircularProgress size={22} />
+          </Box>
+        ) : vars.length > 0 ? (
+          <Table size="small" sx={{ mb: 2 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Key</TableCell>
+                <TableCell>Value</TableCell>
+                <TableCell padding="none" />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {vars.map(v => (
+                <TableRow key={v.key} hover>
+                  <TableCell sx={{ fontFamily: "monospace" }}>
+                    {v.key}
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      fontFamily: "monospace",
+                      maxWidth: 220,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      color: v.secret ? "text.secondary" : undefined,
+                    }}
+                  >
+                    {v.secret ? "•••••••• (secret)" : v.value}
+                  </TableCell>
+                  <TableCell padding="none" align="right">
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => handleEdit(v)}>
+                        <EditIcon size={15} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="small"
+                        onClick={() => void handleDelete(v.key, v.secret)}
+                      >
+                        <DeleteIcon size={15} />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mb: 2, fontStyle: "italic" }}
+          >
+            No variables yet.
+          </Typography>
+        )}
+        <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+          <TextField
+            size="small"
+            label="Key"
+            placeholder="VITE_GOOGLE_MAPS_API_KEY"
+            value={key}
+            onChange={e => setKey(e.target.value)}
+            sx={{ flex: 1, "& input": { fontFamily: "monospace" } }}
+          />
+          <TextField
+            size="small"
+            label="Value"
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            sx={{ flex: 1.4, "& input": { fontFamily: "monospace" } }}
+          />
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            mt: 0.5,
+          }}
+        >
+          <FormControlLabel
+            control={
+              <Checkbox
+                size="small"
+                checked={secret}
+                onChange={e => setSecret(e.target.checked)}
+              />
+            }
+            label={
+              <Typography variant="body2">
+                Secret (dev only, never in published builds)
+              </Typography>
+            }
+          />
+          <Button
+            variant="contained"
+            size="small"
+            disabled={saving || !key.trim()}
+            onClick={() => void handleSave()}
+          >
+            {saving
+              ? "Saving…"
+              : vars?.some(v => v.key === key.trim())
+                ? "Update"
+                : "Add"}
+          </Button>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -30,6 +30,7 @@ import {
   FileText as TextFileIcon,
   Folder as FolderIcon,
   FolderOpen as FolderOpenIcon,
+  KeyRound as EnvIcon,
   Plus as AddIcon,
   Github as LinkIcon,
   RefreshCw as RefreshIcon,
@@ -46,6 +47,7 @@ import { useAppsStore, type AppFileEntry } from "../store/appsStore";
 import { useAuth } from "../contexts/auth-context";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import ShareDialog from "./ShareDialog";
+import AppEnvDialog from "./AppEnvDialog";
 import { focusAppsFileTab, focusAppsTab } from "../apps-runtime/shell";
 import {
   useExplorerRevealStore,
@@ -230,6 +232,7 @@ export default function AppsExplorer() {
   );
   const [createOpen, setCreateOpen] = useState(false);
   const [shareAppId, setShareAppId] = useState<string | null>(null);
+  const [envAppId, setEnvAppId] = useState<string | null>(null);
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const [newTitle, setNewTitle] = useState("");
   const [creating, setCreating] = useState(false);
@@ -449,6 +452,18 @@ export default function AppsExplorer() {
           Share…
         </MenuItem>,
         <MenuItem
+          key="env"
+          onClick={() => {
+            helpers.closeMenu();
+            setEnvAppId(parsed.appId);
+          }}
+        >
+          <ListItemIcon>
+            <EnvIcon size={16} />
+          </ListItemIcon>
+          Environment variables…
+        </MenuItem>,
+        <MenuItem
           key="delete"
           onClick={() => {
             helpers.closeMenu();
@@ -466,6 +481,7 @@ export default function AppsExplorer() {
   );
 
   const shareApp = shareAppId ? apps.find(a => a.id === shareAppId) : null;
+  const envApp = envAppId ? apps.find(a => a.id === envAppId) : null;
 
   const actions = (
     <>
@@ -696,6 +712,16 @@ export default function AppsExplorer() {
             // the list is the only place that learns about it.
             if (workspaceId) void fetchApps(workspaceId);
           }}
+        />
+      )}
+
+      {envApp && workspaceId && (
+        <AppEnvDialog
+          open={!!envAppId}
+          onClose={() => setEnvAppId(null)}
+          workspaceId={workspaceId}
+          appId={envApp.id}
+          appTitle={envApp.title}
         />
       )}
     </>

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -45,6 +45,13 @@ export interface AppFileEntry {
   size: number;
 }
 
+/** One env var as the API returns it (no value when it is a secret). */
+export interface AppEnvVar {
+  key: string;
+  secret: boolean;
+  value?: string;
+}
+
 export interface AppChange {
   path: string;
   status: "added" | "modified" | "deleted" | "renamed";
@@ -439,6 +446,22 @@ interface AppsStore {
    * exactly one fresh dev terminal.
    */
   stopDev: (workspaceId: string, appId: string) => Promise<void>;
+  /**
+   * The app's env vault (per-app environment variables). Secrets never echo
+   * their value back — the API accepts and injects them, it does not
+   * retrieve them — so `value` is absent whenever `secret` is true.
+   */
+  fetchAppEnv: (workspaceId: string, appId: string) => Promise<AppEnvVar[]>;
+  setAppEnvVar: (
+    workspaceId: string,
+    appId: string,
+    input: { key: string; value: string; secret: boolean },
+  ) => Promise<AppEnvVar[]>;
+  deleteAppEnvVar: (
+    workspaceId: string,
+    appId: string,
+    key: string,
+  ) => Promise<void>;
   /** Bindings state for an app (per-binding materialization status/history). */
   fetchAppBindings: (
     workspaceId: string,
@@ -1475,6 +1498,34 @@ export const useAppsStore = create<AppsStore>()(
         }
         get().markDevDown(appId);
         get().setEditing(workspaceId, appId, false);
+      },
+
+      fetchAppEnv: async (workspaceId, appId) => {
+        const body = unwrapBody(
+          await api.GET("/api/workspaces/{workspaceId}/apps/{id}/env", {
+            params: { path: { workspaceId, id: appId } },
+          }),
+        ) as { vars?: AppEnvVar[] };
+        return body.vars ?? [];
+      },
+
+      setAppEnvVar: async (workspaceId, appId, input) => {
+        const body = unwrapBody(
+          await api.PUT("/api/workspaces/{workspaceId}/apps/{id}/env", {
+            params: { path: { workspaceId, id: appId } },
+            body: input,
+          }),
+        ) as { vars?: AppEnvVar[] };
+        return body.vars ?? [];
+      },
+
+      deleteAppEnvVar: async (workspaceId, appId, key) => {
+        unwrapBody(
+          await api.DELETE(
+            "/api/workspaces/{workspaceId}/apps/{id}/env/{key}",
+            { params: { path: { workspaceId, id: appId, key } } },
+          ),
+        );
       },
 
       fetchAppBindings: async (workspaceId, appId) => {

--- a/apps.md
+++ b/apps.md
@@ -358,7 +358,7 @@ Each phase ships behind a flag and is independently valuable (Phase 1 alone give
 | Do bindings-as-files break the binding editor UI? | No — the binding editor becomes a structured editor over `bindings/*.sql` + `mako.json` via the Files API. |
 | Monaco in-browser editing (no sandbox running) | Explorer writes go through a Files API write endpoint that commits directly to the draft ref server-side (isomorphic-git or a transient sandbox); keeps "quick edit" cheap. |
 | Public URL isolation for published apps | Per-app host on a separate PSL-registered registrable domain (never `mako.ai`): different browser *sites*, no shared cookies or same-site trust with the control plane; Worker enforces share tokens/passwords. |
-| Where do secrets for apps/scripts live? | Workspace-scoped secrets vault (encrypt with existing `crypto.service`), injected as env into sandboxes per `mako.json` declaration; never committed. Design in Phase 5. |
+| Where do secrets for apps/scripts live? | SHIPPED as the per-app env vault (`env.service.ts`, §13.21): vars on the `AppProject` row, values encrypted with `crypto.service`, never committed. One `secret` boolean encodes the static-publish boundary — non-secret vars reach the dev server and the publish build (`VITE_*` inlined into the public bundle: the publishable-key class), secrets reach dev processes only and refuse the `VITE_` prefix. Runtime secrets for published apps (a true backend) remain out of scope. |
 
 ## 8. Alternatives considered (summary)
 
@@ -1419,6 +1419,38 @@ tab to Start dev via the box-state push, no reload.
 Known cosmetic leftover: the dev boot banner can print twice when two
 dev-preview POSTs race the same cold boot (mount effect + status poll — the
 launch is single-flighted, the route's log-genesis section is not).
+
+### 13.21 Per-app environment variables (2026-09-01)
+
+An app hits a wall the moment it needs a vendor key — a Google Maps browser
+key, a Supabase URL + anon key — because there was nowhere sanctioned to put
+one: hardcoding commits it to a clonable repo, and the sandbox env was
+deliberately credential-free. The env vault (`env.service.ts`) is that place:
+vars live on the `AppProject` row, values encrypted with `crypto.service`
+like every other credential, managed via `GET/PUT/DELETE /apps/:id/env`
+(editor-gated) and the explorer's "Environment variables…" dialog.
+
+One `secret` boolean encodes the publish model's hard boundary (§13.4.6 —
+a published app is a static bundle, no server, no runtime env):
+
+- **non-secret** → injected into the sandbox dev-server launch AND the
+  publish build. `VITE_*` is inlined into the public bundle, which is exactly
+  right for the publishable-key class (Maps keys, anon keys, Stripe
+  publishable keys — public by design, protected by referrer restrictions and
+  RLS, not secrecy).
+- **secret** → injected into sandbox DEV processes only, never into a build
+  (`resolveAppEnv(project, "build")` excludes them by construction), and the
+  `VITE_` prefix is refused outright — a "secret" Vite would inline is a
+  contradiction that fails loudly at the door.
+
+Injection is process-env at launch time only: the dev-server `execDetached`
+and the publish build exec carry the record; nothing is ever written into
+the working tree, committed, or served. A running dev server picks edits up
+on its next restart. Secrets never echo back through the API — the list
+returns only their key. Reserved names (`PATH`, `HOME`, `MAKO_*`, …) are
+refused so a var cannot break the box contract. Runtime secrets for
+published apps (a real backend/proxy) remain out of scope, exactly as §7's
+risk table says.
 
 ## 14. State of play and roadmap (2026-08-26)
 

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -26293,6 +26293,275 @@
         "operationId": "patch_api_workspaces_workspaceId_apps_id_access"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/env": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "List the app's environment variables",
+        "description": "Non-secret vars include their value; secret vars return only their key. Values reach the sandbox dev server (all vars) and the publish build (non-secret only) at process launch.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_env"
+      },
+      "put": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Set (upsert) one environment variable on the app",
+        "description": "Values are encrypted at rest. `secret: true` keeps the value out of the publish build and forbids the VITE_ prefix (Vite inlines VITE_* into the public bundle). A running dev server picks the change up on its next restart.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "value": {
+                    "type": "string",
+                    "maxLength": 8192
+                  },
+                  "secret": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "put_api_workspaces_workspaceId_apps_id_env"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/env/{key}": {
+      "delete": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Delete one environment variable from the app",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+            },
+            "required": true,
+            "name": "key",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "delete_api_workspaces_workspaceId_apps_id_env_key"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/eyes-shots/{shot}": {
       "get": {
         "tags": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Apps hit a wall the moment they need a vendor key (Google Maps browser key, Supabase URL + anon key, PostHog project key): there was nowhere sanctioned to put one — hardcoding commits it to a clonable repo, and the sandbox env is deliberately credential-free. This adds the per-app env vault the apps.md §7 risk table planned ("Design in Phase 5"), now documented as §13.21.

## How it works

- **Storage** — `env: [{ key, valueEncrypted, secret }]` on the `AppProject` row; values encrypted at rest with the existing `crypto.service` AES-256-CBC, exactly like connection credentials (`api/src/apps/env.service.ts`).
- **The `secret` boolean encodes the static-publish boundary** (§13.4.6 — a published app is a static bundle, no server, no runtime env):
  - `secret: false` → injected into the sandbox dev-server launch **and** the publish build. `VITE_*` is inlined into the public bundle, which is correct for the publishable-key class (Maps keys, anon keys, Stripe publishable keys).
  - `secret: true` → injected into sandbox **dev** processes only; `resolveAppEnv(project, "build")` excludes secrets by construction, so nothing secret can ever influence a published artifact. The `VITE_` prefix on a secret is refused with an explanatory 400.
- **Injection** — the dev-tier record is baked into the generated dev-server launcher (`Object.assign(process.env, …)` before `createServer()`), making it immune to how the process daemonizes: plain inheritance survives dtach and nohup but **not** the tmux fallback, whose sessions take the tmux server's environment. The publish build gets the build-tier record on the `vite build` exec. Nothing is ever written into the working tree, committed, or served. A running dev server picks edits up on its next restart.
- **API** — `GET/PUT/DELETE /api/workspaces/:id/apps/:id/env[/:key]`, editor-gated end to end; secrets never echo their value back (the list returns only their key). Reserved names (`PATH`, `HOME`, `MAKO_*`, …) are refused so a var cannot break the box contract. OpenAPI spec + typed client regenerated.
- **UI** — "Environment variables…" in the Apps explorer context menu opens a dialog (list / upsert / delete, secrets render as dots), via new `appsStore` actions.

## Local-provider fixes found while verifying end-to-end

- `options.env` was ignored by the local provider (E2B already merged it), and detached processes inherited the **full API process env** — both fixed with the same allowlisted base env the microVM uses.
- The dev-server launcher hardcoded the E2B working-copy path `/home/user/app`; it now asks the provider seam (`provider.root(ctx)`), identical on E2B.
- A stale same-name tmux session made the launch `new-session` fail silently under `|| true` — `kill-session` first.
- The local session directory embedded the raw `<workspaceId>:<userId>` key; the colon split every npm-script `PATH` entry, so `npm run build` failed with `vite: not found` while the binary sat right there. Directory names are sanitized now.

## Testing

- New `api/src/apps/env.service.test.ts` (12 specs in the apps vitest suite): encryption at rest, secret-value non-echo, build-tier exclusion, VITE_-secret refusal, reserved names, upsert/delete, stale-doc resolution. Full apps suite: 13 files / 137 tests green.
- Manual end-to-end on a live stack (`APPS_SANDBOX_PROVIDER=local`), all verified:
  - Mongo at rest holds `iv:ciphertext`, never plaintext.
  - Dev server serves `import.meta.env = { …, "VITE_DEMO_MESSAGE": "hello-from-the-vault" }`; the secret string appears **zero** times in any served module.
  - `publish` succeeds and the deployed bundle contains the non-secret value (1 hit) and the secret (0 hits).
  - GUI demo (video below): dialog lists vars with the secret masked, a `VITE_`-prefixed secret is rejected with the explanatory error, add/delete round-trips, and the running app renders the injected value.
- Gates: `pnpm --filter api run lint`, `pnpm --filter app run typecheck && lint` — 0 errors.

[app_env_vars_dialog_and_dev_injection_demo.mp4](https://cursor.com/agents/bc-286f3369-7f80-4e03-83e4-1ac22fc70a94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_env_vars_dialog_and_dev_injection_demo.mp4)

[Environment variables dialog listing a non-secret VITE var with its value and a secret masked as dots](https://cursor.com/agents/bc-286f3369-7f80-4e03-83e4-1ac22fc70a94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_env_dialog_vars_list.png)

[App dev server rendering the injected VITE_DEMO_MESSAGE while the secret is undefined in the client](https://cursor.com/agents/bc-286f3369-7f80-4e03-83e4-1ac22fc70a94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dev_server_env_values_rendered.png)

## Out of scope (deliberately)

Runtime secrets for published apps (a true backend/proxy) — the static-publish model has no place for them; §13.21 records the boundary.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-286f3369-7f80-4e03-83e4-1ac22fc70a94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-286f3369-7f80-4e03-83e4-1ac22fc70a94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

