### PR TITLE
feat(notebooks): checkpoint into the workspace repo as canonical .deepnote files

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1139,6 +1139,9 @@ jobs:
           # the customer mirror; without the connected-tier flag the push
           # silently no-ops and the salvage dies with the runner's clone.
           APPS_REQUIRE_CONNECTED_REPO: "true"
+          # Notebook adoption (apps.md §24) reads the GCS store; without the
+          # bucket the runner silently reads an empty filesystem store.
+          NOTEBOOK_GCS_BUCKET: ${{ vars.NOTEBOOK_GCS_BUCKET }}
         run: pnpm run migrate
 
       - name: Sync Inngest app

--- a/api/package.json
+++ b/api/package.json
@@ -28,6 +28,7 @@
     "@ai-sdk/gateway": "^3.0.124",
     "@ai-sdk/mcp": "^2.0.5",
     "@clickhouse/client": "^1.14.0",
+    "@deepnote/blocks": "4.7.0",
     "@duckdb/node-api": "1.5.0-r.1",
     "@google-cloud/bigquery": "^8.1.1",
     "@google-cloud/cloud-sql-connector": "^1.8.4",

--- a/api/src/agent-lib/tools/server-notebook-tools.ts
+++ b/api/src/agent-lib/tools/server-notebook-tools.ts
@@ -9,6 +9,7 @@
  *
  * Spread AFTER `clientNotebookTools` in the unified factory so these win.
  */
+import { scheduleNotebookCheckpoint } from "../../notebooks/notebook-git.service";
 import { tool } from "ai";
 import { z } from "zod";
 import { randomUUID } from "crypto";
@@ -173,6 +174,7 @@ export function createNotebookServerTools({
     await updateNotebookIndex(workspaceId, notebookId, {
       updatedAt: new Date(updated.updatedAt),
     });
+    scheduleNotebookCheckpoint(workspaceId, notebookId, userId);
     publishRealtimeEvent(workspaceId, {
       type: "notebook.updated",
       notebookId,

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -212,6 +212,16 @@ export function notifyRepoPushed(workspaceId: string, userId: string): void {
         error: error instanceof Error ? error.message : String(error),
       });
     });
+  // Notebook .deepnote checkpoints (apps.md §24): external edits flow into
+  // the hot store unless the live document is ahead.
+  void import("../notebooks/notebook-git.service")
+    .then(m => m.syncNotebooksFromRepo(workspaceId, userId))
+    .catch(error => {
+      logger.warn("Notebook sync after push failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
 }
 
 // The sandbox HAS a remote, and a credential for it — see box.ts. Two things

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3522,6 +3522,10 @@ export interface INotebookIndex extends Document {
   folderId?: Types.ObjectId;
   ownerId: string;
   access: "private" | "workspace";
+  /** Repo-relative path of the committed .deepnote checkpoint (apps.md §24). */
+  path?: string;
+  /** Blob sha of the last checkpoint (sync levelling). */
+  checkpointBlobSha?: string;
   /** Role workspace members get when `access === "workspace"`. */
   workspaceRole?: ResourceShareRole;
   sharedWith?: IResourceShareEntry[];
@@ -3969,6 +3973,8 @@ const NotebookIndexSchema = new Schema<INotebookIndex>(
       enum: ["private", "workspace"],
       default: "private",
     },
+    path: { type: String },
+    checkpointBlobSha: { type: String },
     workspaceRole: {
       type: String,
       enum: ["viewer", "editor"],

--- a/api/src/migrations/2026-09-01-140000_notebooks_to_git.ts
+++ b/api/src/migrations/2026-09-01-140000_notebooks_to_git.ts
@@ -1,0 +1,63 @@
+/**
+ * Notebooks checkpoint into the workspace repo as `.deepnote` files
+ * (apps.md §24). The store (GCS) STAYS the hot working copy — nothing is
+ * dropped; this only writes the initial checkpoints and stamps index rows.
+ *
+ * Mongoose connects first (§21 rule). NOTE for the deploy workflow: the
+ * migrate step must carry NOTEBOOK_GCS_BUCKET or the runner would silently
+ * read an empty filesystem store — the same env-class bug as the dbt
+ * salvage, caught this time before it shipped.
+ */
+import { Db } from "mongodb";
+import mongoose from "mongoose";
+import { loggers } from "../logging";
+import { adoptWorkspaceNotebooks } from "../notebooks/notebook-git.service";
+import { mirrorPushNow } from "../apps/cloud-repo.service";
+
+const log = loggers.migration();
+
+export const description =
+  "Notebooks checkpoint into the workspace repo as .deepnote files (store stays the hot layer)";
+
+export async function up(db: Db): Promise<void> {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      (db as unknown as { client: { s: { url: string } } }).client.s.url,
+      { dbName: db.databaseName },
+    );
+  }
+  if (!process.env.NOTEBOOK_GCS_BUCKET) {
+    log.warn(
+      "NOTEBOOK_GCS_BUCKET is not set — adopting from the local filesystem store (dev only). In CI this means the migrate step env is missing the bucket.",
+    );
+  }
+  const workspaceIds = (await db
+    .collection("notebookindexes")
+    .distinct("workspaceId")) as Array<{ toString(): string }>;
+  let adopted = 0;
+  let failed = 0;
+  for (const raw of workspaceIds) {
+    const workspaceId = raw.toString();
+    try {
+      const report = await adoptWorkspaceNotebooks(workspaceId);
+      if (report.written > 0) {
+        await mirrorPushNow(workspaceId);
+        adopted++;
+        log.info("Notebooks adopted", { workspaceId, ...report });
+      }
+    } catch (error) {
+      failed++;
+      log.error("Notebook adoption failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  if (failed > 0) {
+    throw new Error(`Notebook adoption failed for ${failed} workspace(s)`);
+  }
+  log.info("notebooks_to_git done", {
+    workspaces: workspaceIds.length,
+    adopted,
+  });
+}

--- a/api/src/notebooks/deepnote-file.ts
+++ b/api/src/notebooks/deepnote-file.ts
@@ -1,0 +1,195 @@
+/**
+ * Notebooks as `.deepnote` files (apps.md §24): the pure format layer.
+ *
+ * The committed file is Deepnote's OPEN project format (validated against
+ * `@deepnote/blocks`' canonical zod schema), single-notebook variant — so a
+ * notebook committed to the workspace repo opens in Deepnote, converts to
+ * .ipynb/Quarto/percent/Marimo with `npx @deepnote/convert`, and renders as
+ * ordinary YAML in any diff view.
+ *
+ * OUTPUTS ARE STRIPPED — Deepnote's own architecture (source file clean;
+ * execution snapshots live elsewhere), the nbstripout convention, and ours:
+ * rendered outputs stay in the hot store document and the artifact store.
+ *
+ * Paths: `notebooks/<slug>.deepnote` for workspace-visible notebooks,
+ * `users/<ownerId>/notebooks/<slug>.deepnote` for private ones — the same
+ * owner-first layout consoles use.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import yaml from "js-yaml";
+import { deepnoteFileSchema } from "@deepnote/blocks";
+import type { NotebookBlock, NotebookDoc } from "./types";
+
+export const NOTEBOOK_FILE_EXTENSION = ".deepnote";
+export const NOTEBOOKS_ROOT = "notebooks";
+
+/** Mako-specific keys carried inside block/notebook metadata (round-trip). */
+const MAKO_CONNECTION_KEY = "mako_connection_id";
+
+export function slugifyNotebookName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug || "notebook";
+}
+
+export function notebookRepoPath(
+  slug: string,
+  owner?: { access: "private" | "workspace"; ownerId: string },
+): string {
+  if (owner && owner.access === "private") {
+    return `users/${owner.ownerId}/${NOTEBOOKS_ROOT}/${slug}${NOTEBOOK_FILE_EXTENSION}`;
+  }
+  return `${NOTEBOOKS_ROOT}/${slug}${NOTEBOOK_FILE_EXTENSION}`;
+}
+
+export function isNotebookRepoPath(repoRelative: string): boolean {
+  return (
+    repoRelative.endsWith(NOTEBOOK_FILE_EXTENSION) &&
+    (repoRelative.startsWith(`${NOTEBOOKS_ROOT}/`) ||
+      /^users\/[^/]+\/notebooks\//.test(repoRelative))
+  );
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Deterministic uuid (v5-style, sha1 of the inputs): serialization must be
+ * BYTE-STABLE for identical documents — the checkpoint pipeline levels on
+ * blob shas, so a random uuid per run would make every checkpoint "dirty".
+ */
+function stableUuid(...parts: string[]): string {
+  const h = createHash("sha1").update(parts.join("\u0000")).digest("hex");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-5${h.slice(13, 16)}-a${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
+
+/** Serialize a NotebookDoc to the .deepnote YAML (outputs stripped). */
+export function serializeNotebookFile(doc: NotebookDoc): string {
+  const blocks = doc.blocks.map((block, i) => {
+    const metadata: Record<string, unknown> = {};
+    if (!UUID_RE.test(block.id)) metadata.mako_block_id = block.id;
+    const blockId = UUID_RE.test(block.id)
+      ? block.id
+      : stableUuid(doc.id, block.id);
+    if (block.type === "sql" && block.connectionId) {
+      // Deepnote's own key for the datasource binding, so the file means
+      // something outside Mako too; the Mako key is the round-trip anchor.
+      metadata.sql_integration_id = block.connectionId;
+      metadata[MAKO_CONNECTION_KEY] = block.connectionId;
+    }
+    return {
+      id: blockId,
+      blockGroup: stableUuid(doc.id, block.id, "group"),
+      sortingKey: String(i).padStart(6, "0"),
+      type: block.type,
+      content: block.source,
+      metadata,
+    };
+  });
+  const file = {
+    version: "1.0.0",
+    metadata: { createdAt: doc.createdAt },
+    project: {
+      id: doc.id,
+      name: doc.name,
+      integrations: [],
+      notebooks: [
+        {
+          id: doc.id,
+          name: doc.name,
+          executionMode: "block",
+          isModule: false,
+          blocks,
+        },
+      ],
+      settings: {},
+    },
+  };
+  const validated = deepnoteFileSchema.safeParse(file);
+  if (!validated.success) {
+    // Never write a file the canonical schema rejects — fail loudly so the
+    // checkpoint pipeline surfaces it instead of committing junk.
+    throw new Error(
+      `Notebook does not serialize to a valid .deepnote file: ${validated.error.issues[0]?.message ?? "unknown"}`,
+    );
+  }
+  return yaml.dump(file, { lineWidth: 100, noRefs: true, sortKeys: true });
+}
+
+export interface ParsedNotebookFile {
+  /** The notebook id embedded in the file (project/notebook id). */
+  id: string | null;
+  name: string;
+  blocks: NotebookBlock[];
+}
+
+/**
+ * Parse a .deepnote file back into our block model. Tolerant by design:
+ * external files may carry Deepnote block types we do not model — text
+ * cells fold into markdown, unknown executable types fold into code, and
+ * anything unrecognizable is skipped with the file still accepted.
+ */
+export function parseNotebookFile(contents: string): ParsedNotebookFile | null {
+  let raw: unknown;
+  try {
+    raw = yaml.load(contents);
+  } catch {
+    return null;
+  }
+  const parsed = deepnoteFileSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const project = parsed.data.project as {
+    id?: string;
+    name?: string;
+    notebooks?: Array<{
+      id?: string;
+      name?: string;
+      blocks?: Array<{
+        id?: string;
+        type?: string;
+        content?: string;
+        metadata?: Record<string, unknown> | null;
+      }>;
+    }>;
+  };
+  const notebook = project.notebooks?.[0];
+  if (!notebook) return null;
+
+  const blocks: NotebookBlock[] = [];
+  for (const block of notebook.blocks ?? []) {
+    const metadata = (block.metadata ?? {}) as Record<string, unknown>;
+    const id =
+      typeof metadata.mako_block_id === "string"
+        ? metadata.mako_block_id
+        : (block.id ?? randomUUID());
+    const content = typeof block.content === "string" ? block.content : "";
+    const type = block.type ?? "";
+    if (type === "markdown" || type.startsWith("text-cell-")) {
+      blocks.push({ id, type: "markdown", source: content });
+    } else if (type === "sql") {
+      const connectionId =
+        typeof metadata[MAKO_CONNECTION_KEY] === "string"
+          ? (metadata[MAKO_CONNECTION_KEY] as string)
+          : typeof metadata.sql_integration_id === "string"
+            ? (metadata.sql_integration_id as string)
+            : undefined;
+      blocks.push({ id, type: "sql", source: content, connectionId });
+    } else if (type === "code") {
+      blocks.push({ id, type: "code", source: content });
+    } else if (content.trim()) {
+      // Unmodeled Deepnote block (visualization, input, …): preserve its
+      // content as a code comment rather than dropping user work.
+      blocks.push({ id, type: "code", source: content });
+    }
+  }
+  return {
+    id: notebook.id ?? project.id ?? null,
+    name: notebook.name?.trim() || project.name?.trim() || "Untitled notebook",
+    blocks,
+  };
+}

--- a/api/src/notebooks/notebook-git.service.test.ts
+++ b/api/src/notebooks/notebook-git.service.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Notebook checkpoints in the workspace repo (apps.md §24): real bare repo,
+ * real filesystem notebook store, mongodb-memory-server for the index.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { NotebookIndex } from "../database/workspace-schema";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  initRepo,
+  log as repoLog,
+  readBlob,
+  repoDirFor,
+} from "../apps/repository.service";
+import { getNotebookStore } from "./store";
+import {
+  notebookRepoPath,
+  parseNotebookFile,
+  serializeNotebookFile,
+} from "./deepnote-file";
+import {
+  adoptWorkspaceNotebooks,
+  checkpointNotebook,
+  removeNotebookFile,
+  syncNotebooksFromRepo,
+} from "./notebook-git.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+const WS = new Types.ObjectId().toString();
+const MAIN = `refs/heads/${DEFAULT_BRANCH}`;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "notebook-git-test-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.NOTEBOOK_WORKDIR = path.join(tmpRoot, "notebooks");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.NOTEBOOK_GCS_BUCKET;
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await NotebookIndex.deleteMany({});
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+  await fs.rm(path.join(tmpRoot, "notebooks"), {
+    recursive: true,
+    force: true,
+  });
+  await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+});
+
+async function seedNotebook(name: string, access: "private" | "workspace") {
+  const store = getNotebookStore();
+  const doc = await store.create(WS, { name });
+  await store.update(WS, doc.id, {
+    blocks: [
+      { id: "b1", type: "markdown", source: `# ${name}` },
+      { id: "b2", type: "sql", source: "select 1", connectionId: "conn-1" },
+      {
+        id: "b3",
+        type: "code",
+        source: "print('hi')",
+        outputs: [{ type: "stream", name: "stdout", text: "hi" }],
+        executionCount: 3,
+      },
+    ],
+  });
+  await NotebookIndex.create({
+    workspaceId: new Types.ObjectId(WS),
+    notebookId: doc.id,
+    name,
+    ownerId: "u1",
+    access,
+    updatedAt: new Date(),
+  });
+  return doc.id;
+}
+
+async function fileAt(rel: string): Promise<string | null> {
+  try {
+    const blob = await readBlob(repoDirFor(WS), MAIN, rel);
+    return blob.isBinary ? null : blob.contents;
+  } catch {
+    return null;
+  }
+}
+
+describe("checkpoint", () => {
+  it("commits a stripped single-notebook .deepnote at the access-scoped path", async () => {
+    const id = await seedNotebook("Revenue walk", "workspace");
+    const result = await checkpointNotebook(WS, id, "u1");
+    expect(result.committed).toBe(true);
+
+    const contents = await fileAt("notebooks/revenue-walk.deepnote");
+    expect(contents).toBeTruthy();
+    expect(contents).toContain("version: 1.0.0");
+    expect(contents).toContain("type: sql");
+    expect(contents).toContain("mako_connection_id: conn-1");
+    // Outputs are STRIPPED (Deepnote's own source-vs-snapshot split).
+    expect(contents).not.toContain("stdout");
+    expect(contents).not.toContain("executionCount");
+
+    // Idempotent: same content → no second commit.
+    const again = await checkpointNotebook(WS, id, "u1");
+    expect(again.committed).toBe(false);
+  });
+
+  it("a private notebook lands under users/<owner>/notebooks/", async () => {
+    const id = await seedNotebook("Scratch pad", "private");
+    await checkpointNotebook(WS, id, "u1");
+    expect(
+      await fileAt("users/u1/notebooks/scratch-pad.deepnote"),
+    ).toBeTruthy();
+  });
+
+  it("an access flip moves the file in one commit", async () => {
+    const id = await seedNotebook("Shared later", "private");
+    await checkpointNotebook(WS, id, "u1");
+    await NotebookIndex.updateOne(
+      { notebookId: id },
+      { $set: { access: "workspace" } },
+    );
+    await checkpointNotebook(WS, id, "u1");
+    expect(await fileAt("users/u1/notebooks/shared-later.deepnote")).toBeNull();
+    expect(await fileAt("notebooks/shared-later.deepnote")).toBeTruthy();
+    const [head] = await repoLog(repoDirFor(WS), MAIN, 1);
+    expect(head.subject).toContain("move to notebooks/shared-later.deepnote");
+  });
+
+  it("removeNotebookFile deletes the committed file", async () => {
+    const id = await seedNotebook("Doomed", "workspace");
+    await checkpointNotebook(WS, id, "u1");
+    const index = await NotebookIndex.findOne({ notebookId: id });
+    await removeNotebookFile(WS, index!, "u1");
+    expect(await fileAt("notebooks/doomed.deepnote")).toBeNull();
+  });
+});
+
+describe("push-sync", () => {
+  it("an external .deepnote edit flows into the store when the doc is level", async () => {
+    const id = await seedNotebook("Synced", "workspace");
+    await checkpointNotebook(WS, id, "u1");
+    const raw = (await fileAt("notebooks/synced.deepnote"))!;
+    const parsed = parseNotebookFile(raw)!;
+    parsed.blocks[0] = { ...parsed.blocks[0], source: "# Synced (edited)" };
+    const doc = await getNotebookStore().get(WS, id);
+    const edited = serializeNotebookFile({
+      ...doc!,
+      name: "Synced",
+      blocks: parsed.blocks,
+    });
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { writes: { "notebooks/synced.deepnote": edited } },
+      { message: "laptop edit" },
+    );
+    await syncNotebooksFromRepo(WS);
+    const fresh = await getNotebookStore().get(WS, id);
+    expect(fresh?.blocks[0]?.source).toBe("# Synced (edited)");
+  });
+
+  it("the live editor wins over a stale external edit", async () => {
+    const id = await seedNotebook("Contended", "workspace");
+    await checkpointNotebook(WS, id, "u1");
+    // Live edit AFTER the checkpoint…
+    await getNotebookStore().update(WS, id, {
+      blocks: [{ id: "b1", type: "markdown", source: "# LIVE WORK" }],
+    });
+    // …and an external edit landing on the OLD checkpoint.
+    const doc = await getNotebookStore().get(WS, id);
+    const external = serializeNotebookFile({
+      ...doc!,
+      name: "Contended",
+      blocks: [{ id: "b1", type: "markdown", source: "# EXTERNAL" }],
+    });
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { writes: { "notebooks/contended.deepnote": external } },
+      { message: "stale laptop edit" },
+    );
+    await syncNotebooksFromRepo(WS);
+    const fresh = await getNotebookStore().get(WS, id);
+    expect(fresh?.blocks[0]?.source).toBe("# LIVE WORK");
+  });
+});
+
+describe("adoption", () => {
+  it("checkpoints every notebook once, re-runnable", async () => {
+    await seedNotebook("First", "workspace");
+    await seedNotebook("Second", "private");
+    const first = await adoptWorkspaceNotebooks(WS);
+    expect(first).toEqual({ notebooks: 2, written: 2 });
+    expect(await fileAt(notebookRepoPath("first"))).toBeTruthy();
+    expect(
+      await fileAt(
+        notebookRepoPath("second", { access: "private", ownerId: "u1" }),
+      ),
+    ).toBeTruthy();
+    const again = await adoptWorkspaceNotebooks(WS);
+    expect(again.written).toBe(0);
+  });
+});

--- a/api/src/notebooks/notebook-git.service.ts
+++ b/api/src/notebooks/notebook-git.service.ts
@@ -1,0 +1,376 @@
+/**
+ * Notebook checkpoints in the workspace repo (apps.md §24).
+ *
+ * The notebook STORE (GCS/filesystem) is the hot working copy — the editor
+ * autosaves there on every patch, exactly like a sandbox working tree. Git
+ * gets CHECKPOINTS: a debounced commit of the stripped `.deepnote` source
+ * after edits go quiet (§19 rule 3 — granularity is per-surface, and a
+ * commit per keystroke would be noise, not history). Nothing durable is
+ * ever only in the timer: the store IS durable; the checkpoint is the
+ * review/history/interop surface.
+ *
+ * Sync back: an external edit to a committed `.deepnote` file (laptop
+ * clone, sandbox, PR merge) flows into the store on push — unless the live
+ * document changed since its last checkpoint, in which case THE EDITOR
+ * WINS: the store keeps the newer work, the external version stays in git
+ * history, and the next checkpoint records the resolution. A hot-document
+ * system must never clobber the screen someone is typing into.
+ */
+import { Types } from "mongoose";
+import {
+  NotebookIndex,
+  type INotebookIndex,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+import { authorForUser } from "../apps/workspace-consoles.service";
+import { ensureLocalRepo, queueMirrorPush } from "../apps/cloud-repo.service";
+import {
+  DEFAULT_BRANCH,
+  blobOid,
+  commitBlobsOnBranch,
+  listTree,
+  readBlob,
+  repoDirFor,
+  repoExists,
+  resolveCommit,
+} from "../apps/repository.service";
+import { publishRealtimeEvent } from "../services/realtime.service";
+import { getNotebookStore } from "./store";
+import {
+  isNotebookRepoPath,
+  notebookRepoPath,
+  parseNotebookFile,
+  serializeNotebookFile,
+  slugifyNotebookName,
+} from "./deepnote-file";
+import type { NotebookDoc } from "./types";
+
+const logger = loggers.api("notebook-git");
+
+/** Commit after this much quiet following an edit… */
+const CHECKPOINT_DEBOUNCE_MS = 30_000;
+/** …but never let a busy editor outrun history by more than this. */
+const CHECKPOINT_MAX_WAIT_MS = 5 * 60_000;
+
+async function repoDirIfExists(workspaceId: string): Promise<string | null> {
+  await ensureLocalRepo(workspaceId);
+  const repoDir = repoDirFor(workspaceId);
+  return (await repoExists(repoDir)) ? repoDir : null;
+}
+
+async function uniqueNotebookPath(
+  workspaceId: string,
+  index: INotebookIndex,
+): Promise<string> {
+  const base = slugifyNotebookName(index.name);
+  let slug = base;
+  for (let i = 2; i < 100; i++) {
+    const wanted = notebookRepoPath(slug, {
+      access: index.access,
+      ownerId: index.ownerId,
+    });
+    const clash = await NotebookIndex.findOne({
+      workspaceId: index.workspaceId,
+      path: wanted,
+      notebookId: { $ne: index.notebookId },
+    }).select("_id");
+    if (!clash) return wanted;
+    slug = `${base}-${i}`;
+  }
+  throw new Error(`No free path for notebook "${index.name}"`);
+}
+
+/**
+ * Commit the notebook's current store document as its `.deepnote` file,
+ * reconciling the path (rename/access moves the file in the same commit).
+ * No-op when the serialized source is byte-identical to the last checkpoint.
+ */
+export async function checkpointNotebook(
+  workspaceId: string,
+  notebookId: string,
+  actorUserId?: string,
+): Promise<{ committed: boolean }> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return { committed: false };
+  const [doc, index] = await Promise.all([
+    getNotebookStore().get(workspaceId, notebookId),
+    NotebookIndex.findOne({
+      workspaceId: new Types.ObjectId(workspaceId),
+      notebookId,
+    }),
+  ]);
+  if (!doc || !index) return { committed: false };
+
+  // The index row's name is authoritative for the tree; keep the doc's copy
+  // in the file so the file stands alone.
+  const contents = serializeNotebookFile({ ...doc, name: index.name });
+  const sha = blobOid(contents);
+  const wantedPath = await uniqueNotebookPath(workspaceId, index);
+  if (index.checkpointBlobSha === sha && index.path === wantedPath) {
+    return { committed: false };
+  }
+
+  const deletes =
+    index.path && index.path !== wantedPath ? [index.path] : undefined;
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    { writes: { [wantedPath]: contents }, deletes },
+    {
+      message: deletes?.length
+        ? `notebook: move to ${wantedPath}`
+        : `notebook: checkpoint "${index.name}"`,
+      author: actorUserId ? await authorForUser(actorUserId) : undefined,
+    },
+  );
+  index.path = wantedPath;
+  index.checkpointBlobSha = sha;
+  await index.save();
+  queueMirrorPush(workspaceId);
+  return { committed: true };
+}
+
+/** Remove the notebook's file when the notebook itself is deleted. */
+export async function removeNotebookFile(
+  workspaceId: string,
+  index: Pick<INotebookIndex, "path" | "name">,
+  actorUserId?: string,
+): Promise<void> {
+  if (!index.path) return;
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return;
+  await commitBlobsOnBranch(
+    repoDir,
+    DEFAULT_BRANCH,
+    { deletes: [index.path] },
+    {
+      message: `notebook: delete "${index.name}"`,
+      author: actorUserId ? await authorForUser(actorUserId) : undefined,
+    },
+  );
+  queueMirrorPush(workspaceId);
+}
+
+// ---------------------------------------------------------------------------
+// Debounced checkpoint scheduling
+// ---------------------------------------------------------------------------
+
+interface PendingCheckpoint {
+  timer: NodeJS.Timeout;
+  firstScheduledAt: number;
+  actorUserId?: string;
+}
+
+const pending = new Map<string, PendingCheckpoint>();
+
+function keyFor(workspaceId: string, notebookId: string): string {
+  return `${workspaceId}:${notebookId}`;
+}
+
+/**
+ * Schedule a checkpoint after the edit burst goes quiet. Losing a timer
+ * (instance recycle) loses no data — the store holds the truth and the next
+ * edit reschedules; the checkpoint arrives one burst later.
+ */
+export function scheduleNotebookCheckpoint(
+  workspaceId: string,
+  notebookId: string,
+  actorUserId?: string,
+): void {
+  const key = keyFor(workspaceId, notebookId);
+  const existing = pending.get(key);
+  const firstScheduledAt = existing?.firstScheduledAt ?? Date.now();
+  if (existing) clearTimeout(existing.timer);
+
+  const waited = Date.now() - firstScheduledAt;
+  const delay = Math.max(
+    1_000,
+    Math.min(CHECKPOINT_DEBOUNCE_MS, CHECKPOINT_MAX_WAIT_MS - waited),
+  );
+  const timer = setTimeout(() => {
+    pending.delete(key);
+    void checkpointNotebook(workspaceId, notebookId, actorUserId).catch(
+      error => {
+        logger.warn("Notebook checkpoint failed", {
+          workspaceId,
+          notebookId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    );
+  }, delay);
+  timer.unref?.();
+  pending.set(key, {
+    timer,
+    firstScheduledAt,
+    actorUserId: actorUserId ?? existing?.actorUserId,
+  });
+}
+
+/** Flush a pending checkpoint immediately (delete/close paths). */
+export async function flushNotebookCheckpoint(
+  workspaceId: string,
+  notebookId: string,
+): Promise<void> {
+  const key = keyFor(workspaceId, notebookId);
+  const entry = pending.get(key);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  pending.delete(key);
+  await checkpointNotebook(workspaceId, notebookId, entry.actorUserId).catch(
+    () => undefined,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Push-sync: external .deepnote edits flow into the store
+// ---------------------------------------------------------------------------
+
+const syncInFlight = new Map<string, Promise<void>>();
+
+export async function syncNotebooksFromRepo(
+  workspaceId: string,
+  actorUserId?: string,
+): Promise<void> {
+  const running = syncInFlight.get(workspaceId);
+  if (running) return running;
+  const run = syncNotebooksNow(workspaceId, actorUserId).finally(() => {
+    syncInFlight.delete(workspaceId);
+  });
+  syncInFlight.set(workspaceId, run);
+  return run;
+}
+
+async function syncNotebooksNow(
+  workspaceId: string,
+  actorUserId?: string,
+): Promise<void> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return;
+  const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
+  if (!head) return;
+  const paths = (await listTree(repoDir, head))
+    .map(e => e.path)
+    .filter(isNotebookRepoPath);
+  if (paths.length === 0) return;
+
+  const store = getNotebookStore();
+  for (const path of paths) {
+    try {
+      const index = await NotebookIndex.findOne({
+        workspaceId: new Types.ObjectId(workspaceId),
+        path,
+      });
+      // Files with no index row are externally-created notebooks; creating
+      // store documents for them is a follow-up (the store API cannot yet
+      // create with a caller-chosen id). Skip quietly.
+      if (!index) continue;
+
+      const blob = await readBlob(repoDir, head, path);
+      if (blob.isBinary) continue;
+      const sha = blobOid(blob.contents);
+      if (index.checkpointBlobSha === sha) continue; // level already
+
+      const parsed = parseNotebookFile(blob.contents);
+      if (!parsed) {
+        logger.warn("Invalid .deepnote file; keeping current notebook", {
+          workspaceId,
+          path,
+        });
+        continue;
+      }
+
+      const doc = await store.get(workspaceId, index.notebookId);
+      if (!doc) continue;
+      // Conflict guard: if the live document moved past its last checkpoint,
+      // the editor wins — git history keeps the external version, and the
+      // next checkpoint records the live state.
+      const liveSha = blobOid(
+        serializeNotebookFile({ ...doc, name: index.name }),
+      );
+      if (index.checkpointBlobSha && liveSha !== index.checkpointBlobSha) {
+        logger.warn(
+          "External notebook edit skipped: live document has newer changes",
+          { workspaceId, path },
+        );
+        continue;
+      }
+
+      const updated = await store.update(workspaceId, index.notebookId, {
+        name: parsed.name,
+        blocks: parsed.blocks,
+      });
+      if (!updated) continue;
+      index.name = parsed.name;
+      index.checkpointBlobSha = sha;
+      await index.save();
+      publishRealtimeEvent(workspaceId, {
+        type: "notebook.updated",
+        notebookId: index.notebookId,
+        version: updated.version,
+        updatedBy: actorUserId ?? "git",
+        origin: "save",
+      });
+      logger.info("Notebook synced from repo", { workspaceId, path });
+    } catch (error) {
+      logger.warn("Notebook sync failed for path", {
+        workspaceId,
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adoption (migration path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Checkpoint every notebook of a repo-holding workspace in ONE commit.
+ * Re-runnable: already-checkpointed notebooks are skipped by sha.
+ */
+export async function adoptWorkspaceNotebooks(workspaceId: string): Promise<{
+  notebooks: number;
+  written: number;
+}> {
+  const repoDir = await repoDirIfExists(workspaceId);
+  if (!repoDir) return { notebooks: 0, written: 0 };
+  const store = getNotebookStore();
+  const indexes = await NotebookIndex.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  const writes: Record<string, string> = {};
+  const stamps: Array<{ index: INotebookIndex; path: string; sha: string }> =
+    [];
+  for (const index of indexes) {
+    const doc = await store.get(workspaceId, index.notebookId);
+    if (!doc) continue;
+    const contents = serializeNotebookFile({
+      ...(doc as NotebookDoc),
+      name: index.name,
+    });
+    const sha = blobOid(contents);
+    if (index.checkpointBlobSha === sha && index.path) continue;
+    const path = await uniqueNotebookPath(workspaceId, index);
+    writes[path] = contents;
+    stamps.push({ index, path, sha });
+  }
+  if (Object.keys(writes).length > 0) {
+    await commitBlobsOnBranch(
+      repoDir,
+      DEFAULT_BRANCH,
+      { writes },
+      {
+        message: `notebook: adopt ${Object.keys(writes).length} notebooks into git (apps.md §24)`,
+      },
+    );
+    for (const { index, path, sha } of stamps) {
+      index.path = path;
+      index.checkpointBlobSha = sha;
+      await index.save();
+    }
+    queueMirrorPush(workspaceId);
+  }
+  return { notebooks: indexes.length, written: Object.keys(writes).length };
+}

--- a/api/src/routes/notebooks.ts
+++ b/api/src/routes/notebooks.ts
@@ -34,6 +34,10 @@ import type { NotebookBlock } from "../notebooks/types";
 import { loggers } from "../logging";
 import { publishRealtimeEvent } from "../services/realtime.service";
 import {
+  removeNotebookFile,
+  scheduleNotebookCheckpoint,
+} from "../notebooks/notebook-git.service";
+import {
   createNotebookIndex,
   deleteNotebookIndex,
   getNotebookIndex,
@@ -197,6 +201,7 @@ notebookRoutes.openapi(
     });
 
     logger.info("Created notebook", { workspaceId: ws, notebookId: doc.id });
+    scheduleNotebookCheckpoint(ws, doc.id, userId);
     publishRealtimeEvent(ws, {
       type: "notebook.updated",
       notebookId: doc.id,
@@ -471,6 +476,9 @@ notebookRoutes.openapi(
       clientId: typeof body.clientId === "string" ? body.clientId : undefined,
       origin: "save",
     });
+    // Git checkpoint after the edit burst goes quiet (apps.md §24) — the
+    // store above is the durable working copy; the commit is history.
+    scheduleNotebookCheckpoint(ws, id, editorUserId(c));
     return c.json({ success: true, data: doc });
   },
 );
@@ -566,11 +574,20 @@ notebookRoutes.openapi(
       );
     }
 
+    const doomedIndex = await NotebookIndex.findOne({
+      workspaceId: new Types.ObjectId(ws),
+      notebookId: id,
+    }).select("path name");
     const ok = await getNotebookStore().remove(ws, id);
     if (!ok) {
       return c.json({ success: false, error: "Notebook not found" }, 404);
     }
     await deleteNotebookIndex(ws, id);
+    if (doomedIndex) {
+      await removeNotebookFile(ws, doomedIndex, editorUserId(c)).catch(
+        () => undefined,
+      );
+    }
     publishTreeUpdated(ws);
     return c.json({ success: true });
   },
@@ -603,6 +620,9 @@ const notebookFolderBackend = createModelFolderBackend({
         return { ok: false, status: 404, error: "Folder not found" };
       }
     }
+    // Access flips relocate the committed file (notebooks/ <-> users/…);
+    // the next checkpoint reconciles the path.
+    scheduleNotebookCheckpoint(ctx.workspaceId, itemId, ctx.userId);
     await updateNotebookIndex(ctx.workspaceId, itemId, {
       folderId: folderId ?? null,
       access,

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       "src/apps/workspace-repo.test.ts",
       "src/apps/workspace-prompt.test.ts",
       "src/services/skills.service.test.ts",
+      "src/notebooks/notebook-git.service.test.ts",
       "src/apps/bindings.service.test.ts",
       "src/apps/cloud-repo.service.test.ts",
       "src/apps/adversarial.test.ts",

--- a/apps.md
+++ b/apps.md
@@ -2860,3 +2860,41 @@ Migration adopts existing jobs/environments into the repo (one commit,
 re-runnable, mongoose connected per the §21 rule) and pushes the mirror.
 With this, "dbt is in git" carries no asterisk: source, rules, jobs,
 environments — all files; Mongo keeps runs and claims.
+
+## 24. Notebooks checkpoint as .deepnote files (2026-09-01)
+
+Notebooks join the repo — by RIPPING OFF the best available architecture
+rather than inventing one. Deepnote open-sourced their project format
+(`@deepnote/blocks` 4.7, `@deepnote/convert` 4.0), and their own design
+answers all three open questions from §11.11:
+
+- **Format**: the committed file is a canonical single-notebook `.deepnote`
+  (YAML, validated against Deepnote's zod schema before every write — we
+  never commit a file their toolchain rejects). It opens in Deepnote and
+  converts to .ipynb/Quarto/percent/Marimo with `npx @deepnote/convert`.
+  SQL blocks carry `sql_integration_id` (their key) + `mako_connection_id`
+  (our round-trip anchor). Serialization is BYTE-STABLE (deterministic
+  v5-style uuids) so blob-sha levelling works.
+- **Outputs**: STRIPPED — Deepnote's own source-vs-execution-snapshot
+  split, the nbstripout convention, and ours: outputs stay in the hot
+  store document and the artifact store.
+- **Cadence** (§19 rule 3 made concrete): the notebook STORE (GCS) remains
+  the durable hot working copy the editor autosaves into; git gets
+  CHECKPOINTS — debounced 30s after an edit burst goes quiet, max 5min,
+  flushed on delete. Losing a timer loses nothing durable; the checkpoint
+  is the history/review/interop surface, not the durability layer.
+
+Paths: `notebooks/<slug>.deepnote`, private under
+`users/<ownerId>/notebooks/` (consoles' owner-first layout). Rename and
+access flips relocate the file in the next checkpoint commit. Push-sync
+flows external `.deepnote` edits into the store — unless the live document
+moved past its last checkpoint, in which case THE EDITOR WINS (git history
+keeps the external version; the next checkpoint records the resolution).
+Deliberate v1 gaps, documented: externally-created files are not yet
+materialized as store docs (store API lacks create-with-id), file deletions
+on main do not delete notebooks, and Mongo folder organization is not
+mirrored into paths yet.
+
+Migration checkpoints every existing notebook (non-destructive — the store
+keeps everything) and the deploy migrate step gains NOTEBOOK_GCS_BUCKET —
+the third instance of the runner-env bug class, caught at design time.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 6.1.3(encoding@0.1.13)(openapi-types@12.1.3)
       axios:
         specifier: ^1.6.2
-        version: 1.9.0(debug@4.4.3(supports-color@5.5.0))
+        version: 1.9.0
       bson:
         specifier: ^6.2.0
         version: 6.10.3
@@ -34,7 +34,7 @@ importers:
         version: 16.5.0
       eslint-plugin-prettier:
         specifier: ^5.4.1
-        version: 5.4.1(eslint-config-prettier@10.1.5(eslint@8.57.1(supports-color@5.5.0)))(eslint@8.57.1(supports-color@5.5.0))(prettier@3.5.3)
+        version: 5.4.1(eslint-config-prettier@10.1.5(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
       inquirer:
         specifier: ^8.2.6
         version: 8.2.6
@@ -62,19 +62,19 @@ importers:
         version: 20.17.50
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.2
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^6.13.2
-        version: 6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
+        version: 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
       eslint:
         specifier: ^8.55.0
-        version: 8.57.1(supports-color@5.5.0)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: ^10.1.5
-        version: 10.1.5(eslint@8.57.1(supports-color@5.5.0))
+        version: 10.1.5(eslint@8.57.1)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -114,18 +114,21 @@ importers:
       '@clickhouse/client':
         specifier: ^1.14.0
         version: 1.15.0
+      '@deepnote/blocks':
+        specifier: 4.7.0
+        version: 4.7.0
       '@duckdb/node-api':
         specifier: 1.5.0-r.1
         version: 1.5.0-r.1
       '@google-cloud/bigquery':
         specifier: ^8.1.1
-        version: 8.1.1(supports-color@10.2.2)
+        version: 8.1.1
       '@google-cloud/cloud-sql-connector':
         specifier: ^1.8.4
-        version: 1.8.4(supports-color@10.2.2)
+        version: 1.8.4
       '@google-cloud/storage':
         specifier: ^7.19.0
-        version: 7.19.0(encoding@0.1.13)(supports-color@10.2.2)
+        version: 7.19.0(encoding@0.1.13)
       '@hono/node-server':
         specifier: ^1.14.4
         version: 1.14.4(hono@4.7.11)
@@ -134,7 +137,7 @@ importers:
         version: 1.3.0(hono@4.7.11)(zod@4.2.1)
       '@kubernetes/client-node':
         specifier: ^1.4.0
-        version: 1.4.0(encoding@0.1.13)(supports-color@10.2.2)
+        version: 1.4.0(encoding@0.1.13)
       '@langfuse/otel':
         specifier: ^5.4.1
         version: 5.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
@@ -152,7 +155,7 @@ importers:
         version: link:../packages/schemas
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(supports-color@10.2.2)(zod@4.2.1)
+        version: 1.29.0(zod@4.2.1)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -170,7 +173,7 @@ importers:
         version: 0.11.3(hono@4.7.11)
       '@tavily/core':
         specifier: ^0.7.6
-        version: 0.7.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 0.7.6
       ai:
         specifier: 6.0.196
         version: 6.0.196(zod@4.2.1)
@@ -182,7 +185,7 @@ importers:
         version: 3.7.0
       axios:
         specifier: ^1.6.2
-        version: 1.9.0(debug@4.4.3(supports-color@10.2.2))
+        version: 1.9.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -209,22 +212,22 @@ importers:
         version: 2.32.0
       express-rate-limit:
         specifier: ^7.5.0
-        version: 7.5.0(express@5.2.1(supports-color@10.2.2))
+        version: 7.5.0(express@5.2.1)
       google-auth-library:
         specifier: ^10.4.0
-        version: 10.4.0(supports-color@10.2.2)
+        version: 10.4.0
       hono:
         specifier: ^4.7.11
         version: 4.7.11
       inngest:
         specifier: ^4.18.1
-        version: 4.18.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(express@5.2.1(supports-color@10.2.2))(h3@1.15.4)(hono@4.7.11)(next@14.2.33(@babel/core@7.27.3(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(zod@4.2.1)
+        version: 4.18.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(express@5.2.1)(h3@1.15.4)(hono@4.7.11)(next@14.2.33(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(zod@4.2.1)
       inquirer:
         specifier: ^8.2.6
         version: 8.2.6
       ioredis:
         specifier: ^5.11.1
-        version: 5.11.1(supports-color@10.2.2)
+        version: 5.11.1
       ipaddr.js:
         specifier: ^2.4.0
         version: 2.4.0
@@ -236,10 +239,10 @@ importers:
         version: 6.17.0(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
       mongoose:
         specifier: ^8.15.1
-        version: 8.15.1(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2)
+        version: 8.15.1(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
       mssql:
         specifier: ^11.0.1
-        version: 11.0.1(supports-color@10.2.2)
+        version: 11.0.1
       mysql2:
         specifier: ^3.14.1
         version: 3.14.1
@@ -272,7 +275,7 @@ importers:
         version: 5.1.1
       sqlite3:
         specifier: ^5.1.7
-        version: 5.1.7(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 5.1.7
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0
@@ -297,7 +300,7 @@ importers:
     devDependencies:
       '@testcontainers/postgresql':
         specifier: ^12.0.3
-        version: 12.0.3(supports-color@10.2.2)
+        version: 12.0.3
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
@@ -315,7 +318,7 @@ importers:
         version: 4.0.9
       '@types/mssql':
         specifier: ^9.1.7
-        version: 9.1.7(supports-color@10.2.2)
+        version: 9.1.7
       '@types/node':
         specifier: ^24.0.0
         version: 24.0.0
@@ -339,22 +342,22 @@ importers:
         version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.34.0
-        version: 8.34.0(@typescript-eslint/parser@8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3))(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+        version: 8.34.0(@typescript-eslint/parser@8.34.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^8.34.0
-        version: 8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+        version: 8.34.0(eslint@8.57.1)(typescript@5.8.3)
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       eslint:
         specifier: ^8.57.1
-        version: 8.57.1(supports-color@10.2.2)
+        version: 8.57.1
       mongodb-memory-server:
         specifier: ^10.4.3
-        version: 10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2)
+        version: 10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
       testcontainers:
         specifier: ^12.0.3
-        version: 12.0.3(supports-color@10.2.2)
+        version: 12.0.3
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
@@ -363,7 +366,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.0.0)(jsdom@25.0.1(supports-color@10.2.2))(lightningcss@1.31.0)(supports-color@10.2.2)
+        version: 2.1.9(@types/node@24.0.0)(jsdom@25.0.1)(lightningcss@1.31.0)
 
   app:
     dependencies:
@@ -387,10 +390,10 @@ importers:
         version: 1.33.1-dev20.0
       '@emotion/react':
         specifier: ^11.11.1
-        version: 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+        version: 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/styled':
         specifier: ^11.11.0
-        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mako/agent-tools':
         specifier: workspace:*
         version: link:../packages/agent-tools
@@ -402,13 +405,13 @@ importers:
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material':
         specifier: ^7.1.0
-        version: 7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+        version: 7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/material':
         specifier: ^7.1.0
-        version: 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/x-data-grid-premium':
         specifier: ^8.4.0
-        version: 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/x-license':
         specifier: ^8.4.0
         version: 8.4.0(@types/react@18.3.23)(react@18.3.1)
@@ -438,7 +441,7 @@ importers:
         version: 6.0.196(zod@4.2.1)
       axios:
         specifier: ^1.6.2
-        version: 1.9.0(debug@4.4.3(supports-color@10.2.2))
+        version: 1.9.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -459,7 +462,7 @@ importers:
         version: 4.7.0
       mui-chips-input:
         specifier: ^9.0.0
-        version: 9.0.0(98441616543936ce9d0e0aee190b2ba9)
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -504,7 +507,7 @@ importers:
         version: 4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       streamdown:
         specifier: ^2.5.0
-        version: 2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.2.2)
+        version: 2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vega:
         specifier: ^6.2.0
         version: 6.2.0
@@ -523,7 +526,7 @@ importers:
     devDependencies:
       '@react-scan/vite-plugin-react-scan':
         specifier: ^0.2.3
-        version: 0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(supports-color@10.2.2))(supports-color@10.2.2)(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
+        version: 0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1))(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
@@ -544,34 +547,34 @@ importers:
         version: 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3))(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+        version: 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.5.0(supports-color@10.2.2)(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
+        version: 4.5.0(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
       eslint:
         specifier: ^8.57.1
-        version: 8.57.1(supports-color@10.2.2)
+        version: 8.57.1
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@8.57.1(supports-color@10.2.2))
+        version: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
-        version: 5.2.0(eslint@8.57.1(supports-color@10.2.2))
+        version: 5.2.0(eslint@8.57.1)
       eslint-plugin-react-refresh:
         specifier: ^0.4.20
-        version: 0.4.20(eslint@8.57.1(supports-color@10.2.2))
+        version: 0.4.20(eslint@8.57.1)
       jsdom:
         specifier: ^25.0.1
-        version: 25.0.1(supports-color@10.2.2)
+        version: 25.0.1
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@5.8.3)
       react-scan:
         specifier: ^0.5.3
-        version: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(supports-color@10.2.2)
+        version: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -583,22 +586,22 @@ importers:
         version: 5.4.19(@types/node@24.12.0)(lightningcss@1.31.0)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.12.0)(jsdom@25.0.1(supports-color@10.2.2))(lightningcss@1.31.0)(supports-color@10.2.2)
+        version: 2.1.9(@types/node@24.12.0)(jsdom@25.0.1)(lightningcss@1.31.0)
 
   docs:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.36.2
-        version: 0.36.2(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2)
+        version: 0.36.2(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))
       astro:
         specifier: ^5.6.1
-        version: 5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
+        version: 5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.2
         version: 0.34.5
       starlight-openapi:
         specifier: ^0.22.1
-        version: 0.22.1(@astrojs/markdown-remark@6.3.9(supports-color@10.2.2))(@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2))(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(openapi-types@12.1.3)
+        version: 0.22.1(@astrojs/markdown-remark@6.3.9)(@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)))(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(openapi-types@12.1.3)
 
   packages/agent-tools:
     dependencies:
@@ -635,13 +638,13 @@ importers:
         version: 24.12.0
       electron:
         specifier: ^36.0.0
-        version: 36.9.5(supports-color@10.2.2)
+        version: 36.9.5
       electron-builder:
         specifier: ^26.0.12
-        version: 26.15.2(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
+        version: 26.15.2(electron-builder-squirrel-windows@26.15.2)
       electron-updater:
         specifier: ^6.8.9
-        version: 6.8.9(supports-color@10.2.2)
+        version: 6.8.9
       esbuild:
         specifier: ^0.25.5
         version: 0.25.5
@@ -1287,6 +1290,10 @@ packages:
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
+
+  '@deepnote/blocks@4.7.0':
+    resolution: {integrity: sha512-GW5jIpO2Sr7R2LaokuF8js60FHw4DLk1e4bq6BnMs2QkxGr2QF6JbRONl82V7zEV3iJQesXX+mFuTMWp9jCxPA==}
+    engines: {node: '>=22.14.0', pnpm: '>=10.17.1'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -2096,183 +2103,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2619,28 +2598,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -3681,67 +3656,56 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -4061,28 +4025,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -7945,56 +7905,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -11740,7 +11692,7 @@ snapshots:
 
   '@astrojs/internal-helpers@0.7.5': {}
 
-  '@astrojs/markdown-remark@6.3.9(supports-color@10.2.2)':
+  '@astrojs/markdown-remark@6.3.9':
     dependencies:
       '@astrojs/internal-helpers': 0.7.5
       '@astrojs/prism': 3.3.0
@@ -11752,8 +11704,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       shiki: 3.21.0
@@ -11766,18 +11718,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.11(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2)':
+  '@astrojs/mdx@4.3.11(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/markdown-remark': 6.3.9(supports-color@10.2.2)
-      '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 6.3.9
+      '@mdx-js/mdx': 3.1.1
       acorn: 8.15.0
-      astro: 5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
+      astro: 5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       picocolors: 1.1.1
       rehype-raw: 7.0.0
-      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-gfm: 4.0.1
       remark-smartypants: 3.0.2
       source-map: 0.7.6
       unist-util-visit: 5.0.0
@@ -11795,17 +11747,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2)':
+  '@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/markdown-remark': 6.3.9(supports-color@10.2.2)
-      '@astrojs/mdx': 4.3.11(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 6.3.9
+      '@astrojs/mdx': 4.3.11(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))
       '@astrojs/sitemap': 3.6.0
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
-      astro-expressive-code: 0.41.3(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))
+      astro: 5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
+      astro-expressive-code: 0.41.3(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -11814,13 +11766,13 @@ snapshots:
       i18next: 23.16.8
       js-yaml: 4.1.0
       klona: 2.0.6
-      mdast-util-directive: 3.1.0(supports-color@10.2.2)
+      mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
       pagefind: 1.4.0
       rehype: 13.0.2
       rehype-format: 5.0.1
-      remark-directive: 3.0.1(supports-color@10.2.2)
+      remark-directive: 3.0.1
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
@@ -11828,7 +11780,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/telemetry@3.3.0(supports-color@10.2.2)':
+  '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.3.1
       debug: 4.4.3(supports-color@10.2.2)
@@ -12257,39 +12209,39 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.9.0(supports-color@10.2.2)':
+  '@azure/core-auth@1.9.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.9.4(supports-color@10.2.2)':
+  '@azure/core-client@1.9.4':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
-      '@azure/core-rest-pipeline': 1.21.0(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
+      '@azure/core-rest-pipeline': 1.21.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/logger': 1.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-http-compat@2.3.0(supports-color@10.2.2)':
+  '@azure/core-http-compat@2.3.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.9.4(supports-color@10.2.2)
-      '@azure/core-rest-pipeline': 1.21.0(supports-color@10.2.2)
+      '@azure/core-client': 1.9.4
+      '@azure/core-rest-pipeline': 1.21.0
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-lro@2.7.2(supports-color@10.2.2)':
+  '@azure/core-lro@2.7.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/logger': 1.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -12298,14 +12250,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-rest-pipeline@1.21.0(supports-color@10.2.2)':
+  '@azure/core-rest-pipeline@1.21.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
-      '@typespec/ts-http-runtime': 0.2.3(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/logger': 1.2.0
+      '@typespec/ts-http-runtime': 0.2.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -12314,23 +12266,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.12.0(supports-color@10.2.2)':
+  '@azure/core-util@1.12.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.2.3(supports-color@10.2.2)
+      '@typespec/ts-http-runtime': 0.2.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.10.0(supports-color@10.2.2)':
+  '@azure/identity@4.10.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
-      '@azure/core-client': 1.9.4(supports-color@10.2.2)
-      '@azure/core-rest-pipeline': 1.21.0(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
+      '@azure/core-client': 1.9.4
+      '@azure/core-rest-pipeline': 1.21.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/logger': 1.2.0
       '@azure/msal-browser': 4.13.0
       '@azure/msal-node': 3.6.0
       open: 10.1.2
@@ -12338,39 +12290,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-common@2.0.0(supports-color@10.2.2)':
+  '@azure/keyvault-common@2.0.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
-      '@azure/core-client': 1.9.4(supports-color@10.2.2)
-      '@azure/core-rest-pipeline': 1.21.0(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
+      '@azure/core-client': 1.9.4
+      '@azure/core-rest-pipeline': 1.21.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/logger': 1.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-keys@4.9.0(supports-color@10.2.2)':
+  '@azure/keyvault-keys@4.9.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
-      '@azure/core-client': 1.9.4(supports-color@10.2.2)
-      '@azure/core-http-compat': 2.3.0(supports-color@10.2.2)
-      '@azure/core-lro': 2.7.2(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
+      '@azure/core-client': 1.9.4
+      '@azure/core-http-compat': 2.3.0
+      '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.21.0
       '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0(supports-color@10.2.2)
-      '@azure/keyvault-common': 2.0.0(supports-color@10.2.2)
-      '@azure/logger': 1.2.0(supports-color@10.2.2)
+      '@azure/core-util': 1.12.0
+      '@azure/keyvault-common': 2.0.0
+      '@azure/logger': 1.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.2.0(supports-color@10.2.2)':
+  '@azure/logger@1.2.0':
     dependencies:
-      '@typespec/ts-http-runtime': 0.2.3(supports-color@10.2.2)
+      '@typespec/ts-http-runtime': 0.2.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -12395,17 +12347,17 @@ snapshots:
 
   '@babel/compat-data@7.27.3': {}
 
-  '@babel/core@7.27.3(supports-color@10.2.2)':
+  '@babel/core@7.27.3':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.27.3)
       '@babel/helpers': 7.27.3
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
@@ -12443,48 +12395,48 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@10.2.2)
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.27.3)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@10.2.2)':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.3(supports-color@10.2.2)
+      '@babel/traverse': 7.27.3
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
+      '@babel/core': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12496,18 +12448,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@10.2.2)
+      '@babel/core': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@10.2.2)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.3(supports-color@10.2.2)
+      '@babel/traverse': 7.27.3
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -12535,64 +12487,64 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.27.3
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.27.3)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.27.3(supports-color@10.2.2))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.27.3(supports-color@10.2.2))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.27.3)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@10.2.2)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.27.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.27.3)':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.27.3)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.27.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12612,7 +12564,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.27.3(supports-color@10.2.2)':
+  '@babel/traverse@7.27.3':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.27.3
@@ -12624,7 +12576,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.0(supports-color@10.2.2)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -12744,6 +12696,12 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@deepnote/blocks@4.7.0':
+    dependencies:
+      ts-dedent: 2.2.0
+      yaml: 2.9.0
+      zod: 3.25.76
+
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -12828,7 +12786,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3(supports-color@10.2.2)':
+  '@electron/get@2.0.3':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       env-paths: 2.2.1
@@ -12836,13 +12794,13 @@ snapshots:
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1(supports-color@10.2.2)
+      sumchecker: 3.0.1
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0(supports-color@10.2.2)':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       env-paths: 2.2.1
@@ -12850,13 +12808,13 @@ snapshots:
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1(supports-color@10.2.2)
+      sumchecker: 3.0.1
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/notarize@2.5.0(supports-color@10.2.2)':
+  '@electron/notarize@2.5.0':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 9.1.0
@@ -12864,7 +12822,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.3(supports-color@10.2.2)':
+  '@electron/osx-sign@1.3.3':
     dependencies:
       compare-version: 0.1.2
       debug: 4.4.3(supports-color@10.2.2)
@@ -12875,18 +12833,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@4.0.4(supports-color@10.2.2)':
+  '@electron/rebuild@4.0.4':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
       node-abi: 4.31.0
       node-api-version: 0.2.1
       node-gyp: 12.4.0
-      read-binary-file-arch: 1.0.6(supports-color@10.2.2)
+      read-binary-file-arch: 1.0.6
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/universal@2.0.3(supports-color@10.2.2)':
+  '@electron/universal@2.0.3':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
@@ -12898,7 +12856,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/windows-sign@1.2.2(supports-color@10.2.2)':
+  '@electron/windows-sign@1.2.2':
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3(supports-color@10.2.2)
@@ -12914,9 +12872,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin@11.13.5(supports-color@10.2.2)':
+  '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/runtime': 7.29.2
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -12946,10 +12904,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)':
+  '@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.3
-      '@emotion/babel-plugin': 11.13.5(supports-color@10.2.2)
+      '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
@@ -12972,12 +12930,12 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.3
-      '@emotion/babel-plugin': 11.13.5(supports-color@10.2.2)
+      '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
       '@emotion/utils': 1.4.2
@@ -13217,36 +13175,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
     dependencies:
-      eslint: 8.57.1(supports-color@10.2.2)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1(supports-color@5.5.0))':
-    dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/eslintrc@2.1.4(supports-color@10.2.2)':
+  '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@10.2.2)
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/eslintrc@2.1.4(supports-color@5.5.0)':
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -13314,9 +13253,9 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google-cloud/bigquery@8.1.1(supports-color@10.2.2)':
+  '@google-cloud/bigquery@8.1.1':
     dependencies:
-      '@google-cloud/common': 6.0.0(supports-color@10.2.2)
+      '@google-cloud/common': 6.0.0
       '@google-cloud/paginator': 6.0.0
       '@google-cloud/precise-date': 5.0.0
       '@google-cloud/promisify': 5.0.0
@@ -13325,30 +13264,30 @@ snapshots:
       duplexify: 4.1.3
       extend: 3.0.2
       stream-events: 1.0.5
-      teeny-request: 10.1.0(supports-color@10.2.2)
+      teeny-request: 10.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/cloud-sql-connector@1.8.4(supports-color@10.2.2)':
+  '@google-cloud/cloud-sql-connector@1.8.4':
     dependencies:
-      '@googleapis/sqladmin': 31.1.0(supports-color@10.2.2)
-      gaxios: 7.1.2(supports-color@10.2.2)
-      google-auth-library: 10.4.0(supports-color@10.2.2)
+      '@googleapis/sqladmin': 31.1.0
+      gaxios: 7.1.2
+      google-auth-library: 10.4.0
       p-throttle: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/common@6.0.0(supports-color@10.2.2)':
+  '@google-cloud/common@6.0.0':
     dependencies:
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.1.0
       arrify: 2.0.1
       duplexify: 4.1.3
       extend: 3.0.2
-      google-auth-library: 10.4.0(supports-color@10.2.2)
+      google-auth-library: 10.4.0
       html-entities: 2.6.0
-      retry-request: 8.0.2(supports-color@10.2.2)
-      teeny-request: 10.1.0(supports-color@10.2.2)
+      retry-request: 8.0.2
+      teeny-request: 10.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13371,7 +13310,7 @@ snapshots:
 
   '@google-cloud/promisify@5.0.0': {}
 
-  '@google-cloud/storage@7.19.0(encoding@0.1.13)(supports-color@10.2.2)':
+  '@google-cloud/storage@7.19.0(encoding@0.1.13)':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -13380,21 +13319,21 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.5.8
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@10.2.2)
-      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@10.2.2)
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
       html-entities: 2.6.0
       mime: 3.0.0
       p-limit: 3.1.0
-      retry-request: 7.0.2(encoding@0.1.13)(supports-color@10.2.2)
-      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@10.2.2)
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@googleapis/sqladmin@31.1.0(supports-color@10.2.2)':
+  '@googleapis/sqladmin@31.1.0':
     dependencies:
-      googleapis-common: 8.0.2-rc.0(supports-color@10.2.2)
+      googleapis-common: 8.0.2-rc.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13438,18 +13377,10 @@ snapshots:
       hono: 4.7.11
       zod: 4.2.1
 
-  '@humanwhocodes/config-array@0.13.0(supports-color@10.2.2)':
+  '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@humanwhocodes/config-array@0.13.0(supports-color@5.5.0)':
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13703,7 +13634,7 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubernetes/client-node@1.4.0(encoding@0.1.13)(supports-color@10.2.2)':
+  '@kubernetes/client-node@1.4.0(encoding@0.1.13)':
     dependencies:
       '@types/js-yaml': 4.0.9
       '@types/node': 24.12.0
@@ -13717,7 +13648,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       openid-client: 6.8.4
       rfc4648: 1.5.4
-      socks-proxy-agent: 8.0.5(supports-color@10.2.2)
+      socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
       tar-fs: 3.1.2
       ws: 8.18.2
@@ -13730,7 +13661,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@kwsites/file-exists@1.1.1(supports-color@10.2.2)':
+  '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -13759,7 +13690,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@malept/flatpak-bundler@0.4.0(supports-color@10.2.2)':
+  '@malept/flatpak-bundler@0.4.0':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 9.1.0
@@ -13768,7 +13699,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/mdx@3.1.1(supports-color@10.2.2)':
+  '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
@@ -13780,14 +13711,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.15.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0(supports-color@10.2.2)
-      remark-mdx: 3.1.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -13802,7 +13733,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.2.1)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.2.1)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.20.0
@@ -13812,8 +13743,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.5.2(express@5.2.1(supports-color@10.2.2))
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.27
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -13841,19 +13772,19 @@ snapshots:
 
   '@mui/core-downloads-tracker@7.1.0': {}
 
-  '@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
+  '@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.3
-      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.3
       '@mui/core-downloads-tracker': 7.1.0
-      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/types': 7.4.2(@types/react@18.3.23)
       '@mui/utils': 7.1.0(@types/react@18.3.23)(react@18.3.1)
       '@popperjs/core': 2.11.8
@@ -13866,8 +13797,8 @@ snapshots:
       react-is: 19.1.0
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@types/react': 18.3.23
 
   '@mui/private-theming@7.1.0(@types/react@18.3.23)(react@18.3.1)':
@@ -13879,7 +13810,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@mui/styled-engine@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)':
+  '@mui/styled-engine@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
@@ -13889,14 +13820,14 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
 
-  '@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)':
+  '@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mui/private-theming': 7.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@mui/styled-engine': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@mui/styled-engine': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.4.2(@types/react@18.3.23)
       '@mui/utils': 7.1.0(@types/react@18.3.23)(react@18.3.1)
       clsx: 2.1.1
@@ -13904,8 +13835,8 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@types/react': 18.3.23
 
   '@mui/types@7.4.2(@types/react@18.3.23)':
@@ -13926,14 +13857,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@mui/x-data-grid-premium@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/x-data-grid-premium@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.3
-      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 7.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@mui/x-data-grid': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/x-data-grid-pro': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-data-grid': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-data-grid-pro': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/x-internals': 8.4.0(@types/react@18.3.23)(react@18.3.1)
       '@mui/x-license': 8.4.0(@types/react@18.3.23)(react@18.3.1)
       '@types/format-util': 1.0.4
@@ -13944,18 +13875,18 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       reselect: 5.1.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid-pro@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/x-data-grid-pro@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 7.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@mui/x-data-grid': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-data-grid': 8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/x-internals': 8.4.0(@types/react@18.3.23)(react@18.3.1)
       '@mui/x-license': 8.4.0(@types/react@18.3.23)(react@18.3.1)
       '@types/format-util': 1.0.4
@@ -13965,16 +13896,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       reselect: 5.1.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/x-data-grid@8.4.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 7.1.0(@types/react@18.3.23)(react@18.3.1)
       '@mui/x-internals': 8.4.0(@types/react@18.3.23)(react@18.3.1)
       clsx: 2.1.1
@@ -13984,8 +13915,8 @@ snapshots:
       reselect: 5.1.1
       use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -14092,59 +14023,59 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@10.2.2)':
+  '@opentelemetry/auto-instrumentations-node@0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-amqplib': 0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-aws-lambda': 0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-aws-sdk': 0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-bunyan': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-cassandra-driver': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-connect': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-cucumber': 0.37.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-dataloader': 0.38.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-dns': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-express': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-fs': 0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-generic-pool': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-graphql': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-grpc': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-hapi': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-host-metrics': 0.4.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-http': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-ioredis': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-kafkajs': 0.30.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-knex': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-koa': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-memcached': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-mongodb': 0.74.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-mongoose': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-mysql': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-mysql2': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-nestjs-core': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-net': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-openai': 0.19.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-oracledb': 0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-pg': 0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-pino': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-redis': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-restify': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-router': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-runtime-node': 0.34.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-socket.io': 0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-tedious': 0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-undici': 0.31.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/instrumentation-winston': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.68.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-lambda': 0.73.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-sdk': 0.76.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-bunyan': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.64.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cucumber': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dns': 0.64.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.64.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-host-metrics': 0.4.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.30.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-memcached': 0.64.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.74.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-nestjs-core': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-net': 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-openai': 0.19.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-oracledb': 0.46.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.73.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pino': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-restify': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-router': 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-runtime-node': 0.34.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-socket.io': 0.68.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-winston': 0.65.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-alibaba-cloud': 0.36.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-aws': 2.21.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-azure': 0.29.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-container': 0.8.12(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resource-detector-gcp': 0.56.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/resource-detector-gcp': 0.56.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14269,274 +14200,274 @@ snapshots:
       '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/instrumentation-amqplib@0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-amqplib@0.68.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-aws-lambda@0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-aws-lambda@0.73.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-aws-xray': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/aws-lambda': 8.10.161
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-aws-sdk@0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-aws-sdk@0.76.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-bunyan@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-bunyan@0.66.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
       '@types/bunyan': 1.8.11
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-cassandra-driver@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-cassandra-driver@0.66.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-connect@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-connect@0.64.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-cucumber@0.37.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-cucumber@0.37.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dataloader@0.38.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-dataloader@0.38.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dns@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-dns@0.64.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-fs@0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-fs@0.40.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-generic-pool@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-generic-pool@0.64.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-graphql@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-graphql@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-grpc@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-grpc@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-hapi@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-hapi@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-host-metrics@0.4.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-host-metrics@0.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       systeminformation: 5.33.6
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-ioredis@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.38.3
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-kafkajs@0.30.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-kafkajs@0.30.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-knex@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-knex@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-koa@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-koa@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-lru-memoizer@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-lru-memoizer@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-memcached@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-memcached@0.64.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/memcached': 2.2.10
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongodb@0.74.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-mongodb@0.74.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongoose@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-mongoose@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql2@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-mysql2@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.42.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-mysql@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/mysql': 2.15.27
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-nestjs-core@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-nestjs-core@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-net@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-net@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-openai@0.19.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-openai@0.19.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-oracledb@0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-oracledb@0.46.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/oracledb': 6.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-pg@0.73.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.42.0(@opentelemetry/api@1.9.1)
       '@types/pg': 8.15.6
@@ -14544,108 +14475,108 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pino@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-pino@0.67.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.38.3
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-restify@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-restify@0.66.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-router@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-router@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-runtime-node@0.34.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-runtime-node@0.34.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-socket.io@0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-socket.io@0.68.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-tedious@0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-tedious@0.40.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-undici@0.31.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-undici@0.31.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-winston@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation-winston@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.203.0
       import-in-the-middle: 1.14.2
-      require-in-the-middle: 7.5.2(supports-color@10.2.2)
+      require-in-the-middle: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.215.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1(supports-color@10.2.2)
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1(supports-color@10.2.2)
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14732,12 +14663,12 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/resource-detector-gcp@0.56.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/resource-detector-gcp@0.56.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      gcp-metadata: 8.1.2(supports-color@10.2.2)
+      gcp-metadata: 8.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14787,7 +14718,7 @@ snapshots:
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
@@ -14805,7 +14736,7 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
@@ -15101,14 +15032,14 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@react-scan/vite-plugin-react-scan@0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(supports-color@10.2.2))(supports-color@10.2.2)(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))':
+  '@react-scan/vite-plugin-react-scan@0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1))(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.27.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.27.3
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.27.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.27.3)
       babel-plugin-add-react-displayname: 0.0.5
       cheerio: 1.2.0
-      react-scan: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(supports-color@10.2.2)
+      react-scan: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)
       vite: 5.4.19(@types/node@24.12.0)(lightningcss@1.31.0)
     transitivePeerDependencies:
       - supports-color
@@ -15783,9 +15714,9 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 5.4.19(@types/node@24.12.0)(lightningcss@1.31.0)
 
-  '@tavily/core@0.7.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@tavily/core@0.7.6':
     dependencies:
-      axios: 1.9.0(debug@4.4.3(supports-color@10.2.2))
+      axios: 1.9.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-tiktoken: 1.0.21
     transitivePeerDependencies:
@@ -15794,9 +15725,9 @@ snapshots:
 
   '@tediousjs/connection-string@0.5.0': {}
 
-  '@testcontainers/postgresql@12.0.3(supports-color@10.2.2)':
+  '@testcontainers/postgresql@12.0.3':
     dependencies:
-      testcontainers: 12.0.3(supports-color@10.2.2)
+      testcontainers: 12.0.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -15837,11 +15768,11 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@traceloop/instrumentation-anthropic@0.20.0(supports-color@10.2.2)':
+  '@traceloop/instrumentation-anthropic@0.20.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@traceloop/ai-semantic-conventions': 0.20.0
       tslib: 2.8.1
@@ -16110,11 +16041,11 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/mssql@9.1.7(supports-color@10.2.2)':
+  '@types/mssql@9.1.7':
     dependencies:
       '@types/node': 24.0.0
       tarn: 3.0.2
-      tedious: 18.6.1(supports-color@10.2.2)
+      tedious: 18.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16287,36 +16218,16 @@ snapshots:
       '@types/node': 24.12.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3))(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@10.2.2)
-      eslint: 8.57.1(supports-color@10.2.2)
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.8.3)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.1(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -16327,15 +16238,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3))(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.0(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.34.0
-      '@typescript-eslint/type-utils': 8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.34.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.0
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -16344,45 +16255,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@10.2.2)
-      eslint: 8.57.1(supports-color@10.2.2)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@5.5.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.1(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.34.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
-      '@typescript-eslint/typescript-estree': 8.34.0(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.0
       debug: 4.4.1(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.34.0(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.34.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.34.0
@@ -16405,36 +16303,24 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.34.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@5.5.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@5.5.0)
-      ts-api-utils: 1.4.3(typescript@5.8.3)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.34.0(supports-color@10.2.2)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@8.57.1)(typescript@5.8.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -16444,7 +16330,7 @@ snapshots:
 
   '@typescript-eslint/types@8.34.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -16459,24 +16345,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.21.0(supports-color@5.5.0)(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.34.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@5.5.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.8.3)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.34.0(supports-color@10.2.2)(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.34.0(supports-color@10.2.2)(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.34.0(typescript@5.8.3)
       '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/visitor-keys': 8.34.0
@@ -16490,41 +16361,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@10.2.2)(typescript@5.8.3)
-      eslint: 8.57.1(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      eslint: 8.57.1
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.34.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1(supports-color@5.5.0))
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.0
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@5.5.0)(typescript@5.8.3)
-      eslint: 8.57.1(supports-color@5.5.0)
-      semver: 7.7.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@8.34.0(eslint@8.57.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
-      '@typescript-eslint/typescript-estree': 8.34.0(supports-color@10.2.2)(typescript@5.8.3)
-      eslint: 8.57.1(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
+      eslint: 8.57.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -16539,9 +16396,9 @@ snapshots:
       '@typescript-eslint/types': 8.34.0
       eslint-visitor-keys: 4.2.1
 
-  '@typespec/ts-http-runtime@0.2.3(supports-color@10.2.2)':
+  '@typespec/ts-http-runtime@0.2.3':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -16566,11 +16423,11 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@4.5.0(supports-color@10.2.2)(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))':
+  '@vitejs/plugin-react@4.5.0(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))':
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.3(supports-color@10.2.2))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.3(supports-color@10.2.2))
+      '@babel/core': 7.27.3
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.3)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.3)
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -16699,7 +16556,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2(supports-color@10.2.2):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -16842,33 +16699,33 @@ snapshots:
       - encoding
       - openapi-types
 
-  app-builder-lib@26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2):
+  app-builder-lib@26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
-      '@electron/get': 3.1.0(supports-color@10.2.2)
-      '@electron/notarize': 2.5.0(supports-color@10.2.2)
-      '@electron/osx-sign': 1.3.3(supports-color@10.2.2)
-      '@electron/rebuild': 4.0.4(supports-color@10.2.2)
-      '@electron/universal': 2.0.3(supports-color@10.2.2)
-      '@malept/flatpak-bundler': 0.4.0(supports-color@10.2.2)
+      '@electron/get': 3.1.0
+      '@electron/notarize': 2.5.0
+      '@electron/osx-sign': 1.3.3
+      '@electron/rebuild': 4.0.4
+      '@electron/universal': 2.0.3
+      '@malept/flatpak-bundler': 0.4.0
       '@noble/hashes': 2.2.0
       '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
       ajv: 8.20.0
       asn1js: 3.0.10
       async-exit-hook: 2.0.1
-      builder-util: 26.15.0(supports-color@10.2.2)
-      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      builder-util: 26.15.0
+      builder-util-runtime: 9.7.0
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3(supports-color@10.2.2)
-      dmg-builder: 26.15.2(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
+      dmg-builder: 26.15.2(electron-builder-squirrel-windows@26.15.2)
       dotenv: 16.5.0
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.15.2(dmg-builder@26.15.2)(supports-color@10.2.2)
-      electron-publish: 26.15.1(supports-color@10.2.2)
+      electron-builder-squirrel-windows: 26.15.2(dmg-builder@26.15.2)
+      electron-publish: 26.15.1
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
@@ -17064,17 +16921,17 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.3(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)):
+  astro-expressive-code@0.41.3(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)):
     dependencies:
-      astro: 5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
+      astro: 5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
       rehype-expressive-code: 0.41.3
 
-  astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0):
+  astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.5
-      '@astrojs/markdown-remark': 6.3.9(supports-color@10.2.2)
-      '@astrojs/telemetry': 3.3.0(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 6.3.9
+      '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 3.0.1
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
@@ -17123,7 +16980,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.6.0
       unist-util-visit: 5.0.0
-      unstorage: 1.17.2(@azure/identity@4.10.0(supports-color@10.2.2))(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.2(@azure/identity@4.10.0)(idb-keyval@6.2.2)(ioredis@5.11.1)
       vfile: 6.0.3
       vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.0)(tsx@4.19.4)(yaml@2.9.0)
       vitefu: 1.1.1(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.0)(tsx@4.19.4)(yaml@2.9.0))
@@ -17203,17 +17060,9 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.9.0(debug@4.4.3(supports-color@10.2.2)):
+  axios@1.9.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3(supports-color@10.2.2))
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.9.0(debug@4.4.3(supports-color@5.5.0)):
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3(supports-color@5.5.0))
+      follow-redirects: 1.15.9
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -17334,7 +17183,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.2(supports-color@10.2.2):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -17424,22 +17273,22 @@ snapshots:
   buildcheck@0.0.7:
     optional: true
 
-  builder-util-runtime@9.7.0(supports-color@10.2.2):
+  builder-util-runtime@9.7.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       sax: 1.4.3
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.15.0(supports-color@10.2.2):
+  builder-util@26.15.0:
     dependencies:
       '@types/debug': 4.1.12
-      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 10.1.0
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-yaml: 4.1.1
       sanitize-filename: 1.6.4
@@ -17467,7 +17316,7 @@ snapshots:
 
   cac@6.7.14: {}
 
-  cacache@15.3.0(bluebird@3.7.2):
+  cacache@15.3.0:
     dependencies:
       '@npmcli/fs': 1.1.1
       '@npmcli/move-file': 1.1.2
@@ -17482,7 +17331,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1(bluebird@3.7.2)
+      promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.2.1
@@ -18225,12 +18074,6 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  debug@4.4.1(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
-
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -18242,12 +18085,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 10.2.2
-
-  debug@4.4.3(supports-color@5.5.0):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 5.5.0
 
   decimal.js@10.6.0: {}
 
@@ -18349,10 +18186,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dmg-builder@26.15.2(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2):
+  dmg-builder@26.15.2(electron-builder-squirrel-windows@26.15.2):
     dependencies:
-      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
-      builder-util: 26.15.0(supports-color@10.2.2)
+      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)
+      builder-util: 26.15.0
       fs-extra: 10.1.0
       js-yaml: 4.1.1
     transitivePeerDependencies:
@@ -18363,7 +18200,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  docker-modem@5.0.7(supports-color@10.2.2):
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       readable-stream: 3.6.2
@@ -18377,12 +18214,12 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
 
-  dockerode@5.0.0(supports-color@10.2.2):
+  dockerode@5.0.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7(supports-color@10.2.2)
+      docker-modem: 5.0.7
       protobufjs: 7.5.3
       tar-fs: 2.1.4
     transitivePeerDependencies:
@@ -18480,23 +18317,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.15.2(dmg-builder@26.15.2)(supports-color@10.2.2):
+  electron-builder-squirrel-windows@26.15.2(dmg-builder@26.15.2):
     dependencies:
-      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
-      builder-util: 26.15.0(supports-color@10.2.2)
-      electron-winstaller: 5.4.0(supports-color@10.2.2)
+      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)
+      builder-util: 26.15.0
+      electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.2(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2):
+  electron-builder@26.15.2(electron-builder-squirrel-windows@26.15.2):
     dependencies:
-      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
-      builder-util: 26.15.0(supports-color@10.2.2)
-      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      app-builder-lib: 26.15.2(dmg-builder@26.15.2)(electron-builder-squirrel-windows@26.15.2)
+      builder-util: 26.15.0
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       ci-info: 4.3.1
-      dmg-builder: 26.15.2(electron-builder-squirrel-windows@26.15.2)(supports-color@10.2.2)
+      dmg-builder: 26.15.2(electron-builder-squirrel-windows@26.15.2)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -18505,12 +18342,12 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-publish@26.15.1(supports-color@10.2.2):
+  electron-publish@26.15.1:
     dependencies:
       '@types/fs-extra': 9.0.13
       aws4: 1.13.2
-      builder-util: 26.15.0(supports-color@10.2.2)
-      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      builder-util: 26.15.0
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       form-data: 4.0.5
       fs-extra: 10.1.0
@@ -18521,9 +18358,9 @@ snapshots:
 
   electron-to-chromium@1.5.159: {}
 
-  electron-updater@6.8.9(supports-color@10.2.2):
+  electron-updater@6.8.9:
     dependencies:
-      builder-util-runtime: 9.7.0(supports-color@10.2.2)
+      builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
       js-yaml: 4.1.1
       lazy-val: 1.0.5
@@ -18534,7 +18371,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-winstaller@5.4.0(supports-color@10.2.2):
+  electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
       debug: 4.4.3(supports-color@10.2.2)
@@ -18542,15 +18379,15 @@ snapshots:
       lodash: 4.17.21
       temp: 0.9.4
     optionalDependencies:
-      '@electron/windows-sign': 1.2.2(supports-color@10.2.2)
+      '@electron/windows-sign': 1.2.2
     transitivePeerDependencies:
       - supports-color
 
-  electron@36.9.5(supports-color@10.2.2):
+  electron@36.9.5:
     dependencies:
-      '@electron/get': 2.0.3(supports-color@10.2.2)
+      '@electron/get': 2.0.3
       '@types/node': 22.15.34
-      extract-zip: 2.0.1(supports-color@10.2.2)
+      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18844,28 +18681,28 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.5(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-config-prettier@10.1.5(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
 
-  eslint-plugin-prettier@5.4.1(eslint-config-prettier@10.1.5(eslint@8.57.1(supports-color@5.5.0)))(eslint@8.57.1(supports-color@5.5.0))(prettier@3.5.3):
+  eslint-plugin-prettier@5.4.1(eslint-config-prettier@10.1.5(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
       prettier: 3.5.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.8
     optionalDependencies:
-      eslint-config-prettier: 10.1.5(eslint@8.57.1(supports-color@5.5.0))
+      eslint-config-prettier: 10.1.5(eslint@8.57.1)
 
-  eslint-plugin-react-hooks@5.2.0(eslint@8.57.1(supports-color@10.2.2)):
+  eslint-plugin-react-hooks@5.2.0(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
 
-  eslint-plugin-react-refresh@0.4.20(eslint@8.57.1(supports-color@10.2.2)):
+  eslint-plugin-react-refresh@0.4.20(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
 
-  eslint-plugin-react@7.37.5(eslint@8.57.1(supports-color@10.2.2)):
+  eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -18873,7 +18710,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 8.57.1(supports-color@10.2.2)
+      eslint: 8.57.1
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -18896,56 +18733,13 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@8.57.1(supports-color@10.2.2):
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/eslintrc': 2.1.4(supports-color@10.2.2)
+      '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0(supports-color@10.2.2)
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@10.2.2)
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@8.57.1(supports-color@5.5.0):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1(supports-color@5.5.0))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/eslintrc': 2.1.4(supports-color@5.5.0)
-      '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0(supports-color@5.5.0)
+      '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
@@ -19107,19 +18901,19 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@7.5.0(express@5.2.1(supports-color@10.2.2)):
+  express-rate-limit@7.5.0(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@10.2.2)
+      express: 5.2.1
 
-  express-rate-limit@8.5.2(express@5.2.1(supports-color@10.2.2)):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@10.2.2)
+      express: 5.2.1
       ip-address: 10.2.0
 
-  express@5.2.1(supports-color@10.2.2):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@10.2.2)
+      body-parser: 2.2.2
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -19129,7 +18923,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@10.2.2)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -19140,9 +18934,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@10.2.2)
-      send: 1.2.1(supports-color@10.2.2)
-      serve-static: 2.2.1(supports-color@10.2.2)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -19170,7 +18964,7 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extract-zip@2.0.1(supports-color@10.2.2):
+  extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       get-stream: 5.2.0
@@ -19281,7 +19075,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@10.2.2):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
@@ -19330,15 +19124,9 @@ snapshots:
 
   flattie@1.1.1: {}
 
-  follow-redirects@1.15.9(debug@4.4.3(supports-color@10.2.2)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+  follow-redirects@1.15.9: {}
 
-  follow-redirects@1.15.9(debug@4.4.3(supports-color@5.5.0)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@10.2.2)
 
@@ -19485,7 +19273,7 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
-  gaxios@6.7.1(encoding@0.1.13)(supports-color@10.2.2):
+  gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
@@ -19496,7 +19284,7 @@ snapshots:
       - encoding
       - supports-color
 
-  gaxios@7.1.2(supports-color@10.2.2):
+  gaxios@7.1.2:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
@@ -19504,26 +19292,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@6.1.1(encoding@0.1.13)(supports-color@10.2.2):
+  gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@10.2.2)
+      gaxios: 6.7.1(encoding@0.1.13)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gcp-metadata@7.0.1(supports-color@10.2.2):
+  gcp-metadata@7.0.1:
     dependencies:
-      gaxios: 7.1.2(supports-color@10.2.2)
+      gaxios: 7.1.2
       google-logging-utils: 1.1.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2(supports-color@10.2.2):
+  gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.2(supports-color@10.2.2)
+      gaxios: 7.1.2
       google-logging-utils: 1.1.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -19651,25 +19439,25 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@10.4.0(supports-color@10.2.2):
+  google-auth-library@10.4.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.2(supports-color@10.2.2)
-      gcp-metadata: 7.0.1(supports-color@10.2.2)
+      gaxios: 7.1.2
+      gcp-metadata: 7.0.1
       google-logging-utils: 1.1.1
-      gtoken: 8.0.0(supports-color@10.2.2)
+      gtoken: 8.0.0
       jws: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1(encoding@0.1.13)(supports-color@10.2.2):
+  google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@10.2.2)
-      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@10.2.2)
-      gtoken: 7.1.0(encoding@0.1.13)(supports-color@10.2.2)
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
@@ -19679,11 +19467,11 @@ snapshots:
 
   google-logging-utils@1.1.1: {}
 
-  googleapis-common@8.0.2-rc.0(supports-color@10.2.2):
+  googleapis-common@8.0.2-rc.0:
     dependencies:
       extend: 3.0.2
-      gaxios: 7.1.2(supports-color@10.2.2)
-      google-auth-library: 10.4.0(supports-color@10.2.2)
+      gaxios: 7.1.2
+      google-auth-library: 10.4.0
       qs: 6.14.1
       url-template: 2.0.8
     transitivePeerDependencies:
@@ -19709,17 +19497,17 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  gtoken@7.1.0(encoding@0.1.13)(supports-color@10.2.2):
+  gtoken@7.1.0(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@10.2.2)
+      gaxios: 6.7.1(encoding@0.1.13)
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gtoken@8.0.0(supports-color@10.2.2):
+  gtoken@8.0.0:
     dependencies:
-      gaxios: 7.1.2(supports-color@10.2.2)
+      gaxios: 7.1.2
       jws: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -19879,7 +19667,7 @@ snapshots:
       unist-util-visit: 5.0.0
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3(supports-color@10.2.2):
+  hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -19889,9 +19677,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.16
@@ -19914,7 +19702,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.7
       '@types/hast': 3.0.4
@@ -19923,9 +19711,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.16
@@ -20045,24 +19833,24 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@4.0.1(supports-color@10.2.2):
+  http-proxy-agent@4.0.1:
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2(supports-color@10.2.2)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  http-proxy-agent@5.0.0(supports-color@10.2.2):
+  http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2(supports-color@10.2.2)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2(supports-color@10.2.2):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@10.2.2)
@@ -20076,9 +19864,9 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1(supports-color@10.2.2):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -20174,20 +19962,20 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
-  inngest@4.18.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(express@5.2.1(supports-color@10.2.2))(h3@1.15.4)(hono@4.7.11)(next@14.2.33(@babel/core@7.27.3(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(zod@4.2.1):
+  inngest@4.18.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(express@5.2.1)(h3@1.15.4)(hono@4.7.11)(next@14.2.33(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(zod@4.2.1):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@inngest/ai': 0.1.4
       '@jpwilliams/waitgroup': 2.1.1
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/auto-instrumentations-node': 0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@10.2.2)
+      '@opentelemetry/auto-instrumentations-node': 0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.215.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.215.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@standard-schema/spec': 1.1.0
-      '@traceloop/instrumentation-anthropic': 0.20.0(supports-color@10.2.2)
+      '@traceloop/instrumentation-anthropic': 0.20.0
       '@types/debug': 4.1.12
       '@types/ms': 2.1.0
       canonicalize: 1.0.8
@@ -20200,10 +19988,10 @@ snapshots:
       ulid: 2.4.0
       zod: 4.2.1
     optionalDependencies:
-      express: 5.2.1(supports-color@10.2.2)
+      express: 5.2.1
       h3: 1.15.4
       hono: 4.7.11
-      next: 14.2.33(@babel/core@7.27.3(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.33(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -20241,7 +20029,7 @@ snapshots:
 
   iobuffer@5.4.0: {}
 
-  ioredis@5.11.1(supports-color@10.2.2):
+  ioredis@5.11.1:
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.1
@@ -20517,14 +20305,14 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jsdom@25.0.1(supports-color@10.2.2):
+  jsdom@25.0.1:
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
@@ -20981,13 +20769,13 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@9.1.0(bluebird@3.7.2)(supports-color@10.2.2):
+  make-fetch-happen@9.1.0:
     dependencies:
       agentkeepalive: 4.6.0
-      cacache: 15.3.0(bluebird@3.7.2)
+      cacache: 15.3.0
       http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1(supports-color@10.2.2)
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
       lru-cache: 6.0.0
       minipass: 3.3.6
@@ -20997,7 +20785,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@10.2.2)
+      socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
@@ -21029,13 +20817,13 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
 
-  mdast-util-directive@3.1.0(supports-color@10.2.2):
+  mdast-util-directive@3.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -21050,14 +20838,14 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2(supports-color@10.2.2):
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@10.2.2)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -21075,67 +20863,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@10.2.2):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -21143,7 +20931,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -21152,23 +20940,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@10.2.2):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21505,7 +21293,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@10.2.2):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@10.2.2)
@@ -21675,16 +21463,16 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2):
+  mongodb-memory-server-core@10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5):
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@10.2.2)
       find-cache-dir: 3.3.2
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.4.3)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       mongodb: 6.17.0(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
-      new-find-package-json: 2.0.0(supports-color@10.2.2)
+      new-find-package-json: 2.0.0
       semver: 7.7.3
       tar-stream: 3.2.0
       tslib: 2.8.1
@@ -21702,9 +21490,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2):
+  mongodb-memory-server@10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5):
     dependencies:
-      mongodb-memory-server-core: 10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2)
+      mongodb-memory-server-core: 10.4.3(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -21737,13 +21525,13 @@ snapshots:
       '@aws-sdk/credential-providers': 3.835.0
       socks: 2.8.5
 
-  mongoose@8.15.1(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)(supports-color@10.2.2):
+  mongoose@8.15.1(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.16.0(@aws-sdk/credential-providers@3.835.0)(socks@2.8.5)
       mpath: 0.9.0
-      mquery: 5.0.0(supports-color@10.2.2)
+      mquery: 5.0.0
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -21758,7 +21546,7 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mquery@5.0.0(supports-color@10.2.2):
+  mquery@5.0.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -21768,23 +21556,23 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mssql@11.0.1(supports-color@10.2.2):
+  mssql@11.0.1:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
       debug: 4.4.1(supports-color@5.5.0)
       rfdc: 1.4.1
       tarn: 3.0.2
-      tedious: 18.6.1(supports-color@10.2.2)
+      tedious: 18.6.1
     transitivePeerDependencies:
       - supports-color
 
-  mui-chips-input@9.0.0(98441616543936ce9d0e0aee190b2ba9):
+  mui-chips-input@9.0.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2)
-      '@mui/icons-material': 7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
-      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/icons-material': 7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -21832,7 +21620,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  new-find-package-json@2.0.0(supports-color@10.2.2):
+  new-find-package-json@2.0.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -21840,7 +21628,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.33(@babel/core@7.27.3(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.33(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.33
       '@swc/helpers': 0.5.5
@@ -21850,7 +21638,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.27.3(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -21926,12 +21714,12 @@ snapshots:
       undici: 6.26.0
       which: 6.0.1
 
-  node-gyp@8.4.1(bluebird@3.7.2)(supports-color@10.2.2):
+  node-gyp@8.4.1:
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0(bluebird@3.7.2)(supports-color@10.2.2)
+      make-fetch-happen: 9.1.0
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
@@ -22574,9 +22362,7 @@ snapshots:
 
   progress@2.0.3: {}
 
-  promise-inflight@1.0.1(bluebird@3.7.2):
-    optionalDependencies:
-      bluebird: 3.7.2
+  promise-inflight@1.0.1:
     optional: true
 
   promise-retry@2.0.1:
@@ -22601,9 +22387,9 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  properties-reader@3.0.1(supports-color@10.2.2):
+  properties-reader@3.0.1:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@10.2.2)
+      '@kwsites/file-exists': 1.1.1
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -22757,9 +22543,9 @@ snapshots:
       '@remix-run/router': 1.23.0
       react: 18.3.1
 
-  react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(supports-color@10.2.2):
+  react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1):
     dependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
+      '@babel/core': 7.27.3
       '@babel/generator': 7.27.3
       '@babel/types': 7.28.5
       '@preact/signals': 1.3.4(preact@10.29.1)
@@ -22808,7 +22594,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  read-binary-file-arch@1.0.6(supports-color@10.2.2):
+  read-binary-file-arch@1.0.6:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -22956,11 +22742,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0(supports-color@10.2.2):
+  rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.7
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3(supports-color@10.2.2)
+      hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22982,37 +22768,37 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  remark-directive@3.0.1(supports-color@10.2.2):
+  remark-directive@3.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0(supports-color@10.2.2)
+      mdast-util-directive: 3.1.0
       micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1(supports-color@10.2.2):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1(supports-color@10.2.2):
+  remark-mdx@3.1.1:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@10.2.2):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -23047,7 +22833,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2(supports-color@10.2.2):
+  require-in-the-middle@7.5.2:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4
@@ -23055,7 +22841,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  require-in-the-middle@8.0.1(supports-color@10.2.2):
+  require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4
@@ -23131,19 +22917,19 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-request@7.0.2(encoding@0.1.13)(supports-color@10.2.2):
+  retry-request@7.0.2(encoding@0.1.13):
     dependencies:
       '@types/request': 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@10.2.2)
+      teeny-request: 9.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  retry-request@8.0.2(supports-color@10.2.2):
+  retry-request@8.0.2:
     dependencies:
       extend: 3.0.2
-      teeny-request: 10.1.0(supports-color@10.2.2)
+      teeny-request: 10.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23231,7 +23017,7 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0(supports-color@10.2.2):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
@@ -23317,7 +23103,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  send@1.2.1(supports-color@10.2.2):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
@@ -23340,12 +23126,12 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
-  serve-static@2.2.1(supports-color@10.2.2):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@10.2.2)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -23565,16 +23351,16 @@ snapshots:
 
   smol-toml@1.5.2: {}
 
-  socks-proxy-agent@6.2.1(supports-color@10.2.2):
+  socks-proxy-agent@6.2.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
       socks: 2.8.5
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  socks-proxy-agent@8.0.5(supports-color@10.2.2):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@10.2.2)
@@ -23618,14 +23404,14 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
-  sqlite3@5.1.7(bluebird@3.7.2)(supports-color@10.2.2):
+  sqlite3@5.1.7:
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
       tar: 6.2.1
     optionalDependencies:
-      node-gyp: 8.4.1(bluebird@3.7.2)(supports-color@10.2.2)
+      node-gyp: 8.4.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -23668,12 +23454,12 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  starlight-openapi@0.22.1(@astrojs/markdown-remark@6.3.9(supports-color@10.2.2))(@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2))(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(openapi-types@12.1.3):
+  starlight-openapi@0.22.1(@astrojs/markdown-remark@6.3.9)(@astrojs/starlight@0.36.2(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)))(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(openapi-types@12.1.3):
     dependencies:
-      '@astrojs/markdown-remark': 6.3.9(supports-color@10.2.2)
-      '@astrojs/starlight': 0.36.2(astro@5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 6.3.9
+      '@astrojs/starlight': 0.36.2(astro@5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0))
       '@readme/openapi-parser': 4.1.2(openapi-types@12.1.3)
-      astro: 5.15.9(@azure/identity@4.10.0(supports-color@10.2.2))(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(supports-color@10.2.2)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
+      astro: 5.15.9(@azure/identity@4.10.0)(@types/node@24.12.0)(idb-keyval@6.2.2)(ioredis@5.11.1)(jiti@2.6.1)(lightningcss@1.31.0)(rollup@4.41.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.9.0)
       github-slugger: 2.0.0
       url-template: 3.1.1
     transitivePeerDependencies:
@@ -23708,10 +23494,10 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
-  streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.2.2):
+  streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       clsx: 2.1.1
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.1
       mermaid: 11.13.0
@@ -23720,8 +23506,8 @@ snapshots:
       rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remend: 1.3.0
       tailwind-merge: 3.4.0
@@ -23863,20 +23649,17 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.1(@babel/core@7.27.3(supports-color@10.2.2))(babel-plugin-macros@3.1.0)(react@18.3.1):
+  styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.27.3(supports-color@10.2.2)
-      babel-plugin-macros: 3.1.0
     optional: true
 
   stylis@4.2.0: {}
 
   stylis@4.3.6: {}
 
-  sumchecker@3.0.1(supports-color@10.2.2):
+  sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -24001,11 +23784,11 @@ snapshots:
 
   tarn@3.0.2: {}
 
-  tedious@18.6.1(supports-color@10.2.2):
+  tedious@18.6.1:
     dependencies:
-      '@azure/core-auth': 1.9.0(supports-color@10.2.2)
-      '@azure/identity': 4.10.0(supports-color@10.2.2)
-      '@azure/keyvault-keys': 4.9.0(supports-color@10.2.2)
+      '@azure/core-auth': 1.9.0
+      '@azure/identity': 4.10.0
+      '@azure/keyvault-keys': 4.9.0
       '@js-joda/core': 5.6.5
       '@types/node': 24.12.0
       bl: 6.1.0
@@ -24016,19 +23799,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@10.1.0(supports-color@10.2.2):
+  teeny-request@10.1.0:
     dependencies:
-      http-proxy-agent: 5.0.0(supports-color@10.2.2)
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       node-fetch: 3.3.2
       stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@9.0.0(encoding@0.1.13)(supports-color@10.2.2):
+  teeny-request@9.0.0(encoding@0.1.13):
     dependencies:
-      http-proxy-agent: 5.0.0(supports-color@10.2.2)
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.1
@@ -24059,7 +23842,7 @@ snapshots:
 
   temporal-spec@0.2.4: {}
 
-  testcontainers@12.0.3(supports-color@10.2.2):
+  testcontainers@12.0.3:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
@@ -24068,10 +23851,10 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3(supports-color@10.2.2)
       docker-compose: 1.4.2
-      dockerode: 5.0.0(supports-color@10.2.2)
+      dockerode: 5.0.0
       get-port: 7.2.0
       proper-lockfile: 4.1.2
-      properties-reader: 3.0.1(supports-color@10.2.2)
+      properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
@@ -24468,7 +24251,7 @@ snapshots:
       webpack-virtual-modules: 0.6.2
     optional: true
 
-  unstorage@1.17.2(@azure/identity@4.10.0(supports-color@10.2.2))(idb-keyval@6.2.2)(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.2(@azure/identity@4.10.0)(idb-keyval@6.2.2)(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -24479,9 +24262,9 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.1
     optionalDependencies:
-      '@azure/identity': 4.10.0(supports-color@10.2.2)
+      '@azure/identity': 4.10.0
       idb-keyval: 6.2.2
-      ioredis: 5.11.1(supports-color@10.2.2)
+      ioredis: 5.11.1
 
   untildify@4.0.0: {}
 
@@ -24845,7 +24628,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.1.9(@types/node@24.0.0)(lightningcss@1.31.0)(supports-color@10.2.2):
+  vite-node@2.1.9(@types/node@24.0.0)(lightningcss@1.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
@@ -24863,7 +24646,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@24.12.0)(lightningcss@1.31.0)(supports-color@10.2.2):
+  vite-node@2.1.9(@types/node@24.12.0)(lightningcss@1.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
@@ -24921,7 +24704,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.0)(tsx@4.19.4)(yaml@2.9.0)
 
-  vitest@2.1.9(@types/node@24.0.0)(jsdom@25.0.1(supports-color@10.2.2))(lightningcss@1.31.0)(supports-color@10.2.2):
+  vitest@2.1.9(@types/node@24.0.0)(jsdom@25.0.1)(lightningcss@1.31.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.0.0)(lightningcss@1.31.0))
@@ -24941,11 +24724,11 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.19(@types/node@24.0.0)(lightningcss@1.31.0)
-      vite-node: 2.1.9(@types/node@24.0.0)(lightningcss@1.31.0)(supports-color@10.2.2)
+      vite-node: 2.1.9(@types/node@24.0.0)(lightningcss@1.31.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.0
-      jsdom: 25.0.1(supports-color@10.2.2)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -24957,7 +24740,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.12.0)(jsdom@25.0.1(supports-color@10.2.2))(lightningcss@1.31.0)(supports-color@10.2.2):
+  vitest@2.1.9(@types/node@24.12.0)(jsdom@25.0.1)(lightningcss@1.31.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
@@ -24977,11 +24760,11 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.19(@types/node@24.12.0)(lightningcss@1.31.0)
-      vite-node: 2.1.9(@types/node@24.12.0)(lightningcss@1.31.0)(supports-color@10.2.2)
+      vite-node: 2.1.9(@types/node@24.12.0)(lightningcss@1.31.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
-      jsdom: 25.0.1(supports-color@10.2.2)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Notebooks join the repo by adopting Deepnote's OPEN project format rather
than inventing one: the committed file is a single-notebook .deepnote
(YAML), validated against @deepnote/blocks' canonical zod schema before
every write, openable in Deepnote and convertible to .ipynb/Quarto/percent/
Marimo with npx @deepnote/convert. Outputs are stripped (their own
source-vs-snapshot split + nbstripout); serialization is byte-stable
(deterministic v5-style uuids) so blob-sha levelling works.

Architecture (apps.md §24): the GCS store REMAINS the durable hot working
copy the editor autosaves into; git gets debounced checkpoints (30s quiet /
5min max, flush on delete) — §19's granularity rule made concrete. Paths
follow consoles' owner-first layout (notebooks/<slug>.deepnote, private
under users/<owner>/notebooks/); renames and access flips relocate the file
in the next checkpoint. Push-sync flows external edits into the store with
an editor-wins conflict guard (git history keeps the losing version).
Hooks: update/create/delete routes, the agent notebook tool, the folder/
move registrar, notifyRepoPushed.

Migration checkpoints all existing notebooks (non-destructive) and the
deploy migrate step gains NOTEBOOK_GCS_BUCKET — the third runner-env bug of
this class, caught before shipping this time.

Tests: 7 new specs (stripped serialization + idempotence, private paths,
access-flip file moves, delete, external-edit sync, editor-wins conflict,
re-runnable adoption). Apps suite 138 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat
