### PR TITLE
fix(apps): stop a failing live binding from re-querying BigQuery forever

### DIFF
--- a/api/src/apps/dev-server.service.ts
+++ b/api/src/apps/dev-server.service.ts
@@ -302,7 +302,14 @@ const makoData = {
                 body: JSON.stringify({ slug: ${JSON.stringify(slug)}, name }),
                 // A materialized query can be slow (a heavy dashboard mart runs
                 // for a minute); give it room rather than failing the table.
-                signal: AbortSignal.timeout(180000),
+                // Longer than the API's own query ceiling (300s), deliberately:
+                // when this was SHORTER, every binding taking 180-300s was
+                // unsatisfiable through this path — the box abandoned a request
+                // the API was still serving, so the answer could never arrive,
+                // while the warehouse job it started ran on and billed. The
+                // client must outlast the server it is waiting for, or it turns
+                // slow into impossible.
+                signal: AbortSignal.timeout(330000),
               },
             );
             if (!upstream.ok) {

--- a/api/src/apps/live-binding-guard.test.ts
+++ b/api/src/apps/live-binding-guard.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The live-binding circuit breaker.
+ *
+ * What must hold, stated as the prod incident it exists to prevent: a binding
+ * whose query keeps failing must stop reaching the warehouse, and a page that
+ * mounts several tables at once must start ONE query, not one per table.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../logging", () => ({
+  loggers: { api: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) },
+}));
+
+import {
+  LiveBindingCoolingDown,
+  cooldownMsFor,
+  resetLiveBindingGuardForTests,
+  withLiveBindingGuard,
+} from "./live-binding-guard";
+
+const target = { workspaceId: "w1", slug: "app", name: "email_links" };
+
+beforeEach(() => {
+  delete process.env.REDIS_URL; // memory store
+  resetLiveBindingGuardForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("cooldownMsFor", () => {
+  it("doubles per consecutive failure and caps", () => {
+    expect(cooldownMsFor(0)).toBe(0);
+    expect(cooldownMsFor(1)).toBe(60_000);
+    expect(cooldownMsFor(2)).toBe(120_000);
+    expect(cooldownMsFor(3)).toBe(240_000);
+    // Capped, and stays capped however long the streak runs.
+    expect(cooldownMsFor(10)).toBe(15 * 60_000);
+    expect(cooldownMsFor(100)).toBe(15 * 60_000);
+  });
+});
+
+describe("the storm this prevents", () => {
+  it("turns a retry storm into a handful of queries", async () => {
+    let queries = 0;
+    const attempt = () =>
+      withLiveBindingGuard(target, async () => {
+        queries += 1;
+        throw new Error("Query timed out after 300 seconds.");
+      }).catch(() => undefined);
+
+    // The observed storm: a request every 30s for 48 minutes.
+    await attempt();
+    for (let elapsed = 0; elapsed < 48 * 60_000; elapsed += 30_000) {
+      vi.setSystemTime(Date.now() + 30_000);
+      await attempt();
+    }
+
+    // 41 attempts reached BigQuery in the real incident. With 1m/2m/4m/8m/15m
+    // backoff the same 48 minutes admits 7 — at t=0, 1m, 3m, 7m, 15m, 31m, 46m.
+    // Asserted exactly: "fewer" would pass even if the backoff barely worked.
+    expect(queries).toBe(7);
+  });
+
+  it("refuses without running the query, and says how long to wait", async () => {
+    await expect(
+      withLiveBindingGuard(target, async () => {
+        throw new Error("BigQuery said no");
+      }),
+    ).rejects.toThrow("BigQuery said no");
+
+    let ran = false;
+    const refused = await withLiveBindingGuard(target, async () => {
+      ran = true;
+      return "never";
+    }).catch(e => e);
+
+    expect(ran).toBe(false); // the warehouse was not touched
+    expect(refused).toBeInstanceOf(LiveBindingCoolingDown);
+    expect(refused.retryAfterMs).toBeGreaterThan(0);
+    expect(refused.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(refused.failures).toBe(1);
+    // The reason survives, so the user is told what actually went wrong.
+    expect(refused.message).toBe("BigQuery said no");
+  });
+
+  it("lets the binding through again once the window passes", async () => {
+    await withLiveBindingGuard(target, async () => {
+      throw new Error("boom");
+    }).catch(() => undefined);
+
+    vi.setSystemTime(Date.now() + 61_000);
+    await expect(
+      withLiveBindingGuard(target, async () => "fresh parquet"),
+    ).resolves.toBe("fresh parquet");
+  });
+
+  it("escalates while it keeps failing, and resets after a success", async () => {
+    const fail = () =>
+      withLiveBindingGuard(target, async () => {
+        throw new Error("boom");
+      }).catch(e => e);
+
+    await fail(); // 1st failure -> 1m
+    vi.setSystemTime(Date.now() + 61_000);
+    await fail(); // 2nd -> 2m
+    vi.setSystemTime(Date.now() + 121_000);
+    await fail(); // 3rd -> 4m
+
+    const refused = await withLiveBindingGuard(target, async () => "x").catch(
+      e => e,
+    );
+    expect(refused.failures).toBe(3);
+    expect(refused.retryAfterMs).toBeGreaterThan(120_000); // the 4m window
+
+    // A success wipes the streak: the next failure starts back at one minute.
+    vi.setSystemTime(Date.now() + 241_000);
+    await withLiveBindingGuard(target, async () => "ok");
+    const after = await fail();
+    expect(after.message).toBe("boom");
+    const nextRefusal = await withLiveBindingGuard(
+      target,
+      async () => "x",
+    ).catch(e => e);
+    expect(nextRefusal.failures).toBe(1);
+    expect(nextRefusal.retryAfterMs).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe("single flight", () => {
+  it("a page mounting six tables starts one query, not six", async () => {
+    let started = 0;
+    let release: (v: string) => void = () => {};
+    const gate = new Promise<string>(r => (release = r));
+
+    const calls = Array.from({ length: 6 }, () =>
+      withLiveBindingGuard(target, () => {
+        started += 1;
+        return gate;
+      }),
+    );
+    release("parquet");
+    const results = await Promise.all(calls);
+
+    expect(started).toBe(1);
+    expect(results).toEqual(Array(6).fill("parquet"));
+  });
+
+  it("different bindings are independent — one failing does not block another", async () => {
+    await withLiveBindingGuard(target, async () => {
+      throw new Error("only this one is broken");
+    }).catch(() => undefined);
+
+    await expect(
+      withLiveBindingGuard(
+        { ...target, name: "email_weekly" },
+        async () => "ok",
+      ),
+    ).resolves.toBe("ok");
+  });
+});

--- a/api/src/apps/live-binding-guard.ts
+++ b/api/src/apps/live-binding-guard.ts
@@ -1,0 +1,248 @@
+/**
+ * A circuit breaker in front of live binding queries.
+ *
+ * `/__data/<name>.parquet` in a dev box asks the API to run a binding's query
+ * NOW. On success the box caches the parquet and drops the `.live` marker, so
+ * the query runs once per dev session. On FAILURE the marker stays — correctly,
+ * a failure must not be cached as data — and nothing else slows the next
+ * attempt down. So a binding that cannot succeed is re-asked for as fast as the
+ * page re-requests it, and every attempt starts a fresh warehouse query.
+ *
+ * Measured in prod (2026-09-01, app `post-valuation-conversion`): 41 attempts
+ * in 48 minutes across two bindings, each launching a BigQuery job that hit the
+ * 300s ceiling and was abandoned — "the query may still be running in
+ * BigQuery". Abandoned jobs still scan, and still bill. Meanwhile each request
+ * held a Cloud Run slot for up to an hour on a service capped at 15 instances,
+ * which is the same starvation that took apps down that morning.
+ *
+ * So the guard lives HERE, on the server, not in the box: the box's data
+ * middleware is generated into its Vite config when the sandbox is staged, so
+ * every box already running carries the old client code and will keep asking.
+ * Only the server can refuse.
+ *
+ * Two mechanisms:
+ *
+ *  - **Single flight.** Concurrent asks for the same binding share one query
+ *    instead of starting one each. Per-process: it exists to collapse the
+ *    burst a page makes when several tables mount at once, and those arrive on
+ *    one instance.
+ *  - **Failure backoff.** After a failure the same binding is refused without
+ *    touching the warehouse, for a window that doubles per consecutive failure
+ *    (1m, 2m, 4m, 8m, capped at 15m) and resets on success. This is shared
+ *    through Redis where it is configured, because a storm's requests are
+ *    load-balanced across instances and a per-process memory would only catch
+ *    the fraction that happened to land twice on the same one.
+ *
+ * The backoff refuses; it never serves stale data and never invents a result.
+ * The caller gets the previous error and how long to wait.
+ */
+import { Redis } from "ioredis";
+import { loggers } from "../logging";
+
+const logger = loggers.api("apps-live-binding");
+
+/** First refusal window; each further consecutive failure doubles it. */
+const BASE_COOLDOWN_MS = 60_000;
+const MAX_COOLDOWN_MS = 15 * 60_000;
+
+/** Refusals outlive the window they announce, so the count keeps escalating. */
+const RECORD_TTL_SECONDS = 60 * 60;
+
+export interface CooldownRecord {
+  /** Consecutive failures; drives the window width. */
+  failures: number;
+  /** Epoch ms until which this binding is refused. */
+  until: number;
+  /** What went wrong last time, passed back so the user sees a reason. */
+  error: string;
+}
+
+export class LiveBindingCoolingDown extends Error {
+  readonly retryAfterMs: number;
+  readonly failures: number;
+  constructor(record: CooldownRecord) {
+    super(record.error);
+    this.name = "LiveBindingCoolingDown";
+    this.retryAfterMs = Math.max(0, record.until - Date.now());
+    this.failures = record.failures;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Storage: Redis when configured, else in-process with the same expiry.
+// Mirrors box-state.service's store — same reasoning, same failure posture.
+// --------------------------------------------------------------------------
+
+interface GuardStore {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+}
+
+function memoryStore(): GuardStore {
+  const map = new Map<string, { value: string; expiresAt: number }>();
+  return {
+    async get(key) {
+      const hit = map.get(key);
+      if (!hit) return null;
+      if (hit.expiresAt <= Date.now()) {
+        map.delete(key);
+        return null;
+      }
+      return hit.value;
+    },
+    async set(key, value, ttlSeconds) {
+      map.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+    },
+    async del(key) {
+      map.delete(key);
+    },
+  };
+}
+
+function redisStore(url: string): GuardStore {
+  // Fail fast, exactly as the box-state cache does: this guard protects the
+  // warehouse, and a Redis blip must not add seconds to a request that is
+  // about to run a query anyway. A read that fails is treated as "no record",
+  // which degrades to per-process protection rather than to an outage.
+  const redis = new Redis(url, {
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    connectTimeout: 2000,
+  });
+  redis.on("error", error =>
+    logger.warn("Apps live-binding guard redis error", {
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  return {
+    get: key => redis.get(key),
+    async set(key, value, ttlSeconds) {
+      await redis.set(key, value, "EX", ttlSeconds);
+    },
+    async del(key) {
+      await redis.del(key);
+    },
+  };
+}
+
+let store: GuardStore | null = null;
+function getStore(): GuardStore {
+  if (!store) {
+    store = process.env.REDIS_URL
+      ? redisStore(process.env.REDIS_URL)
+      : memoryStore();
+  }
+  return store;
+}
+
+/** Test seam: drop the store so the next call rebuilds it (memory mode). */
+export function resetLiveBindingGuardForTests(): void {
+  store = null;
+  inFlight.clear();
+}
+
+function keyFor(workspaceId: string, slug: string, name: string): string {
+  return `apps:live-binding:cooldown:${workspaceId}:${slug}:${name}`;
+}
+
+/** The window a binding is refused for after `failures` consecutive failures. */
+export function cooldownMsFor(failures: number): number {
+  if (failures <= 0) return 0;
+  const doubled = BASE_COOLDOWN_MS * 2 ** (failures - 1);
+  return Math.min(doubled, MAX_COOLDOWN_MS);
+}
+
+async function readRecord(key: string): Promise<CooldownRecord | null> {
+  let raw: string | null = null;
+  try {
+    raw = await getStore().get(key);
+  } catch {
+    // A store that cannot answer is not a reason to refuse work, and not a
+    // reason to fail: fall through and let the query decide.
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CooldownRecord>;
+    if (
+      typeof parsed.failures !== "number" ||
+      typeof parsed.until !== "number"
+    ) {
+      return null;
+    }
+    return {
+      failures: parsed.failures,
+      until: parsed.until,
+      error: typeof parsed.error === "string" ? parsed.error : "Query failed",
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Single flight is per-process by design: it collapses the burst one page
+// makes when several tables mount together, which arrives on one instance.
+const inFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Run a live binding query under the guard.
+ *
+ * Throws {@link LiveBindingCoolingDown} — without calling `run` — while the
+ * binding is inside its refusal window. Otherwise runs it (sharing an
+ * already-running call for the same binding), records the outcome, and
+ * returns the result.
+ */
+export async function withLiveBindingGuard<T>(
+  input: { workspaceId: string; slug: string; name: string },
+  run: () => Promise<T>,
+): Promise<T> {
+  const key = keyFor(input.workspaceId, input.slug, input.name);
+
+  const record = await readRecord(key);
+  if (record && record.until > Date.now()) {
+    logger.warn("Apps live binding refused while cooling down", {
+      ...input,
+      failures: record.failures,
+      retryInMs: record.until - Date.now(),
+    });
+    throw new LiveBindingCoolingDown(record);
+  }
+
+  const running = inFlight.get(key);
+  if (running) return running as Promise<T>;
+
+  const started = (async () => {
+    try {
+      const result = await run();
+      // Success clears the history: the next failure starts at one minute,
+      // not wherever an old streak had escalated to.
+      await getStore()
+        .del(key)
+        .catch(() => undefined);
+      return result;
+    } catch (error) {
+      const failures = (record?.failures ?? 0) + 1;
+      const next: CooldownRecord = {
+        failures,
+        until: Date.now() + cooldownMsFor(failures),
+        error: error instanceof Error ? error.message : String(error),
+      };
+      await getStore()
+        .set(key, JSON.stringify(next), RECORD_TTL_SECONDS)
+        .catch(() => undefined);
+      logger.warn("Apps live binding failed; cooling down", {
+        ...input,
+        failures,
+        cooldownMs: cooldownMsFor(failures),
+        error: next.error,
+      });
+      throw error;
+    }
+  })().finally(() => {
+    if (inFlight.get(key) === started) inFlight.delete(key);
+  });
+
+  inFlight.set(key, started);
+  return started;
+}

--- a/api/src/routes/apps-box.ts
+++ b/api/src/routes/apps-box.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
 import { GitTokenError, verifyGitToken } from "../apps/git-token.service";
 import { patchBoxState } from "../apps/box-state.service";
 import { buildBindingParquet } from "../apps/bindings.service";
+import {
+  LiveBindingCoolingDown,
+  withLiveBindingGuard,
+} from "../apps/live-binding-guard";
 import { synthesizeProjectFromFolder } from "../apps/worktree.service";
 import { AppProject } from "../database/workspace-schema";
 import { Types } from "mongoose";
@@ -156,8 +160,25 @@ appsBoxRoutes.post("/:workspaceId/live-binding", async c => {
 
   let built;
   try {
-    built = await buildBindingParquet(project, name, payload.userId);
+    // Guarded: a binding that cannot succeed must not be re-queried as fast as
+    // a page can re-request it. See live-binding-guard.ts — 41 abandoned
+    // BigQuery jobs in 48 minutes is what this exists to stop.
+    built = await withLiveBindingGuard({ workspaceId, slug, name }, () =>
+      buildBindingParquet(project, name, payload.userId),
+    );
   } catch (error) {
+    if (error instanceof LiveBindingCoolingDown) {
+      // 503 + Retry-After, not 502: the query was not attempted, and this is
+      // temporary by construction. Distinguishable in logs from a real failure.
+      return c.json(
+        {
+          error: `This binding failed ${error.failures} time(s) in a row and is not being re-run yet: ${error.message}`,
+          retryAfterMs: error.retryAfterMs,
+        },
+        503,
+        { "retry-after": String(Math.ceil(error.retryAfterMs / 1000)) },
+      );
+    }
     logger.warn("Apps live binding failed", {
       workspaceId,
       slug,

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "src/apps/workspace-consoles.service.test.ts",
       "src/apps/workspace-skills.service.test.ts",
       "src/apps/box-state.service.test.ts",
+      "src/apps/live-binding-guard.test.ts",
       "src/apps/preview.service.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",
     ],


### PR DESCRIPTION
## The incident

Prod, 2026-09-01 11:20–12:08. App `post-valuation-conversion`, bindings `email_links` and `email_weekly`:

| | |
|---|---|
| Failures | **41 in 48 minutes** (~30s apart, two bindings in parallel) |
| Each attempt | one BigQuery job, hitting the 300s ceiling, then **abandoned** — *"the query may still be running in BigQuery"* |
| 24h `live-binding` requests | 78, of which **74 over 60s**, median **37.7 min**, 41 ending 502 at ~3,292s |

Abandoned jobs still scan and still bill. Each attempt also held a Cloud Run request slot for up to an hour on a service capped at 15 instances — the same starvation class as the `no available instance` window that took apps down that morning.

## Why it ran away

On **success** the box writes the parquet and deletes the `.live` marker, so a binding is queried once per dev session. On **failure** the marker stays — which is correct, a failure must not be cached as data — and nothing else slows the next attempt down. So a binding that cannot succeed is re-queried as fast as the page re-requests it, forever.

## The guard is server-side on purpose

The box's data middleware is **generated into its Vite config when the sandbox is staged**. Every box already running carries the old client code and will keep asking no matter what the client does. Only the server can refuse — so that is where this lives.

`withLiveBindingGuard` (`api/src/apps/live-binding-guard.ts`):

- **Single flight** per (workspace, app, binding) — a page mounting six tables starts one query, not six. Per-process, because that burst arrives on one instance.
- **Failure backoff** — after a failure the binding is refused **without touching the warehouse** for 1m → 2m → 4m → 8m → capped 15m per consecutive failure, reset on success. It *refuses*; it never serves stale data or invents a result, and the previous error is passed back so the user still sees why.
- Shared through **Redis where configured** (same store shape and fail-fast posture as `box-state.service`), because a storm's requests are load-balanced across up to 15 instances — per-process memory would only catch the fraction that happened to land twice on the same one.

Replaying the actual storm through the guard:

> **41 BigQuery queries → 7.** Asserted *exactly* in the test, not as "fewer" — a `toBeLessThan` would pass even if the backoff barely worked.

## Two smaller fixes in the same path

- The route now answers **503 + `Retry-After`** while cooling down rather than 502, carrying the previous error — so a refusal is distinguishable from a fresh failure in the logs.
- **The timeouts disagreed.** The box aborted at **180s**; the API's query ceiling is **300s**. Every binding taking 180–300s was therefore *permanently unsatisfiable* — the box abandoned a request the API was still serving, so the answer could never arrive, while the job it started ran on and billed. Now 330s: the client must outlast the server it waits on.

## Tests

`live-binding-guard.test.ts` (7 cases, in the apps vitest config): the storm replay above; refusal without running the query, with `retryAfterMs` and the original reason; recovery once the window passes; escalation and reset-on-success; six concurrent callers → one query; and one broken binding not blocking another.

Apps suite: 15 files / 147 tests green.

## Not in this PR

The abandoned BigQuery job is *not* cancelled — the driver tracks jobs for cancellation (`runningBigQueryJobs`), but threading cancel through `buildQueryParquetFile` → `getStreamingQueryFields` is a wider change. With the guard in place there are now ~7 abandoned jobs per storm instead of 41; cancelling them would take it to ~0 and is worth doing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
