### PR TITLE
chore(deploy): production keeps 3 warm instances, not 1

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1026,7 +1026,7 @@ jobs:
             --timeout=3600 \
             --memory=4Gi \
             --concurrency=80 \
-            --min-instances=1 \
+            --min-instances=3 \
             --max-instances=15 \
             --allow-unauthenticated \
             --network=mako-vpc \


### PR DESCRIPTION
## Why

On 2026-09-01 07:02–07:03 production answered `The request was aborted because there was no available instance` for ~30 seconds — apps looked down. A Close CDC webhook burst (~810 req/min) plus 17–26s Inngest handlers arrived at a service with **1 guaranteed instance** and a ~30s cold start (connector registry + Mongo connect), so every request during the scale-out was refused.

The same signature reappeared **today at 13:16, as 429s**, two minutes after a deploy.

Three warm instances is the cheapest thing that shortens that window: a burst is absorbed while Cloud Run scales, rather than refused for the length of a boot. `maxScale` stays at 15.

## Why it has to be in this file

`gcloud run deploy` here passes `--min-instances` on **every** production deploy, so a value set with `gcloud run services update` is silently reverted by the next one.

That is not hypothetical — it is what happened today:

| | |
|---|---|
| 13:06 | set to 3 via `gcloud run services update` (revision `mako-00253`) |
| 13:14 | #905 deploys → **back to 1** (`mako-00255`) |
| 13:16 | 429s, `no available instance` |

The live service has been set back to 3 by hand (`mako-00256`); this change is what makes it survive the next deploy.

## Cost

One `1 vCPU / 4Gi` instance is roughly $50–70/month, so this is ~$100–140/month over `min-instances=1`. Staging/preview (`--min-instances=0`) and canary are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
