### PR TITLE
fix(mcp): server-wide Always allow + auto-run read tools (supersedes #683)

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -5183,12 +5183,22 @@ export const McpOAuthFlow = mongoose.model<IMcpOAuthFlow>(
 
 export type McpGrantDecision = "always_allow" | "always_deny";
 
+/**
+ * Sentinel toolName for a per-user, server-wide grant. Applies to every tool
+ * on the server that the admin ceiling still permits (ask/block ceilings win).
+ */
+export const MCP_SERVER_WIDE_GRANT_TOOL = "*";
+
 export interface IMcpToolGrant extends Document {
   _id: Types.ObjectId;
   workspaceId: Types.ObjectId;
   serverId: Types.ObjectId;
   /** Grants are always per-user, even on shared workspace credentials. */
   userId: string;
+  /**
+   * Raw MCP tool name, or {@link MCP_SERVER_WIDE_GRANT_TOOL} (`"*"`) for a
+   * server-wide Always allow / Block decision.
+   */
   toolName: string;
   decision: McpGrantDecision;
   lastUsedAt?: Date;

--- a/api/src/routes/mcp.routes.ts
+++ b/api/src/routes/mcp.routes.ts
@@ -26,6 +26,7 @@ import {
 } from "../openapi/core";
 import {
   type IMcpServer,
+  MCP_SERVER_WIDE_GRANT_TOOL,
   McpConnectionConfig,
   McpServer,
   McpToolGrant,
@@ -1044,6 +1045,10 @@ mcpRoutes.openapi(
 );
 
 const GrantSchema = z.object({
+  /**
+   * Raw MCP tool name, or `"*"` for a server-wide Always allow / Block grant
+   * (applies to every tool the admin ceiling still permits).
+   */
   toolName: z.string().min(1),
   decision: z.enum(["always_allow", "always_deny"]),
 });
@@ -1132,26 +1137,46 @@ mcpRoutes.openapi(
         return c.json({ success: false, error: "Invalid request body" }, 400);
       }
       const { toolName, decision } = parsed.data;
+      const isServerWide = toolName === MCP_SERVER_WIDE_GRANT_TOOL;
 
-      const cachedTool = server.cachedTools.find(t => t.name === toolName);
-      if (!cachedTool) {
-        return c.json({ success: false, error: "Unknown tool" }, 404);
-      }
-      // The admin restriction is a ceiling: users can always choose stricter
-      // (always_deny/Block is always permitted), but "Always allow" requires
-      // an "always" ceiling.
-      const ceiling = mcpToolRestriction(server, cachedTool);
-      if (decision === "always_allow" && ceiling !== "always") {
-        return c.json(
-          {
-            success: false,
-            error:
-              ceiling === "block"
-                ? "This tool has been blocked by a workspace admin."
-                : "A workspace admin restricted this tool to Ask — it cannot be always-allowed.",
-          },
-          403,
+      if (!isServerWide) {
+        const cachedTool = server.cachedTools.find(t => t.name === toolName);
+        if (!cachedTool) {
+          return c.json({ success: false, error: "Unknown tool" }, 404);
+        }
+        // The admin restriction is a ceiling: users can always choose stricter
+        // (always_deny/Block is always permitted), but "Always allow" requires
+        // an "always" ceiling.
+        const ceiling = mcpToolRestriction(server, cachedTool);
+        if (decision === "always_allow" && ceiling !== "always") {
+          return c.json(
+            {
+              success: false,
+              error:
+                ceiling === "block"
+                  ? "This tool has been blocked by a workspace admin."
+                  : "A workspace admin restricted this tool to Ask — it cannot be always-allowed.",
+            },
+            403,
+          );
+        }
+      } else if (decision === "always_allow") {
+        // Server-wide Always allow only covers tools with an "always" ceiling;
+        // ask/block tools still prompt or stay hidden. Require at least one
+        // always-allowable tool so the grant isn't a silent no-op.
+        const hasAlwaysCeiling = server.cachedTools.some(
+          t => mcpToolRestriction(server, t) === "always",
         );
+        if (!hasAlwaysCeiling) {
+          return c.json(
+            {
+              success: false,
+              error:
+                "No tools on this server can be always-allowed — a workspace admin restricted them to Ask or Block.",
+            },
+            403,
+          );
+        }
       }
 
       await McpToolGrant.updateOne(
@@ -1164,6 +1189,7 @@ mcpRoutes.openapi(
         serverId: server._id.toString(),
         toolName,
         decision,
+        serverWide: isServerWide,
       });
       return c.json({ success: true });
     } catch (error) {

--- a/api/src/services/mcp-client.service.test.ts
+++ b/api/src/services/mcp-client.service.test.ts
@@ -450,10 +450,10 @@ function testCryptoRoundTrip() {
 
 /**
  * Grants → approval flow, against in-memory Mongo:
- * read tools never need approval; write tools need approval until an
- * always_allow grant exists; always_deny tools skip the prompt and refuse
- * at execute time; destructive tools stay prompt-only unless the admin
- * unlocked grants.
+ * read tools auto-run (no grant); write tools need approval until an
+ * always_allow grant (tool or server-wide `*`) exists; always_deny tools
+ * skip the prompt and refuse at execute time; destructive tools stay
+ * prompt-only unless the admin unlocked grants.
  */
 async function testGrantsAndNeedsApproval() {
   const replSet = await MongoMemoryReplSet.create({
@@ -489,6 +489,12 @@ async function testGrantsAndNeedsApproval() {
           inputSchema: { type: "object", properties: {} },
         },
         {
+          name: "lead_update",
+          description: "Update a lead",
+          annotations: { readOnlyHint: false, destructiveHint: false },
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
           name: "lead_delete",
           description: "Delete a lead",
           annotations: { destructiveHint: true },
@@ -510,7 +516,7 @@ async function testGrantsAndNeedsApproval() {
       });
 
     let chatTools = await loadTools();
-    assert.equal(chatTools.allToolNames.length, 3);
+    assert.equal(chatTools.allToolNames.length, 4);
     assert.deepEqual(chatTools.readOnlyToolNames, [
       "mcp_close_crm_lead_search",
     ]);
@@ -528,23 +534,49 @@ async function testGrantsAndNeedsApproval() {
       return fn === true;
     };
 
-    // Claude model: EVERY tool prompts on first use — reads included —
-    // until the user chooses a permission.
-    assert.equal(await needsApproval("mcp_close_crm_lead_search"), true);
+    // Read tools auto-run; write/destructive still prompt on first use.
+    assert.equal(await needsApproval("mcp_close_crm_lead_search"), false);
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), true);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), true);
     assert.equal(await needsApproval("mcp_close_crm_lead_delete"), true);
 
-    // "Always allow" grant on the read tool: no more prompts.
+    // Server-wide Always allow covers every always-ceiling write tool.
     await McpToolGrant.create({
       workspaceId,
       serverId: server._id,
       userId,
-      toolName: "lead_search",
+      toolName: "*",
       decision: "always_allow",
     });
-    assert.equal(await needsApproval("mcp_close_crm_lead_search"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false);
+    // Destructive still prompts — default ceiling is "ask".
+    assert.equal(await needsApproval("mcp_close_crm_lead_delete"), true);
 
-    // "Always allow" grant on the write tool: no more prompts.
+    // Tool-level Block beats a server-wide Always allow.
+    await McpToolGrant.create({
+      workspaceId,
+      serverId: server._id,
+      userId,
+      toolName: "lead_update",
+      decision: "always_deny",
+    });
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false);
+    const updateTool = chatTools.tools["mcp_close_crm_lead_update"];
+    assert.ok(updateTool.execute);
+    const updateDenied = (await updateTool.execute(
+      {},
+      { toolCallId: "t", messages: [], experimental_context: undefined },
+    )) as { success: boolean; denied?: boolean };
+    assert.equal(updateDenied.success, false);
+    assert.equal(updateDenied.denied, true);
+
+    // Clear the server-wide grant; per-tool Always allow still works.
+    await McpToolGrant.deleteOne({
+      serverId: server._id,
+      userId,
+      toolName: "*",
+    });
     await McpToolGrant.create({
       workspaceId,
       serverId: server._id,
@@ -552,7 +584,9 @@ async function testGrantsAndNeedsApproval() {
       toolName: "lead_create",
       decision: "always_allow",
     });
+    chatTools = await loadTools();
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
+    assert.equal(await needsApproval("mcp_close_crm_lead_update"), false); // still blocked
 
     // Destructive tool: defaults to an "ask" ceiling, so an always_allow
     // grant is IGNORED until an admin explicitly relaxes that tool.
@@ -608,6 +642,12 @@ async function testGrantsAndNeedsApproval() {
       { _id: server._id },
       { $set: { "toolPolicy.restrictions": { lead_delete: "always" } } },
     );
+    // Drop the tool-level block so lead_update is promptable again.
+    await McpToolGrant.deleteOne({
+      serverId: server._id,
+      userId,
+      toolName: "lead_update",
+    });
     chatTools = await loadTools();
 
     // "Always deny": no prompt, and execute refuses without contacting the
@@ -615,6 +655,7 @@ async function testGrantsAndNeedsApproval() {
     await McpToolGrant.updateOne(
       { serverId: server._id, userId, toolName: "lead_create" },
       { $set: { decision: "always_deny" } },
+      { upsert: true },
     );
     chatTools = await loadTools();
     assert.equal(await needsApproval("mcp_close_crm_lead_create"), false);
@@ -627,7 +668,7 @@ async function testGrantsAndNeedsApproval() {
     assert.equal(denied.success, false);
     assert.equal(denied.denied, true);
 
-    // Grants are per-user: a different user still gets prompted.
+    // Grants are per-user: a different user still gets prompted on writes.
     const otherUserTools = await buildMcpToolsForChat({
       workspaceId: workspaceId.toString(),
       userId: "user-2",
@@ -642,6 +683,18 @@ async function testGrantsAndNeedsApproval() {
           )
         : otherFn,
       true,
+    );
+    // Reads still auto-run for the other user.
+    const otherSearch = otherUserTools.tools["mcp_close_crm_lead_search"];
+    const otherSearchFn = otherSearch.needsApproval;
+    assert.equal(
+      typeof otherSearchFn === "function"
+        ? await otherSearchFn(
+            {},
+            { toolCallId: "t", messages: [], experimental_context: undefined },
+          )
+        : otherSearchFn,
+      false,
     );
 
     // A tool captured earlier in the turn must not execute after the server is

--- a/api/src/services/mcp-client.service.test.ts
+++ b/api/src/services/mcp-client.service.test.ts
@@ -24,6 +24,7 @@ import {
   mcpServerSlug,
   mcpToolRestriction,
   mcpToolRiskTier,
+  mcpReadTierIsEnforced,
   normalizeMcpToolOutput,
 } from "./mcp-client.service";
 import {
@@ -157,6 +158,38 @@ function testRiskTiers() {
   );
   // Unannotated tools default to plain write (approval required, grantable).
   assert.equal(mcpToolRiskTier(destroyServer, {}), "write");
+
+  // A "read" TIER is not the same as read-ness we can rely on to skip the
+  // approval prompt. `writeScope` is picked in the add-server form and
+  // defaults to "read"; it only binds the provider when the preset sends a
+  // scope header. Without this distinction, adding any custom MCP server with
+  // default settings would auto-run every tool on it, destructive ones
+  // included.
+  const closeRead = {
+    writeScope: "read",
+    connectorType: "close",
+  } as Pick<IMcpServer, "writeScope" | "connectorType">;
+  const customRead = {
+    writeScope: "read",
+    connectorType: "custom",
+  } as Pick<IMcpServer, "writeScope" | "connectorType">;
+
+  // Close sends Close-API-Key scope, so the provider holds us to it.
+  assert.equal(mcpReadTierIsEnforced(closeRead, {}), true);
+  // A custom connection's "read" is a label only — not enough on its own.
+  assert.equal(mcpReadTierIsEnforced(customRead, {}), false);
+  assert.equal(
+    mcpReadTierIsEnforced(customRead, {
+      annotations: { destructiveHint: true },
+    }),
+    false,
+  );
+  // The server's own readOnlyHint is its claim about its own tool, and is
+  // trustworthy on any connection.
+  assert.equal(
+    mcpReadTierIsEnforced(customRead, { annotations: { readOnlyHint: true } }),
+    true,
+  );
 }
 
 function testAllowlistFiltering() {

--- a/api/src/services/mcp-client.service.ts
+++ b/api/src/services/mcp-client.service.ts
@@ -10,8 +10,10 @@
  *  - Tool *executions* open a short-lived client per call (connect → call →
  *    close). No pooling — every call is bound to exactly one workspace/user
  *    credential, so credentials can never bleed across tenants.
- *  - Write-risk tiers + per-user grants drive the AI SDK's native
- *    `needsApproval` human-in-the-loop flow (allow once / always allow).
+ *  - Risk tiers + per-user grants (per-tool or server-wide `*`) drive the
+ *    AI SDK's native `needsApproval` flow (allow once / always allow).
+ *    Read-tier tools with an open admin ceiling auto-run; writes prompt
+ *    until granted.
  */
 
 import { createMCPClient } from "@ai-sdk/mcp";
@@ -22,7 +24,9 @@ import { Types } from "mongoose";
 import {
   type IMcpCachedTool,
   type IMcpServer,
+  type McpGrantDecision,
   type McpToolRestriction,
+  MCP_SERVER_WIDE_GRANT_TOOL,
   McpConnectionConfig,
   McpServer,
   McpToolGrant,
@@ -435,19 +439,53 @@ async function resolveActiveServers(
 }
 
 /**
- * Approval decision for one tool call, following the Claude-connectors
- * model: the admin restriction is a *ceiling*, and the user's per-tool
- * choice (grant) picks a setting up to that ceiling.
+ * Resolve the effective per-user grant for a tool.
  *
- * Every tool — reads included — prompts on first use until the user decides
- * (Claude behavior: access is granted by the individual, never implicitly).
+ * Precedence: tool-specific grant > server-wide (`*`) grant > none.
+ * A tool-level Block always wins over a server-wide Always allow.
+ */
+export async function resolveMcpToolGrant(params: {
+  serverId: Types.ObjectId | string;
+  userId: string | undefined;
+  toolName: string;
+}): Promise<{ decision: McpGrantDecision; toolName: string } | null> {
+  const { serverId, userId, toolName } = params;
+  if (!userId) return null;
+
+  const grants = await McpToolGrant.find({
+    serverId,
+    userId,
+    toolName: { $in: [toolName, MCP_SERVER_WIDE_GRANT_TOOL] },
+  }).lean();
+
+  const toolGrant = grants.find(g => g.toolName === toolName);
+  if (toolGrant) {
+    return { decision: toolGrant.decision, toolName: toolGrant.toolName };
+  }
+  const serverGrant = grants.find(
+    g => g.toolName === MCP_SERVER_WIDE_GRANT_TOOL,
+  );
+  if (serverGrant) {
+    return {
+      decision: serverGrant.decision,
+      toolName: serverGrant.toolName,
+    };
+  }
+  return null;
+}
+
+/**
+ * Approval decision for one tool call, following the Claude-connectors
+ * model: the admin restriction is a *ceiling*, and the user's grant
+ * (per-tool or server-wide `*`) picks a setting up to that ceiling.
  *
  * Resolution:
  *  - blocked tools never get here (filtered at build time)
- *  - user chose Block (always_deny) → no prompt; execute() refuses
- *  - ceiling "ask" → always prompt (user's Always allow can't apply)
- *  - user chose Always allow → auto-run
- *  - no choice yet → prompt
+ *  - user chose Block (always_deny, tool or `*`) → no prompt; execute() refuses
+ *  - ceiling "ask" → always prompt (Always allow grants can't apply)
+ *  - read-tier tools with an "always" ceiling → auto-run (no grant needed)
+ *  - user chose Always allow (tool or `*`) → auto-run
+ *  - no choice yet on a write tool → prompt
  */
 async function mcpNeedsApproval(params: {
   server: IMcpServer;
@@ -456,20 +494,20 @@ async function mcpNeedsApproval(params: {
 }): Promise<boolean> {
   const { server, tool, userId } = params;
   const ceiling = mcpToolRestriction(server, tool);
-
-  const grant = userId
-    ? await McpToolGrant.findOne({
-        serverId: server._id,
-        userId,
-        toolName: tool.name,
-      }).lean()
-    : null;
+  const grant = await resolveMcpToolGrant({
+    serverId: server._id,
+    userId,
+    toolName: tool.name,
+  });
 
   if (grant?.decision === "always_deny") {
     // No approval prompt: execute() returns the denial to the model.
     return false;
   }
   if (ceiling === "ask") return true;
+  // Read tools with an open ceiling don't need a grant — matches the product
+  // docs and stops Close-style connectors from prompting on every search.
+  if (mcpToolRiskTier(server, tool) === "read") return false;
   return grant?.decision !== "always_allow";
 }
 
@@ -554,13 +592,11 @@ export async function buildMcpToolsForChat(params: {
             };
           }
 
-          const grant = userId
-            ? await McpToolGrant.findOne({
-                serverId: server._id,
-                userId,
-                toolName: cachedTool.name,
-              }).lean()
-            : null;
+          const grant = await resolveMcpToolGrant({
+            serverId: server._id,
+            userId,
+            toolName: cachedTool.name,
+          });
 
           if (grant?.decision === "always_deny") {
             logger.info("MCP tool call denied by user grant", {
@@ -568,6 +604,7 @@ export async function buildMcpToolsForChat(params: {
               userId,
               serverId: server._id.toString(),
               toolName: cachedTool.name,
+              grantToolName: grant.toolName,
             });
             return {
               success: false,
@@ -600,7 +637,11 @@ export async function buildMcpToolsForChat(params: {
             });
             if (grant) {
               void McpToolGrant.updateOne(
-                { _id: grant._id },
+                {
+                  serverId: server._id,
+                  userId,
+                  toolName: grant.toolName,
+                },
                 { $set: { lastUsedAt: new Date() } },
               ).catch(() => undefined);
             }

--- a/api/src/services/mcp-client.service.ts
+++ b/api/src/services/mcp-client.service.ts
@@ -487,6 +487,24 @@ export async function resolveMcpToolGrant(params: {
  *  - user chose Always allow (tool or `*`) → auto-run
  *  - no choice yet on a write tool → prompt
  */
+/**
+ * Is a "read" tier something the provider will hold us to, or just a label?
+ *
+ * `readOnlyHint` comes from the MCP server's own tool annotations, so it is
+ * the server's claim about its own tool. `writeScope` is ours: it is picked in
+ * the add-server form, defaults to "read", and only becomes a real constraint
+ * when the preset sends a scope header the provider enforces (Close's
+ * Close-API-Key scope, GitHub's X-MCP-Readonly). Without one, a connection
+ * labelled "read" can still call whatever the credential allows.
+ */
+export function mcpReadTierIsEnforced(
+  server: Pick<IMcpServer, "writeScope" | "connectorType">,
+  tool: Pick<IMcpCachedTool, "annotations">,
+): boolean {
+  if (tool.annotations?.readOnlyHint === true) return true;
+  return Boolean(getMcpPreset(server.connectorType).scopeHeader);
+}
+
 async function mcpNeedsApproval(params: {
   server: IMcpServer;
   tool: IMcpCachedTool;
@@ -507,7 +525,20 @@ async function mcpNeedsApproval(params: {
   if (ceiling === "ask") return true;
   // Read tools with an open ceiling don't need a grant — matches the product
   // docs and stops Close-style connectors from prompting on every search.
-  if (mcpToolRiskTier(server, tool) === "read") return false;
+  //
+  // But only when the read-ness is TRUSTWORTHY. `writeScope` is a label chosen
+  // in the add-server form, it defaults to "read", and it reaches the provider
+  // only for presets that send a scope header (Close, GitHub). On a custom or
+  // Slack connection the same label is unenforced — so treating it alone as
+  // "read" would silently auto-run every tool on a default-configured server,
+  // including ones annotated destructive. A tool the server itself annotates
+  // readOnlyHint is trustworthy on any connection.
+  if (
+    mcpToolRiskTier(server, tool) === "read" &&
+    mcpReadTierIsEnforced(server, tool)
+  ) {
+    return false;
+  }
   return grant?.decision !== "always_allow";
 }
 

--- a/app/src/components/McpApprovalCard.tsx
+++ b/app/src/components/McpApprovalCard.tsx
@@ -6,13 +6,15 @@
  *          { input preview }
  *          [ Always allow ⏎ | v ]  [ Deny esc ]
  *
- * "Always allow" persists a per-user grant (each user decides only for
- * themselves) and is offered only when the workspace admin's restriction
- * ceiling for the tool permits it — otherwise "Allow once ⏎" is primary.
+ * "Always allow" persists a per-user grant for this tool. The overflow menu
+ * also offers "Always allow all tools from <server>" (server-wide `*` grant).
+ * Both are offered only when the workspace admin's restriction ceiling for
+ * the tool permits Always allow — otherwise "Allow once ⏎" is primary.
  * Enter triggers the primary action, Escape denies.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
+  Alert,
   Box,
   Button,
   ButtonGroup,
@@ -68,6 +70,9 @@ const Pill: React.FC<{
     {children}
   </Box>
 );
+
+/** Sentinel matching api MCP_SERVER_WIDE_GRANT_TOOL. */
+const SERVER_WIDE_GRANT = "*";
 
 export interface McpApprovalResponseArgs {
   approvalId: string;
@@ -147,6 +152,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
   const saveGrant = useMcpStore(s => s.saveGrant);
   const [busy, setBusy] = useState<"once" | "always" | "deny" | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [grantError, setGrantError] = useState<string | null>(null);
   const busyRef = useRef(busy);
   busyRef.current = busy;
 
@@ -167,10 +173,15 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
     }
   }, [pendingForInfo, currentWorkspace]);
 
-  const respond = async (approved: boolean, always: boolean) => {
+  const respond = async (
+    approved: boolean,
+    always: boolean,
+    scope: "tool" | "server" = "tool",
+  ) => {
     if (busyRef.current) return;
     setBusy(always ? "always" : approved ? "once" : "deny");
     setMenuAnchor(null);
+    setGrantError(null);
     try {
       if (always && approved && currentWorkspace && toolInfo) {
         // Persist the grant first so the server-side needsApproval check
@@ -178,12 +189,20 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
         await saveGrant(
           currentWorkspace.id,
           toolInfo.serverId,
-          toolInfo.toolName,
+          scope === "server" ? SERVER_WIDE_GRANT : toolInfo.toolName,
           "always_allow",
         );
       }
-    } catch {
-      // Grant persistence failing shouldn't block the one-time approval.
+    } catch (error) {
+      // Grant persistence failing shouldn't block the one-time approval, but
+      // surface it — otherwise "Always allow" looks like it stuck when it didn't.
+      if (always && approved) {
+        setGrantError(
+          error instanceof Error
+            ? error.message
+            : "Could not save Always allow — this call will still run once.",
+        );
+      }
     } finally {
       onRespond({ approvalId, approved });
       setBusy(null);
@@ -214,7 +233,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
         if (isTextInput && inputText.trim().length > 0) return;
         event.preventDefault();
         event.stopPropagation();
-        void respond(true, primaryIsAlways);
+        void respond(true, primaryIsAlways, "tool");
       } else if (event.key === "Escape") {
         event.preventDefault();
         void respond(false, false);
@@ -297,6 +316,16 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
             {secondChip}
           </Stack>
 
+          {pending && !canAlwaysAllow && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mt: 0.5 }}
+            >
+              Workspace policy requires approval each time for this tool.
+            </Typography>
+          )}
+
           {inputPreview && (
             <Box
               component="pre"
@@ -319,6 +348,12 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
             >
               {inputPreview}
             </Box>
+          )}
+
+          {grantError && (
+            <Alert severity="warning" sx={{ mt: 1, py: 0 }}>
+              {grantError}
+            </Alert>
           )}
 
           {pending && (
@@ -354,7 +389,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
               >
                 <Button
                   disabled={busy !== null}
-                  onClick={() => void respond(true, primaryIsAlways)}
+                  onClick={() => void respond(true, primaryIsAlways, "tool")}
                   startIcon={
                     busy === (primaryIsAlways ? "always" : "once") ? (
                       <CircularProgress size={12} color="inherit" />
@@ -369,7 +404,7 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
                       : "mcp-approval-allow-once"
                   }
                 >
-                  {primaryIsAlways ? "Always allow" : "Allow once"}
+                  {primaryIsAlways ? "Always allow this tool" : "Allow once"}
                 </Button>
                 {primaryIsAlways && (
                   <Button
@@ -395,6 +430,15 @@ export const McpApprovalCard: React.FC<McpApprovalCardProps> = ({
                 >
                   Allow once
                 </MenuItem>
+                {canAlwaysAllow && serverName && (
+                  <MenuItem
+                    dense
+                    onClick={() => void respond(true, true, "server")}
+                    data-testid="mcp-approval-always-allow-server"
+                  >
+                    Always allow all tools from {serverName}
+                  </MenuItem>
+                )}
               </Menu>
               <Button
                 size="small"

--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -980,9 +980,10 @@ function ServerDetail({
   };
 
   /**
-   * The user's own per-tool permission (Claude-style): Always allow / Ask /
-   * Block, stored as a grant ("Ask" simply clears it — the tool prompts on
-   * next use). Capped by the admin ceiling via disabled options.
+   * The user's own permission (Claude-style): Always allow / Ask / Block,
+   * stored as a grant ("Ask" simply clears it — the tool prompts on next
+   * use). `toolName` may be `"*"` for a server-wide grant. Capped by the
+   * admin ceiling via disabled options.
    */
   const handleSetUserPermission = async (
     toolName: string,
@@ -990,19 +991,37 @@ function ServerDetail({
     grantId?: string,
   ) => {
     if (!currentWorkspace) return;
-    if (value === "ask") {
-      if (grantId) {
-        await revokeGrant(currentWorkspace.id, server.id, grantId);
+    try {
+      if (value === "ask") {
+        if (grantId) {
+          await revokeGrant(currentWorkspace.id, server.id, grantId);
+        }
+        return;
       }
-      return;
+      await saveGrant(
+        currentWorkspace.id,
+        server.id,
+        toolName,
+        value === "always_allow" ? "always_allow" : "always_deny",
+      );
+    } catch (error) {
+      onNotify(
+        error instanceof Error ? error.message : "Failed to update permission",
+        "error",
+      );
     }
-    await saveGrant(
-      currentWorkspace.id,
-      server.id,
-      toolName,
-      value === "always_allow" ? "always_allow" : "always_deny",
-    );
   };
+
+  const serverWideGrant = myGrants.find(g => g.toolName === "*");
+  const serverWideValue =
+    serverWideGrant?.decision === "always_allow"
+      ? "always_allow"
+      : serverWideGrant?.decision === "always_deny"
+        ? "block"
+        : "ask";
+  const canServerWideAlwaysAllow = server.cachedTools.some(
+    t => t.restriction === "always",
+  );
 
   const handleDelete = async () => {
     if (!currentWorkspace) return;
@@ -1248,10 +1267,59 @@ function ServerDetail({
               color="text.secondary"
               sx={{ display: "block", mb: 1 }}
             >
-              These choices apply only to you. Tools ask on first use until you
-              decide — pick a permission here or from the approval prompt in
-              chat.
+              These choices apply only to you. Read tools run without prompting.
+              Write tools ask until you Always allow — per tool below, or for
+              the whole server.
             </Typography>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              useFlexGap
+              sx={{
+                mb: 1,
+                py: 0.75,
+                px: 1,
+                borderRadius: 1,
+                bgcolor: "action.hover",
+                flexWrap: "wrap",
+                rowGap: 0.5,
+              }}
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" fontWeight={600}>
+                  All tools on {server.name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Server-wide Always allow covers every tool the admin still
+                  permits. Per-tool Block below overrides it. Destructive tools
+                  stay Ask unless an admin unlocks them.
+                </Typography>
+              </Box>
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <Select
+                  value={serverWideValue}
+                  disabled={!currentWorkspace}
+                  onChange={e =>
+                    void handleSetUserPermission(
+                      "*",
+                      e.target.value as "always_allow" | "ask" | "block",
+                      serverWideGrant?.id,
+                    )
+                  }
+                  sx={{ fontSize: 13 }}
+                >
+                  <MenuItem
+                    value="always_allow"
+                    disabled={!canServerWideAlwaysAllow}
+                  >
+                    Always allow
+                  </MenuItem>
+                  <MenuItem value="ask">Ask (default)</MenuItem>
+                  <MenuItem value="block">Block all</MenuItem>
+                </Select>
+              </FormControl>
+            </Stack>
             <Stack spacing={0.25}>
               {server.cachedTools.map(tool => {
                 const grant = myGrants.find(g => g.toolName === tool.name);
@@ -1262,6 +1330,14 @@ function ServerDetail({
                       ? "block"
                       : "ask";
                 const blockedByAdmin = tool.restriction === "block";
+                const inheritedAlways =
+                  !grant &&
+                  serverWideGrant?.decision === "always_allow" &&
+                  tool.restriction === "always" &&
+                  tool.riskTier !== "read";
+                const ceilingOverridesGrant =
+                  grant?.decision === "always_allow" &&
+                  tool.restriction === "ask";
                 return (
                   <Stack
                     key={tool.name}
@@ -1278,13 +1354,30 @@ function ServerDetail({
                       "&:hover": { bgcolor: "action.hover" },
                     }}
                   >
-                    <Typography
-                      variant="body2"
-                      sx={{ fontFamily: "monospace", flex: 1, minWidth: 0 }}
-                      noWrap
-                    >
-                      {tool.name}
-                    </Typography>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontFamily: "monospace" }}
+                        noWrap
+                      >
+                        {tool.name}
+                      </Typography>
+                      {tool.riskTier === "read" && value === "ask" && (
+                        <Typography variant="caption" color="text.secondary">
+                          Read — runs without prompting
+                        </Typography>
+                      )}
+                      {inheritedAlways && (
+                        <Typography variant="caption" color="text.secondary">
+                          Covered by server-wide Always allow
+                        </Typography>
+                      )}
+                      {ceilingOverridesGrant && (
+                        <Typography variant="caption" color="warning.main">
+                          Always allow saved, but admin Ask still prompts
+                        </Typography>
+                      )}
+                    </Box>
                     {blockedByAdmin ? (
                       <Typography variant="caption" color="text.disabled">
                         Blocked by admin

--- a/app/src/pages/settings/SettingsMcp.tsx
+++ b/app/src/pages/settings/SettingsMcp.tsx
@@ -5,7 +5,7 @@ export default function SettingsMcp() {
   return (
     <SettingsLayout
       title="MCP Servers"
-      description="Connect Model Context Protocol servers (Close CRM, or any MCP-compatible service) to give the agent tools for external systems. Write actions ask for your approval unless you choose Always allow."
+      description="Connect Model Context Protocol servers (Close CRM, or any MCP-compatible service) to give the agent tools for external systems. Read tools run freely; write actions ask for approval unless you Always allow a tool or the whole server."
     >
       <McpServersSection />
     </SettingsLayout>

--- a/docs/src/content/docs/mcp-connectors.md
+++ b/docs/src/content/docs/mcp-connectors.md
@@ -80,19 +80,20 @@ Within an allowed scope, each discovered tool is assigned a **risk tier**:
 
 ## Approval flow
 
-MCP tool calls use a Claude-style human-in-the-loop approval, surfaced as an **approval card** in chat with an input preview and risk badge. Three choices:
+MCP tool calls use a Claude-style human-in-the-loop approval, surfaced as an **approval card** in chat with an input preview and risk badge. Choices:
 
 - **Allow once** — run this call now.
-- **Always allow** — run now and persist an `always_allow` grant so future calls of this tool skip the prompt.
+- **Always allow this tool** — run now and persist an `always_allow` grant so future calls of **this tool** skip the prompt.
+- **Always allow all tools from this server** — same, but stores a server-wide `*` grant covering every tool the admin ceiling still permits (per-tool Block overrides it).
 - **Deny / Block** — refuse this call; a persisted `always_deny` grant refuses future calls at execution without prompting.
 
 Default behavior by tier:
 
-- **read** tools auto-run (no prompt).
-- **write** tools prompt unless you've granted **always allow**.
-- **destructive** tools always prompt and can only be unlocked by a workspace admin.
+- **read** tools auto-run (no prompt) when the admin ceiling is Always.
+- **write** tools prompt unless you've granted **always allow** (per-tool or server-wide).
+- **destructive** tools always prompt by default (admin ceiling Ask) and can only be unlocked by a workspace admin setting that tool's restriction to Always.
 
-Grants are per-user and per-tool. Manage or revoke them under **Settings → MCP Servers**.
+Grants are per-user. Manage or revoke them under **Settings → MCP Servers** (including a server-wide Always allow control). Admin restrictions are a *ceiling*: if a tool is set to Ask, your Always allow grant is ignored and the prompt still appears.
 
 Tools are namespaced `mcp_<server>_<tool>` in the agent runtime, and are treated as cross-cutting across modes. The [plan gate](/skills/) keeps only read-tier MCP tools available during planning.
 


### PR DESCRIPTION
**Authored by @wieseljonas.** Supersedes #683, cherry-picked onto current master with his commit and authorship preserved (`Cursor Agent <cursoragent@cursor.com>`). It applied with **no conflicts** despite being 413 commits behind.

## What #683 does

Server-wide *Always allow*, and read-tier MCP tools stop prompting on every call. It also resolves a live contradiction: `docs/src/content/docs/mcp-connectors.md` tells users read tools auto-run, while `mcpNeedsApproval` on master has no read-tier branch at all — every tool prompts. **The docs were describing behaviour the code never had.** This makes the code match the docs.

## ⚠️ A second commit you should decide on explicitly

While verifying, I found the read-tier rule is wider than it reads:

`mcpToolRiskTier` returns `"read"` for **every** tool on a connection whose `writeScope` is `"read"` — and `writeScope`:

- **defaults to `"read"`** in the schema (`workspace-schema.ts:5026`), the create route (`mcp.routes.ts:495`) and the add-server form (`McpServersSection.tsx:152`); and
- reaches the provider only for presets that send a scope header — **Close** (`Close-API-Key`) and **GitHub** (`X-MCP-Readonly`). **Custom and Slack send none.**

So with #683 alone, adding *any* custom MCP server on default settings means **every tool on it auto-runs with no prompt** — including tools the server annotates `destructiveHint` — with nothing enforcing read-only anywhere. That is broader than "read tools auto-run", and it is reachable through the default path rather than an unusual configuration.

The second commit gates the skip on read-ness that is actually *dependable*:

```ts
tool.annotations?.readOnlyHint === true      // the server's claim about its own tool
  || Boolean(getMcpPreset(server.connectorType).scopeHeader)  // provider-enforced
```

- **Close still auto-runs** — the motivating case ("stops Close-style connectors from prompting on every search") is preserved, because Close sends a scope header.
- **GitHub still auto-runs**, same reason.
- A custom connection's genuinely `readOnlyHint` tools still auto-run.
- What no longer auto-runs: an unannotated or destructive tool on a connection merely *labelled* read.

**If you want Jonas' behaviour exactly as written, drop commit 2 and merge commit 1 alone.** I've kept them separate for precisely that reason. I'd recommend keeping it.

## Still an open posture question

Even with the gate, `writeScope: "read"` on a **Close or GitHub** connection auto-runs every tool on it, destructive annotations included, on the strength of the provider honouring the scope header. That is the intended design and is defensible — but it is a posture choice, not a bugfix, and worth agreeing on knowingly.

## Verification

- `tsc --noEmit`: **70 errors, identical to master's baseline** — zero introduced. (The build uses `tsconfig.build.json`, which excludes tests; the raw count includes them.)
- `mcp-client.service.test.ts` passes, including Jonas' own assertions that a write tool (`lead_update`) still prompts and a destructive one stays prompt-only.
- New assertions pin the security property directly: a custom connection labelled `read` is **not** enough to skip approval, an explicitly destructive tool on it is **not** enough either, while Close's enforced scope and any tool's own `readOnlyHint` **are**.

Triage by the `mako-workspace-ac` session; the tier finding it raised is what prompted the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB