### PR TITLE
fix(connections): withhold connection strings we cannot prove are safe

### DIFF
--- a/api/src/utils/connection-secrets.test.ts
+++ b/api/src/utils/connection-secrets.test.ts
@@ -62,6 +62,59 @@ assert.equal(
   "clickhouse://mako:*****@db.example.com:8443/analytics",
 );
 
+// --- connection strings fail CLOSED on any shape we cannot parse ------------
+
+// A URI whose credential sits in a query parameter is NOT masked by a
+// URI-shaped rule, so it must be withheld wholesale. This is the shape that
+// actually shipped past the first version of this fix: two production
+// ClickHouse connections were still handing back their credential.
+for (const dsn of [
+  "clickhouse:https://host.example.com:8443/db?password=hunter2",
+  "clickhouse://host.example.com:8443/db?password=hunter2",
+  "host=db.example.com;port=9000;user=mako;password=hunter2",
+  "https://api.example.com/v1?api_key=sk-live-1",
+  "sqlserver://host/db;pwd=hunter2",
+  "mongodb://host/db?authSource=admin&secret=shh",
+]) {
+  assert.equal(
+    redactConnectionSecrets({ connectionString: dsn }).connectionString,
+    SECRET_KEPT,
+    `must withhold: ${dsn}`,
+  );
+}
+
+// A string in no recognised format at all is withheld rather than guessed at.
+assert.equal(
+  redactConnectionSecrets({ connectionString: "not a uri at all" })
+    .connectionString,
+  SECRET_KEPT,
+);
+
+// Provably credential-free URIs stay legible — over-redacting these would cost
+// the edit dialog its usefulness for nothing.
+for (const safe of [
+  "bigquery://realadvisor-prod",
+  "clickhouse://db.example.com:8443/analytics",
+  "postgres://db.example.com:5432/analytics?sslmode=require",
+]) {
+  assert.equal(
+    redactConnectionSecrets({ connectionString: safe }).connectionString,
+    safe,
+    `must stay visible: ${safe}`,
+  );
+}
+
+// A withheld connection string round-trips like any other secret.
+{
+  const stored = { connectionString: "host=h;user=u;password=hunter2" };
+  const shown = redactConnectionSecrets(stored);
+  assert.equal(shown.connectionString, SECRET_KEPT);
+  assert.equal(
+    restoreKeptSecrets(shown, stored).connectionString,
+    stored.connectionString,
+  );
+}
+
 // --- restore: a round-trip must never clobber the stored secret -------------
 
 // The dialog echoes back exactly what it was given.

--- a/api/src/utils/connection-secrets.ts
+++ b/api/src/utils/connection-secrets.ts
@@ -40,6 +40,45 @@ export function maskPasswordInConnectionString(connectionString: string) {
   return connectionString.replace(CONNECTION_STRING_PASSWORD, "$1*****$3");
 }
 
+/** `scheme://host/path` with no `user:pass@` — nothing to hide in the authority. */
+const URI_WITHOUT_USERINFO = /^[a-z][a-z0-9+.-]*:\/\/[^@]*$/i;
+
+/**
+ * A credential carried as a parameter rather than in the authority:
+ * `...?password=`, `;pwd=`, `&api_key=`. No URI-shaped mask catches these.
+ */
+const CREDENTIAL_PARAMETER =
+  /[?&;]\s*[a-z0-9_.-]*(pass(word|wd)?|pwd|secret|token|auth|api[_-]?key|credential)[a-z0-9_.-]*\s*=/i;
+
+/**
+ * Redact a connection string, failing CLOSED.
+ *
+ * Masking the password inside a URI keeps the host legible in the edit dialog,
+ * which is genuinely useful — but it only works on strings shaped like
+ * `scheme://user:pass@host`. Production also holds ClickHouse strings in
+ * neither that shape nor any other we parse, carrying their credential as a
+ * query parameter; a URI mask leaves those untouched and hands back the secret
+ * while looking like it did its job. Partial masking is worse than none,
+ * because it reads as safe.
+ *
+ * So: mask what we can prove, return verbatim only what is provably
+ * credential-free, and withhold everything else entirely. An unrecognised
+ * format is treated as a secret, not as a host.
+ */
+export function redactConnectionString(connectionString: string): string {
+  if (!connectionString) return connectionString;
+  if (CONNECTION_STRING_PASSWORD.test(connectionString)) {
+    return maskPasswordInConnectionString(connectionString);
+  }
+  if (
+    URI_WITHOUT_USERINFO.test(connectionString) &&
+    !CREDENTIAL_PARAMETER.test(connectionString)
+  ) {
+    return connectionString;
+  }
+  return SECRET_KEPT;
+}
+
 /** Strip every credential from a decrypted connection, keeping its shape. */
 export function redactConnectionSecrets(
   connection: Record<string, unknown> | undefined,
@@ -47,7 +86,7 @@ export function redactConnectionSecrets(
   const redacted: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(connection ?? {})) {
     if (key === "connectionString" && typeof value === "string") {
-      redacted[key] = maskPasswordInConnectionString(value);
+      redacted[key] = redactConnectionString(value);
     } else if (SECRET_FIELD.test(key) && typeof value === "string" && value) {
       redacted[key] = SECRET_KEPT;
     } else {


### PR DESCRIPTION
## Follow-up to #909 — a real leak that survived it

#909 made connection credentials write-only, and masked the password *inside* a connection string with a URI-shaped rule: `scheme://user:pass@host`.

**Verified against production after #909 deployed: 2 of 11 connection strings still came back carrying a live credential.** Both are ClickHouse connections stored in neither that shape nor any other we parse — they carry the credential as a query parameter (`...?password=...`). The URI mask leaves them untouched and returns the secret *while looking like it did its job*.

Partial masking is worse than none, because the result reads as safe.

## The rule now fails closed

`redactConnectionString`:

1. URI with `user:pass@` → mask the password, keep the host legible (useful in the edit dialog, and provably safe).
2. URI with no userinfo and no credential-shaped parameter → return verbatim; there is nothing to hide, and over-redacting `bigquery://project-id` costs the dialog its usefulness for nothing.
3. **Everything else → withhold wholesale.** DSN forms, query-parameter credentials, anything in a format we do not recognise. An unparseable string is treated as a secret, not as a host.

Withheld strings round-trip through the existing `SECRET_KEPT` sentinel, which already restores on write — so editing a connection still works and the client still never holds the credential.

## Tests

Cover the shapes actually observed in production plus the ones that would have caught this the first time: query-parameter credentials, `;pwd=` DSN pairs, `host=...;password=...`, unrecognised strings, and the credential-free URIs that must stay visible.

One of them earned its keep immediately: `;pwd=` is not matched by `pass(word|wd)?`, so the first version of the new pattern let `sqlserver://host/db;pwd=hunter2` through. The test caught it before the commit.

Verification was done against production reading **shape only** — derived booleans and counts, never a credential value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBu5kWvdBipSVJfxKpapGh