### PR TITLE
fix(config-as-code): freshen main before committing dbt and flow config

### DIFF
--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -19,7 +19,11 @@ import {
 } from "../database/workspace-schema";
 import { loggers } from "../logging";
 import { authorForUser } from "../apps/workspace-consoles.service";
-import { ensureLocalRepo, queueMirrorPush } from "../apps/cloud-repo.service";
+import {
+  ensureLocalRepo,
+  freshenBeforeMainWrite,
+  queueMirrorPush,
+} from "../apps/cloud-repo.service";
 import {
   DEFAULT_BRANCH,
   repoDirFor,
@@ -90,9 +94,13 @@ async function commitConfig(
   author?: GitAuthor,
 ): Promise<void> {
   const repoDir = await repoDirIfExists(workspaceId);
-  // No repo (pre-§17 workspace): Mongo remains the only home — nothing to
-  // write through. RealAdvisor and every §17-era workspace has one.
   if (!repoDir) return;
+  // Config-as-code commits land on main, so they must be judged against the
+  // mirror's main, not this instance's cache. Without this a stale instance
+  // commits onto an old tip and pushes it — the divergence class #897 fixed
+  // for skills and worktree writes, which these two write paths never
+  // adopted. Coalesced and non-blocking on failure.
+  await freshenBeforeMainWrite(workspaceId);
   const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
     message,
     author,

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -14,7 +14,11 @@
  */
 import { loggers } from "../logging";
 import { authorForUser } from "../apps/workspace-consoles.service";
-import { ensureLocalRepo, queueMirrorPush } from "../apps/cloud-repo.service";
+import {
+  ensureLocalRepo,
+  freshenBeforeMainWrite,
+  queueMirrorPush,
+} from "../apps/cloud-repo.service";
 import {
   DEFAULT_BRANCH,
   blobOid,
@@ -45,10 +49,13 @@ async function commitConfig(
   author?: GitAuthor,
 ): Promise<void> {
   const repoDir = await repoDirIfExists(workspaceId);
-  // No repo: Mongo remains the only home. Block 3 makes a repo required at
-  // the route boundary; while this is export-only, a workspace without one
-  // simply gets no files.
   if (!repoDir) return;
+  // Config-as-code commits land on main, so they must be judged against the
+  // mirror's main, not this instance's cache. Without this a stale instance
+  // commits onto an old tip and pushes it — the divergence class #897 fixed
+  // for skills and worktree writes, which these two write paths never
+  // adopted. Coalesced and non-blocking on failure.
+  await freshenBeforeMainWrite(workspaceId);
   const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
     message,
     author,


### PR DESCRIPTION
Found while auditing whether `pnpm flows:export` was safe to run from a developer machine. **It was not** — and the reason turned out to be a defect in the shipped code rather than anything about environments.

## The bug

Both config-as-code write paths commit onto `main` and queue a mirror push, but **neither calls `freshenBeforeMainWrite`**:

- `dbt/dbt-config.service.ts` — in production since #896
- `services/flow-config.service.ts` — merged today in #911

That is precisely the divergence class #897 fixed for skills and worktree writes, whose own comment describes it exactly: *"a laptop pushes to GitHub, and moments later a skill save, a branch merge, a publish or a box's `git push` lands on an instance whose main predates it — accepted locally (it fast-forwards the STALE tip), unmirrorable forever after."* Config saves take the same path and were never given the same protection.

## Why the export audit surfaced it

The coordinating session flagged that running the export from *its* checkout would read a dev database. Checking my own environment, the database was never the interesting part — **the write path is**. This machine has `~/.mako/apps-v2/repos/6846e6a01b05af0948070582.git`, and `ensureLocalRepo` returns early when the repo already exists. So the export would have committed 31 flow files onto a possibly weeks-old tip and pushed them to `realadvisor/mako-workspace`, looking correct at every step. The same holds for any Cloud Run instance whose cache is behind — this is not a laptop-only hazard.

## The fix

One line each, at the single choke point both services already share (`commitConfig`), so every write through them is judged against the mirror's main: job save, environment change, flow create/update/delete/toggle, and the export CLI.

Ordering is deliberate — the `!repoDir` early return comes first, so a workspace with no connected repo still does no work.

## Verification

Typecheck and lint clean; dbt config service tests pass (7). The behaviour itself is #897's, already tested there — this PR only routes two more callers into it.

## Follow-up, not in this PR

`dbt-config.service.ts` has two other `!repoDir` sites (read paths) that may deserve the same treatment; they are reads, and #894's `freshenForServe` covers the serving path, so they are lower risk and belong to whoever owns dbt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZR5pr8Wxrw4NfPHSsb7CW