### PR TITLE
docs(config-as-code): restore the comments explaining the no-repo return

### DIFF
--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -94,6 +94,8 @@ async function commitConfig(
   author?: GitAuthor,
 ): Promise<void> {
   const repoDir = await repoDirIfExists(workspaceId);
+  // No repo (pre-§17 workspace): Mongo remains the only home — nothing to
+  // write through. RealAdvisor and every §17-era workspace has one.
   if (!repoDir) return;
   // Config-as-code commits land on main, so they must be judged against the
   // mirror's main, not this instance's cache. Without this a stale instance

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -49,6 +49,9 @@ async function commitConfig(
   author?: GitAuthor,
 ): Promise<void> {
   const repoDir = await repoDirIfExists(workspaceId);
+  // No repo: Mongo remains the only home. Block 3 makes a repo required at
+  // the route boundary; while this is export-only, a workspace without one
+  // simply gets no files.
   if (!repoDir) return;
   // Config-as-code commits land on main, so they must be judged against the
   // mirror's main, not this instance's cache. Without this a stale instance


### PR DESCRIPTION
Small follow-up to #916, flagged by the coordinating session on review.

My patch there replaced a now-redundant guard and took two explanatory comments with it, leaving `if (!repoDir) return;` unexplained in both config services. The condition isn't self-evident: it encodes that a workspace without a connected repo keeps Mongo as its only home — a product decision (§17 for dbt; for flows, the one block 3 changes when a repo becomes required at the route boundary).

Comments only, no behaviour change. Typecheck and lint clean.

One note on how it was done: the first attempt asserted its anchor was unique in the file and **failed**, because `dbt-config.service.ts` has several `!repoDir` sites. Scoping the replacement to the `commitConfig` function body fixed it — worth mentioning because a looser anchor would have silently commented the wrong early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZR5pr8Wxrw4NfPHSsb7CW