### PR TITLE
fix(security): remove the connector decryption oracle — reveal secrets by id, admin-only

### DIFF
--- a/api/src/routes/connector-reveal-secret.test.ts
+++ b/api/src/routes/connector-reveal-secret.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The connector decrypt oracle, and the two vulnerabilities it carried.
+ *
+ * `POST /connectors/decrypt` took ciphertext from the request body and
+ * returned its plaintext, gated only on workspace membership. Because
+ * ENCRYPTION_KEY is global and the ciphertext was never bound to a
+ * workspace, that gave (1) cross-tenant decryption — any member of any
+ * workspace could decrypt ciphertext harvested from another tenant, a DB
+ * dump or a backup — and (2) privilege escalation inside a workspace, since
+ * a VIEWER could read credentials only admins may edit.
+ *
+ * These specs pin the replacement: the server reads the ciphertext from its
+ * own record, addressed by connector id scoped to the URL workspace, and
+ * only admins/owners may ask.
+ *
+ * Which specs are BEFORE/AFTER PROOFS and which are forward pins, stated
+ * plainly so nobody mistakes one for the other:
+ *   - the two `/decrypt` specs are real proofs: on the old handler that
+ *     route answered 200 with the plaintext (for any member, and for a
+ *     VIEWER), so they fail before the change and pass after it;
+ *   - the reveal-secret specs (cross-workspace 404, viewer 403, owner 200,
+ *     non-secret field 400) are forward pins: on the old code they fail
+ *     only because the route did not exist, which proves nothing about the
+ *     old behaviour. They exist to keep the NEW gates from regressing.
+ *
+ * Real routes + real Mongo (mongodb-memory-server); only auth, the
+ * workspace service, and the connector registry are mocked.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+const ctx = vi.hoisted(() => ({ role: "owner" as string | null }));
+
+vi.mock("../auth/unified-auth.middleware", () => ({
+  unifiedAuthMiddleware: async (
+    c: { set: (k: string, v: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set("user", { id: "u1" });
+    await next();
+  },
+}));
+
+vi.mock("../services/workspace.service", () => ({
+  workspaceService: {
+    hasAccess: vi.fn(async () => ctx.role !== null),
+    getMember: vi.fn(async () => (ctx.role ? { role: ctx.role } : null)),
+    isAdmin: vi.fn(async () => ctx.role === "owner" || ctx.role === "admin"),
+  },
+}));
+
+// The connector's schema declares which config fields are secret.
+vi.mock("../sync/connector-registry", () => ({
+  syncConnectorRegistry: {
+    getConfigSchemaForType: vi.fn(async () => ({
+      fields: [
+        { name: "api_key", type: "password", encrypted: true },
+        { name: "account", type: "string" },
+      ],
+    })),
+  },
+}));
+
+import { dataSourceRoutes } from "./sources";
+import { Connector } from "../database/workspace-schema";
+import { encryptString } from "../services/crypto.service";
+
+let mongo: MongoMemoryServer;
+const WS_MINE = new Types.ObjectId().toString();
+const WS_THEIRS = new Types.ObjectId().toString();
+const SECRET = "sk_live_theirs_do_not_leak";
+
+const app = new Hono();
+app.route("/api/workspaces/:workspaceId/connectors", dataSourceRoutes);
+
+function req(
+  workspaceId: string,
+  path: string,
+  body: unknown,
+): Promise<Response> {
+  return app.request(`/api/workspaces/${workspaceId}/connectors${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  process.env.ENCRYPTION_KEY =
+    process.env.ENCRYPTION_KEY ??
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  ctx.role = "owner";
+  await Connector.deleteMany({});
+});
+
+async function seedConnector(workspaceId: string) {
+  return Connector.create({
+    workspaceId: new Types.ObjectId(workspaceId),
+    name: "Stripe",
+    type: "stripe",
+    config: { api_key: encryptString(SECRET), account: "acct_123" },
+    isActive: true,
+    createdBy: "u1",
+    settings: {
+      sync_batch_size: 100,
+      rate_limit_delay_ms: 200,
+      max_retries: 3,
+      timeout_ms: 30000,
+      timezone: "UTC",
+    },
+  });
+}
+
+describe("the decryption oracle is gone", () => {
+  it("there is no endpoint that decrypts caller-supplied ciphertext", async () => {
+    // THE VULNERABILITY: this used to return the plaintext of any ciphertext
+    // encrypted with the global key, from any tenant. It must not exist.
+    const stolen = encryptString(SECRET);
+    const res = await req(WS_MINE, "/decrypt", { encryptedValue: stolen });
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).not.toContain(SECRET);
+  });
+
+  it("a VIEWER cannot decrypt caller-supplied ciphertext either", async () => {
+    // THE SECOND VULNERABILITY: membership-only gating meant a viewer could
+    // read credentials only admins may edit. On the old handler this
+    // returned plaintext for a viewer; the endpoint must simply be gone.
+    ctx.role = "viewer";
+    const res = await req(WS_MINE, "/decrypt", {
+      encryptedValue: encryptString(SECRET),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain(SECRET);
+  });
+
+  it("a connector from ANOTHER workspace cannot be revealed", async () => {
+    // Cross-tenant, now expressed the only way it still can be: name a
+    // connector id that exists, from a workspace the caller is not in.
+    const theirs = await seedConnector(WS_THEIRS);
+    const res = await req(
+      WS_MINE,
+      `/${theirs._id.toString()}/reveal-secret`,
+      { field: "api_key" },
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain(SECRET);
+  });
+});
+
+describe("reveal-secret is admin/owner only", () => {
+  it("a VIEWER is refused — membership is not enough", async () => {
+    const mine = await seedConnector(WS_MINE);
+    ctx.role = "viewer";
+    const res = await req(
+      WS_MINE,
+      `/${mine._id.toString()}/reveal-secret`,
+      { field: "api_key" },
+    );
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain(SECRET);
+  });
+
+  it("an owner reveals their own connector's secret", async () => {
+    const mine = await seedConnector(WS_MINE);
+    const res = await req(
+      WS_MINE,
+      `/${mine._id.toString()}/reveal-secret`,
+      { field: "api_key" },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { value: string; wasEncrypted: boolean };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.value).toBe(SECRET);
+    expect(body.data.wasEncrypted).toBe(true);
+  });
+
+  it("only fields the schema declares secret may be revealed", async () => {
+    const mine = await seedConnector(WS_MINE);
+    const res = await req(
+      WS_MINE,
+      `/${mine._id.toString()}/reveal-secret`,
+      { field: "account" },
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/api/src/routes/sources.ts
+++ b/api/src/routes/sources.ts
@@ -731,91 +731,152 @@ dataSourceRoutes.openapi(
   },
 );
 
+/**
+ * Reveal ONE stored secret of ONE connector the caller's workspace owns.
+ *
+ * This replaces `POST /decrypt`, which took ciphertext from the request body
+ * and returned its plaintext. That endpoint was a cross-tenant decryption
+ * oracle: ENCRYPTION_KEY is global, the ciphertext was never bound to a
+ * workspace, and membership was the only gate — so any member of any
+ * workspace could decrypt ciphertext harvested from another tenant, a DB
+ * dump or a backup, and any VIEWER could read admin-managed credentials.
+ * (An earlier fix closed the padding-oracle half by collapsing distinct
+ * decryption errors to one opaque message; the plaintext-on-success half is
+ * what this removes.)
+ *
+ * The primitive is gone rather than narrowed: the server reads the
+ * ciphertext from its OWN record, addressed by connector id scoped to the
+ * URL workspace, so nothing decryptable can be supplied by the caller. The
+ * gate is admin/owner — the same people who may edit these credentials —
+ * and every reveal is logged with actor, connector and field, because
+ * showing a credential should leave a trace.
+ */
 dataSourceRoutes.openapi(
   createRoute({
     method: "post",
-    path: "/decrypt",
+    path: "/{id}/reveal-secret",
     tags: ["Connectors"],
-    summary: "Decrypt a connector value (debug)",
+    summary: "Reveal one stored secret of a connector (admin/owner only)",
     security: AUTH_SECURITY,
-    request: { params: WorkspaceParam, body: OpenBody },
+    request: {
+      params: WorkspaceParam.extend({
+        id: z.string().openapi({ param: { name: "id", in: "path" } }),
+      }),
+      body: {
+        content: {
+          "application/json": {
+            schema: z.object({
+              field: z
+                .string()
+                .min(1)
+                .max(128)
+                .openapi({
+                  description:
+                    "Top-level config field name declared encrypted by the connector's schema.",
+                }),
+            }),
+          },
+        },
+      },
+    },
     responses: { ...OPEN_RESPONSES },
   }),
   async c => {
     try {
-      const { encryptedValue } = await c.req.json();
+      const workspaceId = c.req.param("workspaceId");
+      const id = c.req.param("id");
+      const { field } = await c.req.json();
 
-      if (!encryptedValue) {
+      if (!workspaceId || !id || !Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid connector id" }, 400);
+      }
+      if (typeof field !== "string" || !field) {
+        return c.json({ success: false, error: "field is required" }, 400);
+      }
+
+      // Revealing a credential is an admin/owner act — the same bar as
+      // editing it. Membership is NOT enough (a viewer must not read the
+      // credentials an admin configured).
+      const user = c.get("user");
+      if (!user || !(await workspaceService.isAdmin(workspaceId, user.id))) {
         return c.json(
           {
             success: false,
-            error: "Encrypted value is required",
+            error:
+              "Revealing a connector secret requires the admin or owner workspace role",
           },
+          403,
+        );
+      }
+
+      // The ciphertext comes from OUR record for THIS workspace — never from
+      // the caller. This is what makes the oracle impossible.
+      const dataSource = await DataSource.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId,
+      }).lean();
+      if (!dataSource) {
+        return c.json({ success: false, error: "Connector not found" }, 404);
+      }
+
+      // Only fields the connector's schema declares secret may be revealed,
+      // so this cannot be used to walk arbitrary config.
+      const schema = await syncConnectorRegistry.getConfigSchemaForType(
+        (dataSource as { type: string }).type,
+      );
+      const declared = (schema?.fields ?? []).find(
+        (f: ConnectorFieldSchema) => f.name === field,
+      );
+      const isSecret =
+        declared &&
+        (declared.encrypted === true || declared.type === "password");
+      if (!isSecret) {
+        return c.json(
+          { success: false, error: "That field is not a connector secret" },
           400,
         );
       }
 
-      // Get encryption key from environment
-      const encryptionKey = process.env.ENCRYPTION_KEY;
-      if (!encryptionKey) {
-        return c.json(
-          {
-            success: false,
-            error: "ENCRYPTION_KEY not configured",
-          },
-          500,
-        );
+      const stored = (dataSource as { config?: Record<string, unknown> })
+        .config?.[field];
+      if (typeof stored !== "string" || !stored) {
+        return c.json({ success: true, data: { value: "", wasEncrypted: false } });
       }
 
-      // Check if the value is encrypted (contains ':')
-      if (!encryptedValue.includes(":")) {
+      logger.info("Connector secret revealed", {
+        workspaceId,
+        connectorId: id,
+        field,
+        actorId: user.id,
+      });
+
+      if (!stored.includes(":")) {
+        // Stored in the clear (legacy rows predating schema-driven
+        // encryption): hand it back, but say so.
         return c.json({
           success: true,
-          data: {
-            decryptedValue: encryptedValue,
-            wasEncrypted: false,
-          },
+          data: { value: stored, wasEncrypted: false },
         });
       }
 
       try {
-        // Parse the encrypted string (format: iv:encrypted_data)
-        const textParts = encryptedValue.split(":");
-        if (textParts.length < 2) {
-          return c.json(
-            {
-              success: false,
-              error: "Invalid encrypted format (expected iv:data)",
-            },
-            400,
-          );
-        }
-
-        const decrypted = decryptEncrypted(encryptedValue);
-
         return c.json({
           success: true,
-          data: {
-            decryptedValue: decrypted,
-            wasEncrypted: true,
-          },
+          data: { value: decryptEncrypted(stored), wasEncrypted: true },
         });
-      } catch (error: any) {
-        // Log full detail server-side, but return a single opaque error to the
-        // client. Distinct decryption-failure messages (e.g. bad padding) turn
-        // this endpoint into a padding oracle against the unauthenticated
-        // AES-256-CBC scheme, enabling plaintext recovery.
-        logger.error("Decryption error", { error });
-        return c.json(
-          {
-            success: false,
-            error: "Decryption failed",
-          },
-          400,
-        );
+      } catch (error) {
+        // One opaque message: distinct decryption failures against the
+        // unauthenticated AES-256-CBC scheme are a padding oracle.
+        logger.error("Connector secret decryption failed", {
+          error,
+          workspaceId,
+          connectorId: id,
+          field,
+        });
+        return c.json({ success: false, error: "Decryption failed" }, 400);
       }
-    } catch (error: any) {
-      logger.error("Decrypt endpoint error", { error });
+    } catch (error) {
+      logger.error("Reveal-secret endpoint error", { error });
       return c.json(
         {
           success: false,

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "src/dbt/**/*.test.ts",
       "src/integrations/github/**/*.test.ts",
       "src/routes/dbt.routes.integration.test.ts",
+      "src/routes/connector-reveal-secret.test.ts",
       "src/agent-lib/tools/dbt-*.test.ts",
     ],
     exclude: [

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -1714,7 +1714,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/workspaces/{workspaceId}/connectors/decrypt": {
+    "/api/workspaces/{workspaceId}/connectors/{id}/reveal-secret": {
         parameters: {
             query?: never;
             header?: never;
@@ -1723,8 +1723,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Decrypt a connector value (debug) */
-        post: operations["post_api_workspaces_workspaceId_connectors_decrypt"];
+        /** Reveal one stored secret of a connector (admin/owner only) */
+        post: operations["post_api_workspaces_workspaceId_connectors_id_reveal_secret"];
         delete?: never;
         options?: never;
         head?: never;
@@ -11546,19 +11546,21 @@ export interface operations {
             };
         };
     };
-    post_api_workspaces_workspaceId_connectors_decrypt: {
+    post_api_workspaces_workspaceId_connectors_id_reveal_secret: {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 workspaceId: string;
+                id: string;
             };
             cookie?: never;
         };
         requestBody?: {
             content: {
                 "application/json": {
-                    [key: string]: unknown;
+                    /** @description Top-level config field name declared encrypted by the connector's schema. */
+                    field: string;
                 };
             };
         };

--- a/app/src/components/ConnectorForm.tsx
+++ b/app/src/components/ConnectorForm.tsx
@@ -1,3 +1,4 @@
+import { useWorkspace } from "../contexts/workspace-context";
 import { useEffect, useState, useMemo, useRef } from "react";
 import {
   Button,
@@ -112,6 +113,7 @@ function ConnectorForm({
   tabId,
   onDirtyChange,
 }: ConnectorFormProps) {
+  const { currentWorkspace } = useWorkspace();
   const [schema, setSchema] = useState<ConnectorSchemaResponse | null>(null);
   const [schemaLoading, setSchemaLoading] = useState(false);
   const [schemaError, setSchemaError] = useState<string | null>(null);
@@ -249,25 +251,27 @@ function ConnectorForm({
     });
   }, [selectedType, schemas, fetchSchema, form]);
 
-  const decryptValue = async (fieldName: string, encryptedValue: string) => {
-    if (!encryptedValue) {
-      setSnackbarMessage("No value to decrypt");
+  // Reveal a stored secret: the SERVER reads the ciphertext from its own
+  // connector record (apps.md — connector decrypt oracle fix). The client
+  // names a field; it never sends ciphertext, and it no longer picks the
+  // workspace id. Admin/owner only, server-enforced.
+  const revealSecret = async (fieldName: string) => {
+    const connectorId = connector?._id;
+    if (!connectorId) {
+      setSnackbarMessage("Save the connector before revealing its secrets");
       return;
     }
+    if (!currentWorkspace?.id) return;
 
     setDecryptingFields(prev => ({ ...prev, [fieldName]: true }));
 
     try {
-      const workspaceId = connector?.workspaceId || "default";
-
       const response = await fetch(
-        `/api/workspaces/${workspaceId}/connectors/decrypt`,
+        `/api/workspaces/${currentWorkspace.id}/connectors/${connectorId}/reveal-secret`,
         {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ encryptedValue }),
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ field: fieldName }),
         },
       );
 
@@ -276,22 +280,17 @@ function ConnectorForm({
       if (result.success) {
         setDecryptedValues(prev => ({
           ...prev,
-          [fieldName]: result.data.decryptedValue,
+          [fieldName]: result.data.value,
         }));
-        setShowDecryptedFields(prev => ({
-          ...prev,
-          [fieldName]: true,
-        }));
-
+        setShowDecryptedFields(prev => ({ ...prev, [fieldName]: true }));
         if (!result.data.wasEncrypted) {
           setSnackbarMessage("Value was not encrypted");
         }
       } else {
-        setSnackbarMessage(result.error || "Failed to decrypt value");
+        setSnackbarMessage(result.error || "Failed to reveal value");
       }
-    } catch (error) {
-      console.error("Decrypt error:", error);
-      setSnackbarMessage("Failed to decrypt value");
+    } catch {
+      setSnackbarMessage("Failed to reveal value");
     } finally {
       setDecryptingFields(prev => ({ ...prev, [fieldName]: false }));
     }
@@ -594,7 +593,7 @@ function ConnectorForm({
                                 !decryptedValues[name] &&
                                 !showDecryptedFields[name]
                               ) {
-                                decryptValue(name, field.value);
+                                revealSecret(name);
                               } else {
                                 toggleDecryptedVisibility(name);
                               }
@@ -663,7 +662,7 @@ function ConnectorForm({
                               !decryptedValues[name] &&
                               !showDecryptedFields[name]
                             ) {
-                              decryptValue(name, field.value);
+                              revealSecret(name);
                             } else {
                               toggleDecryptedVisibility(name);
                             }

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -11707,12 +11707,12 @@
         "operationId": "get_api_workspaces_workspaceId_connectors_id_entities"
       }
     },
-    "/api/workspaces/{workspaceId}/connectors/decrypt": {
+    "/api/workspaces/{workspaceId}/connectors/{id}/reveal-secret": {
       "post": {
         "tags": [
           "Connectors"
         ],
-        "summary": "Decrypt a connector value (debug)",
+        "summary": "Reveal one stored secret of a connector (admin/owner only)",
         "security": [
           {
             "cookieAuth": []
@@ -11729,15 +11729,32 @@
             "required": true,
             "name": "workspaceId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
           }
         ],
         "requestBody": {
-          "required": false,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": {}
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": "Top-level config field name declared encrypted by the connector's schema."
+                  }
+                },
+                "required": [
+                  "field"
+                ]
               }
             }
           }
@@ -11784,7 +11801,7 @@
             }
           }
         },
-        "operationId": "post_api_workspaces_workspaceId_connectors_decrypt"
+        "operationId": "post_api_workspaces_workspaceId_connectors_id_reveal_secret"
       }
     },
     "/api/workspaces/{workspaceId}/flows": {


### PR DESCRIPTION
## The vulnerability

`POST /api/workspaces/:wid/connectors/decrypt` (OpenAPI summary: *"Decrypt a connector value (debug)"*) took **ciphertext from the request body** and returned its plaintext. `ENCRYPTION_KEY` is global, the ciphertext was never bound to a workspace, and workspace membership was the only gate — `sources.ts` had no role check anywhere in the file. That is three problems, not one:

1. **Cross-tenant decryption.** Any member of any workspace could decrypt ciphertext harvested from another tenant, a DB dump, or a backup. The caller even chose the workspace segment — `ConnectorForm` sent `connector?.workspaceId || "default"` — so the URL constrained nothing.
2. **Privilege escalation inside a workspace.** Membership-only gating meant a **viewer** could read credentials only admins may edit.
3. **Unbounded future scope.** #899 (per-app env vault) encrypts with the same `crypto.service` and the same global key, so this endpoint would have returned per-app env secrets too — a class of secret that did not exist when it was written. Every new encrypted-secret feature silently extended its blast radius.

An earlier fix closed the *padding-oracle* half of this endpoint by collapsing distinct decryption failures into one opaque message (see the comment it left behind). It did not touch the plaintext-on-success half, which is what this removes.

## The change

The primitive is **removed, not narrowed**: `POST /connectors/:id/reveal-secret { field }`.

- The **server** reads the ciphertext from its own record, addressed by connector id **scoped to the URL workspace** — nothing decryptable can be supplied by the caller, so the oracle cannot exist.
- **Admin/owner only**, via the existing `workspaceService.isAdmin` — the same bar as editing these credentials.
- Only fields the connector's schema declares secret (`encrypted: true` or `type: "password"`) may be revealed, so it cannot be used to walk arbitrary config.
- The opaque single failure message is preserved, keeping the padding oracle closed.
- `ConnectorForm` sends a **field name** instead of ciphertext, and no longer picks the workspace id.

**Audit trail:** every successful reveal emits `logger.info("Connector secret revealed", { workspaceId, connectorId, field, actorId })` from `api/src/routes/sources.ts` — structured, so it is greppable by `actorId` or `connectorId` in Cloud Logging.

## Tests — what is proven and what is only pinned

Six specs in `api/src/routes/connector-reveal-secret.test.ts`. Being explicit, because a security fix without a failing-before test is a claim rather than a fix:

**Genuine before/after proofs (2).** I checked out `origin/master`'s `sources.ts`, ran the suite against the vulnerable handler, and watched these fail — the old route answered **200 with the plaintext**, both for an ordinary member and for a **viewer**:
- `there is no endpoint that decrypts caller-supplied ciphertext`
- `a VIEWER cannot decrypt caller-supplied ciphertext either`

**Forward pins, not proofs (4).** Cross-workspace 404, viewer 403, owner 200, non-secret field 400. Against the old code these fail *only because the route did not exist*, which proves nothing about the old behaviour. Worth calling out: the cross-workspace spec initially **passed** against the vulnerable code for the wrong reason — route-absent 404 matching the expected connector-not-found 404. The test file's docblock states which specs are which so nobody later mistakes a pin for a proof.

Placement: this is a **vitest-style** spec, so it is registered in `api/vitest.config.ts`'s include list and deliberately **not** in `api/package.json`'s `&&` chain, where it would fail at import and take every later test down with it.

## Verification

- 6/6 pass with the fix; 5/6 fail without it (the sixth is the cross-workspace pin, explained above).
- No regressions: api routes/dbt suite **233 passed | 2 skipped**, app suite **436 passed**.
- `tsc` and `eslint` clean on both packages.
- `pnpm openapi:sync` committed — the spec now carries `reveal-secret`, and `connectors/decrypt` is gone from both `docs/src/openapi/mako-api.json` and `app/src/api/schema.d.ts` (0 occurrences).

## Not verified

The eye-icon flow is proven at the route and type level but **has not been clicked in a browser** — that needs the dev stack, which is a shared resource here. Worth a manual pass before merge if you want belt and braces.

## Breaking change

Removes `POST /connectors/decrypt`. Breaking for any external API-key client calling it; the in-app caller is migrated in this PR. Approved knowingly. If a deprecation window is wanted instead, that is additive to this change, not a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBvKhee57BjfDVSyvKfoat