### PR TITLE
fix(config-as-code): freshen at the choke point, and say so when it fails

### DIFF
--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -355,6 +355,7 @@ const freshenInFlight = new Map<string, Promise<void>>();
 export async function freshenForServe(
   workspaceId: string,
   intervalMs: number = FRESHEN_INTERVAL_MS,
+  intent: "serve" | "write" = "serve",
 ): Promise<void> {
   if (Date.now() - (lastFreshenAt.get(workspaceId) ?? 0) < intervalMs) return;
   const existing = freshenInFlight.get(workspaceId);
@@ -363,10 +364,29 @@ export async function freshenForServe(
     try {
       await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
     } catch (error) {
-      logger.warn("Freshen before serve failed; serving local state", {
+      const details = {
         workspaceId,
         error: error instanceof Error ? error.message : String(error),
-      });
+      };
+      if (intent === "write") {
+        // A failed freshen before a WRITE is not a degraded read — it means
+        // the commit about to happen is being judged against a tip that may
+        // already be behind the mirror, which is how a local repo diverges
+        // and stops being able to push at all. Staying non-blocking is the
+        // right trade (a brief mirror outage must not fail a user's save),
+        // but it must not be silent: this exact failure went unnoticed in
+        // dev because a local bare repo had no fetch remote configured, and
+        // ten commits landed on a diverged main before anyone looked.
+        logger.error(
+          "Freshen before a main write FAILED; committing against a possibly stale tip",
+          details,
+        );
+      } else {
+        logger.warn(
+          "Freshen before serve failed; serving local state",
+          details,
+        );
+      }
     } finally {
       lastFreshenAt.set(workspaceId, Date.now());
     }
@@ -478,7 +498,11 @@ export async function fetchFromCloud(
  * must not block the user's write; the mirror push simply retries later.
  */
 export function freshenBeforeMainWrite(workspaceId: string): Promise<void> {
-  return freshenForServe(workspaceId, 0);
+  // "write" only raises the volume when it fails; the fetch is identical. A
+  // serve-freshen already in flight is shared rather than duplicated, so a
+  // write can occasionally inherit a serve's warn — acceptable, since the
+  // failure is still reported and the next write logs it at full volume.
+  return freshenForServe(workspaceId, 0, "write");
 }
 
 export type ConnectedRepoAdoption =

--- a/api/src/dbt/dbt-config-freshen.test.ts
+++ b/api/src/dbt/dbt-config-freshen.test.ts
@@ -1,0 +1,257 @@
+/**
+ * A stale local tip must not delete a dbt job.
+ *
+ * `syncDbtConfigNow` reconciles Mongo against the repo by deleting every job
+ * row whose file is absent from the tree it read. That is correct only if the
+ * tree it read is current. The local bare repo is a CACHE — `ensureLocalRepo`
+ * returns early once the directory exists and never refreshes it — so on a
+ * long-lived Cloud Run instance "the repo is present" says nothing about
+ * whether it is up to date, and a push that arrived at GitHub from somebody's
+ * laptop is invisible here until something fetches it.
+ *
+ * So the failure this guards is not a stale read, it is a destructive one: a
+ * job added on the mirror is missing from the stale tree, its row is deleted,
+ * and its schedule is deregistered with it. Nothing else in the system would
+ * notice, because deleting a job whose file is gone is exactly what this code
+ * is supposed to do.
+ *
+ * Lives in its own file rather than joining dbt-config.service.test.ts
+ * because it needs the connected-mirror mocks, and `vi.mock` is file-wide —
+ * pulling them into the existing suite would put every case there behind a
+ * mirror it does not want. Covered by vitest.config.ts's `src/dbt/**` glob.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+const state = vi.hoisted(() => ({
+  binding: null as null | { owner: string; repo: string },
+}));
+
+vi.mock("../services/workspace-repos.service", () => ({
+  getWorkspaceRepo: vi.fn(async () => state.binding),
+  findWorkspaceIdByRepoBinding: vi.fn(async () => null),
+}));
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: async () => undefined,
+}));
+
+import { DbtJob, DbtProject } from "../database/workspace-schema";
+import { runGit } from "../apps/git";
+import { mirrorPushNow } from "../apps/cloud-repo.service";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  initRepo,
+  repoDirFor,
+} from "../apps/repository.service";
+import { jobFilePath, serializeJobFile } from "./dbt-config-files";
+import {
+  adoptDbtConfig,
+  reserveJobSlug,
+  syncDbtConfigFromRepo,
+} from "./dbt-config.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+let remotesRoot: string;
+// A fresh workspace per test. cloud-repo.service keeps per-workspace state —
+// the mirror push is coalesced and fire-and-forget, so a push queued by one
+// test can execute during the next one, against that test's mirror, from a
+// repo mid-clone. Sharing one id makes the two cases fail each other in ways
+// that have nothing to do with what they assert.
+let WS: Types.ObjectId;
+const CONN = new Types.ObjectId();
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "dbt-freshen-test-"));
+  remotesRoot = path.join(tmpRoot, "remotes");
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_GITHUB_REMOTE_BASE = `file://${remotesRoot}`;
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  delete process.env.APPS_REQUIRE_CONNECTED_REPO;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  WS = new Types.ObjectId();
+  await Promise.all([DbtProject.deleteMany({}), DbtJob.deleteMany({})]);
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+  await fs.rm(remotesRoot, { recursive: true, force: true });
+  state.binding = null;
+  process.env.APPS_CONNECTED_REPO_PUSH = "allow";
+});
+
+async function seedProject() {
+  return DbtProject.create({
+    workspaceId: WS,
+    name: "Analytics",
+    dbtVersion: "1.9",
+    environments: [
+      {
+        name: "prod",
+        connectionId: CONN,
+        targetSchema: "dbt_prod",
+        threads: 8,
+      },
+    ],
+    defaultEnvironment: "prod",
+    createdBy: "u1",
+  });
+}
+
+function jobYaml(name: string): string {
+  return serializeJobFile({
+    name,
+    environment: "prod",
+    commands: ["build --select realadvisor"],
+    schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+    enabled: true,
+    deferToProduction: false,
+  });
+}
+
+describe("a stale local tip", () => {
+  it("does not delete a job whose file exists on the mirror", async () => {
+    // The workspace has a connected mirror, and the local repo is a clone of
+    // it that is about to fall behind.
+    const remoteDir = path.join(remotesRoot, "acme", "warehouse.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    // Seeded, not empty: the local repo is a CLONE of this, so the mirror is
+    // where main comes from.
+    await initRepo(remoteDir, { "README.md": "warehouse\n" });
+    state.binding = { owner: "acme", repo: "warehouse" };
+
+    const project = await seedProject();
+    const kept = await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      slug: await reserveJobSlug(project._id, "Nightly build"),
+      name: "Nightly build",
+      environment: "prod",
+      commands: ["build --select realadvisor"],
+      schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+      enabled: true,
+      createdBy: "u1",
+    });
+    // Adoption writes the environments file and this job's file, and pushes.
+    await adoptDbtConfig(WS.toString());
+    // adoptDbtConfig already queued the mirror push; await THAT rather than
+    // pushing by hand, which races it for the same ref lock. mirrorPushNow
+    // shares the per-workspace serialization the queued push uses.
+    await mirrorPushNow(WS.toString());
+
+    // A colleague adds a second job from their laptop: it lands on GitHub,
+    // and this instance's cache knows nothing about it.
+    const added = await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      slug: "laptop-added",
+      name: "Laptop added",
+      environment: "prod",
+      commands: ["build --select realadvisor"],
+      schedule: { cron: "0 7 * * *", timezone: "Europe/Zurich" },
+      enabled: true,
+      createdBy: "u2",
+    });
+    await commitBlobsOnBranch(
+      remoteDir,
+      DEFAULT_BRANCH,
+      { writes: { [jobFilePath("laptop-added")]: jobYaml("Laptop added") } },
+      { message: "add a job from a laptop" },
+    );
+
+    // The local tip is now genuinely behind the mirror — the precondition.
+    const localBefore = (
+      await runGit([
+        "-C",
+        repoDirFor(WS.toString()),
+        "rev-parse",
+        `refs/heads/${DEFAULT_BRANCH}`,
+      ])
+    ).stdout.trim();
+    const remoteHead = (
+      await runGit([
+        "-C",
+        remoteDir,
+        "rev-parse",
+        `refs/heads/${DEFAULT_BRANCH}`,
+      ])
+    ).stdout.trim();
+    expect(localBefore).not.toBe(remoteHead);
+
+    await syncDbtConfigFromRepo(WS.toString());
+
+    // Without the freshen the sync reads the stale tree, does not see
+    // laptop-added.yml, and deletes the row — silently, and taking the
+    // schedule with it.
+    expect(await DbtJob.findById(added._id)).not.toBeNull();
+    expect(await DbtJob.findById(kept._id)).not.toBeNull();
+    // …and the cache caught up rather than merely being read around.
+    const localAfter = (
+      await runGit([
+        "-C",
+        repoDirFor(WS.toString()),
+        "rev-parse",
+        `refs/heads/${DEFAULT_BRANCH}`,
+      ])
+    ).stdout.trim();
+    expect(localAfter).toBe(remoteHead);
+  });
+
+  it("still deletes a job whose file was genuinely removed on the mirror", async () => {
+    // The freshen must not turn the reconciler off: a file deleted on the
+    // mirror must still delete its row, or a stale-tip fix would quietly
+    // become "never delete anything".
+    const remoteDir = path.join(remotesRoot, "acme", "warehouse2.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await initRepo(remoteDir, { "README.md": "warehouse\n" });
+    state.binding = { owner: "acme", repo: "warehouse2" };
+
+    const project = await seedProject();
+    const doomed = await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      slug: await reserveJobSlug(project._id, "Doomed job"),
+      name: "Doomed job",
+      environment: "prod",
+      commands: ["build --select realadvisor"],
+      schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+      enabled: true,
+      createdBy: "u1",
+    });
+    await adoptDbtConfig(WS.toString());
+    // adoptDbtConfig already queued the mirror push; await THAT rather than
+    // pushing by hand, which races it for the same ref lock. mirrorPushNow
+    // shares the per-workspace serialization the queued push uses.
+    await mirrorPushNow(WS.toString());
+
+    await commitBlobsOnBranch(
+      remoteDir,
+      DEFAULT_BRANCH,
+      { deletes: [jobFilePath(doomed.slug!)] },
+      { message: "remove the job on the mirror" },
+    );
+
+    await syncDbtConfigFromRepo(WS.toString());
+    expect(await DbtJob.findById(doomed._id)).toBeNull();
+  });
+});

--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -81,10 +81,36 @@ function environmentsToFile(project: IDbtProject) {
   };
 }
 
+/**
+ * The workspace repo, at a tip that agrees with the mirror.
+ *
+ * Every path in this module — the write, the push-triggered sync, the
+ * adoption migration — reaches the repo through here, so the freshen belongs
+ * here and nowhere else. `ensureLocalRepo` returns early once the directory
+ * exists and never refreshes it, so on a long-lived Cloud Run instance
+ * "the repo is present" says nothing about whether it is current.
+ *
+ * A stale tip is not merely stale on these paths, it is WRONG, and on one of
+ * them it is destructive: `syncDbtConfigNow` deletes every job row whose file
+ * is absent from the tree it read, so reading an old tip deletes the rows for
+ * jobs added since — and deregisters their schedules with them. `adoptDbtConfig`
+ * fails the other way: it computes "which files already exist" from the tree
+ * and writes the rest, so an old tip makes it overwrite a newer job file with
+ * Mongo's version. Freshening at COMMIT time cannot fix that second one — the
+ * payload was already decided from a stale read — which is why this moved up
+ * here from commitConfig rather than being added alongside it (#916).
+ *
+ * Cheap where it sits: the three callers are a write, a push reaction that is
+ * already detached and coalesced by `syncInFlight`, and a rare migration.
+ * None is a per-request hot path, so this is not the reflexive freshen that a
+ * read path should refuse.
+ */
 async function repoDirIfExists(workspaceId: string): Promise<string | null> {
   await ensureLocalRepo(workspaceId);
   const repoDir = repoDirFor(workspaceId);
-  return (await repoExists(repoDir)) ? repoDir : null;
+  if (!(await repoExists(repoDir))) return null;
+  await freshenBeforeMainWrite(workspaceId);
+  return repoDir;
 }
 
 async function commitConfig(
@@ -93,14 +119,13 @@ async function commitConfig(
   message: string,
   author?: GitAuthor,
 ): Promise<void> {
+  // Freshened by repoDirIfExists: config-as-code commits land on main, so
+  // they are judged against the mirror's main rather than this instance's
+  // cache (#916, moved up to the choke point so the reads get it too —
+  // freshenBeforeMainWrite is un-throttled, so doing it in both places would
+  // cost two sequential fetches per write).
   const repoDir = await repoDirIfExists(workspaceId);
   if (!repoDir) return;
-  // Config-as-code commits land on main, so they must be judged against the
-  // mirror's main, not this instance's cache. Without this a stale instance
-  // commits onto an old tip and pushes it — the divergence class #897 fixed
-  // for skills and worktree writes, which these two write paths never
-  // adopted. Coalesced and non-blocking on failure.
-  await freshenBeforeMainWrite(workspaceId);
   const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
     message,
     author,

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -36,10 +36,22 @@ import {
 
 const logger = loggers.api("flow-config");
 
+/**
+ * The workspace repo, at a tip that agrees with the mirror.
+ *
+ * Freshening lives at this choke point rather than beside the commit, for the
+ * same reason it does in dbt-config.service: `ensureLocalRepo` returns early
+ * once the directory exists and never refreshes it, and any caller that READS
+ * the tree to decide what to write has already made its decision by the time
+ * a commit-time freshen runs. Kept identical to the dbt module deliberately —
+ * these two are the same shape and drifted apart once already (#916).
+ */
 async function repoDirIfExists(workspaceId: string): Promise<string | null> {
   await ensureLocalRepo(workspaceId);
   const repoDir = repoDirFor(workspaceId);
-  return (await repoExists(repoDir)) ? repoDir : null;
+  if (!(await repoExists(repoDir))) return null;
+  await freshenBeforeMainWrite(workspaceId);
+  return repoDir;
 }
 
 async function commitConfig(
@@ -48,14 +60,9 @@ async function commitConfig(
   message: string,
   author?: GitAuthor,
 ): Promise<void> {
+  // Freshened by repoDirIfExists (#916, moved up to the choke point).
   const repoDir = await repoDirIfExists(workspaceId);
   if (!repoDir) return;
-  // Config-as-code commits land on main, so they must be judged against the
-  // mirror's main, not this instance's cache. Without this a stale instance
-  // commits onto an old tip and pushes it — the divergence class #897 fixed
-  // for skills and worktree writes, which these two write paths never
-  // adopted. Coalesced and non-blocking on failure.
-  await freshenBeforeMainWrite(workspaceId);
   const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
     message,
     author,


### PR DESCRIPTION
## Why #916 wasn't enough

#916 put `freshenBeforeMainWrite` next to the commit in `dbt-config.service` and `flow-config.service`. That covers the write — but not the **reads that decide the write**, and one of those reads is destructive.

**`syncDbtConfigNow` deletes job rows.** It reconciles Mongo against the repo by removing every row whose file is absent from the tree it read (`slug: { $nin: [...seenSlugs] }`) and deregistering its schedule (`applyJobScheduleChange`). On a stale tip, a job added on the mirror simply isn't there — **so its row is deleted and its schedule stops firing.** Nothing downstream notices, because deleting a job whose file is gone is exactly what that code is for.

Two things make the stale tip likely rather than theoretical:
- `ensureLocalRepo` returns early once the repo directory exists and **never refreshes it**, so a long-lived Cloud Run instance can hold a tip from hours ago.
- `notifyRepoPushed` runs this reconcile after **any** branch push, not just main — so pushing a feature branch triggers a main-based reconcile against whatever main happens to be cached.

**`adoptDbtConfig` fails the other way.** It computes which files already exist from the tree, then writes the rest — so a stale tip makes it treat a newer job file as missing and overwrite it with Mongo's version. A commit-time freshen **structurally cannot** fix that one: the payload was decided before it ran.

## The change

The freshen moves up to **`repoDirIfExists`** — the single choke point all three callers pass through — and comes out of `commitConfig`. Not both: `freshenBeforeMainWrite` is `freshenForServe(ws, 0)` with no throttle, so two layers would mean two sequential fetches per write.

It's cheap where it now sits. The three callers are a write, a push reaction already detached and coalesced by `syncInFlight`, and a rare migration — none is a per-request hot path, so this isn't the reflexive freshen a read path should refuse. `flow-config.service` gets the identical treatment; the two modules are the same shape and drifted apart once already.

## A silent failure, made loud

A freshen that fails before a **write** now logs at **error**, naming the workspace and saying the commit is proceeding against a possibly stale tip. It stays non-blocking — a brief mirror outage must not fail someone's save — but it must not be silent.

It was. Running an exporter from a local checkout whose bare repo had no fetch remote configured, the freshen did nothing, the catch swallowed it, and **ten commits landed on a diverged main** before anyone looked — within an hour of #916 landing. Serving keeps the old `warn`; only the write path is loud.

## Tests

`dbt-config-freshen.test.ts` — a real file:// mirror, a local clone deliberately left behind:

1. **A job added on the mirror survives** a sync against a stale local tip, and the cache catches up rather than being read around.
2. **Its converse**: a file genuinely deleted on the mirror *still* deletes its row — so the fix can't quietly become "never delete anything".

Both fail without the change (verified by reverting the one line: 2 failed → 2 passed).

Coverage guard: `132 test files, all run by a runner`. Suites: `test:dbt` 229 passed, apps 166 passed.

## Note for #916's author

This touches `flow-config.service.ts`, near the exporter work — flagging so we don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
