### PR TITLE
fix(flows): the exporter wrote 10 of 31 flows and reported success

### DIFF
--- a/api/src/routes/connector-reveal-secret.test.ts
+++ b/api/src/routes/connector-reveal-secret.test.ts
@@ -26,7 +26,15 @@
  * Real routes + real Mongo (mongodb-memory-server); only auth, the
  * workspace service, and the connector registry are mocked.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { Hono } from "hono";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
@@ -80,11 +88,14 @@ function req(
   path: string,
   body: unknown,
 ): Promise<Response> {
-  return app.request(`/api/workspaces/${workspaceId}/connectors${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  // `app.request` is typed `Response | Promise<Response>`; await normalises it.
+  return Promise.resolve(
+    app.request(`/api/workspaces/${workspaceId}/connectors${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
 }
 
 beforeAll(async () => {
@@ -150,11 +161,9 @@ describe("the decryption oracle is gone", () => {
     // Cross-tenant, now expressed the only way it still can be: name a
     // connector id that exists, from a workspace the caller is not in.
     const theirs = await seedConnector(WS_THEIRS);
-    const res = await req(
-      WS_MINE,
-      `/${theirs._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${theirs._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(404);
     expect(await res.text()).not.toContain(SECRET);
   });
@@ -164,22 +173,18 @@ describe("reveal-secret is admin/owner only", () => {
   it("a VIEWER is refused — membership is not enough", async () => {
     const mine = await seedConnector(WS_MINE);
     ctx.role = "viewer";
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(403);
     expect(await res.text()).not.toContain(SECRET);
   });
 
   it("an owner reveals their own connector's secret", async () => {
     const mine = await seedConnector(WS_MINE);
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       success: boolean;
@@ -192,11 +197,9 @@ describe("reveal-secret is admin/owner only", () => {
 
   it("only fields the schema declares secret may be revealed", async () => {
     const mine = await seedConnector(WS_MINE);
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "account" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "account",
+    });
     expect(res.status).toBe(400);
   });
 });

--- a/api/src/services/flow-config-export.cli.ts
+++ b/api/src/services/flow-config-export.cli.ts
@@ -14,6 +14,7 @@ import "dotenv/config";
 import mongoose from "mongoose";
 
 import { Flow } from "../database/workspace-schema";
+import { mirrorPushNow } from "../apps/cloud-repo.service";
 import { exportWorkspaceFlows } from "./flow-config.service";
 
 async function main(): Promise<void> {
@@ -27,21 +28,45 @@ async function main(): Promise<void> {
       : (await Flow.distinct("workspaceId")).map(id => String(id));
 
     let written = 0;
+    let unchanged = 0;
     let skipped = 0;
+    const failed: string[] = [];
     for (const workspaceId of workspaceIds) {
       const result = await exportWorkspaceFlows(workspaceId);
       written += result.written;
+      unchanged += result.unchanged;
       skipped += result.skipped;
+      failed.push(...result.failed.map(slug => `${workspaceId}/${slug}`));
       console.log(
-        `${workspaceId}: ${result.written} written, ${result.skipped} skipped (no slug)`,
+        `${workspaceId}: ${result.written} written, ${result.unchanged} unchanged, ` +
+          `${result.skipped} skipped (no slug/name), ${result.failed.length} FAILED`,
       );
+      // The push is fire-and-forget everywhere else, because a user's mutation
+      // must not wait on GitHub. A CLI is the opposite case: if we exit before
+      // the push runs, the commits stay in the local bare repo and the mirror
+      // never sees them — a run that writes every file and pushes none, while
+      // reporting success.
+      if (result.written > 0) await mirrorPushNow(workspaceId);
     }
+
     console.log(
-      `\n${workspaceIds.length} workspace(s): ${written} file(s) written, ${skipped} flow(s) skipped.`,
+      `\n${workspaceIds.length} workspace(s): ${written} written, ` +
+        `${unchanged} unchanged, ${skipped} skipped, ${failed.length} failed.`,
     );
     if (skipped > 0) {
       console.log(
-        "Skipped flows have no slug — run the flow_names_and_slugs migration first.",
+        "Skipped flows have no slug or no name — run the flow_names_and_slugs migration first.",
+      );
+    }
+    if (failed.length > 0) {
+      // Exit non-zero. `commitFlowFile` deliberately swallows its errors so a
+      // failed mirror never fails a user's mutation, which is right in the
+      // request path and wrong here: it once let this CLI report
+      // "10 written, 0 skipped" and exit 0 while 21 of 31 flows had thrown.
+      console.error(`\nFAILED to export ${failed.length} flow(s):`);
+      for (const slug of failed) console.error(`  ${slug}`);
+      throw new Error(
+        `${failed.length} flow(s) failed to export — see the warnings above`,
       );
     }
   } finally {

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -64,11 +64,17 @@ async function commitConfig(
 }
 
 /** Write-through: the flow's file mirrors the row's definition fields. */
+export type FlowFileWriteResult =
+  | "written"
+  | "unchanged"
+  | "skipped"
+  | "failed";
+
 export async function commitFlowFile(
   flow: IFlow,
   actorUserId?: string,
   messageOverride?: string,
-): Promise<void> {
+): Promise<FlowFileWriteResult> {
   // Pre-backfill rows have neither; the migration stamps both. Skipping on
   // an empty NAME as well as an empty slug keeps serialize/parse symmetric:
   // `parseFlowFile` rejects a file with no name, so writing one would
@@ -76,12 +82,12 @@ export async function commitFlowFile(
   // authoritative, a real hazard once block 3 makes files authoritative.
   // (Caught by running the projection against production rows before their
   // backfill had deployed.)
-  if (!flow.slug || !flow.name?.trim()) return;
+  if (!flow.slug || !flow.name?.trim()) return "skipped";
   try {
     const contents = serializeFlowFile(flowToFile(flow));
     const sha = blobOid(contents);
     // Unchanged definition: no commit, no push, no churn.
-    if (flow.sourceBlobSha === sha) return;
+    if (flow.sourceBlobSha === sha) return "unchanged";
     await commitConfig(
       flow.workspaceId.toString(),
       { writes: { [flowFilePath(flow.slug)]: contents } },
@@ -89,6 +95,7 @@ export async function commitFlowFile(
       actorUserId ? await authorForUser(actorUserId) : undefined,
     );
     await Flow.updateOne({ _id: flow._id }, { $set: { sourceBlobSha: sha } });
+    return "written";
   } catch (error) {
     // Export-only: a failed mirror must never fail the user's mutation.
     // Mongo is authoritative and the next write (or the backfill CLI)
@@ -98,6 +105,7 @@ export async function commitFlowFile(
       slug: flow.slug,
       error: error instanceof Error ? error.message : String(error),
     });
+    return "failed";
   }
 }
 
@@ -130,19 +138,36 @@ export async function deleteFlowFile(
 export async function exportWorkspaceFlows(
   workspaceId: string,
   actorUserId?: string,
-): Promise<{ written: number; skipped: number }> {
-  const flows = await Flow.find({ workspaceId }).sort({ _id: 1 });
+): Promise<{
+  written: number;
+  unchanged: number;
+  skipped: number;
+  failed: string[];
+}> {
+  // `.lean()` is load-bearing, not a micro-optimisation. Mongoose documents
+  // carry circular internals, and `serializeFlowFile` ends at `yaml.dump(...,
+  // { noRefs: true })` — which recurses instead of emitting an alias, so a
+  // hydrated subdocument blows the stack. Every flow whose
+  // `destination.table.partitioning` was populated (the BigQuery writers)
+  // failed that way against production, while flows without one serialized
+  // fine — 21 of 31, reported as success by the CLI that ran them.
+  const flows = await Flow.find({ workspaceId })
+    .sort({ _id: 1 })
+    .lean<IFlow[]>();
   let written = 0;
+  let unchanged = 0;
   let skipped = 0;
+  const failed: string[] = [];
   for (const flow of flows) {
-    if (!flow.slug) {
-      skipped++;
-      continue;
-    }
-    const before = flow.sourceBlobSha;
-    await commitFlowFile(flow, actorUserId, `flow: export "${flow.slug}"`);
-    const after = await Flow.findById(flow._id).select("sourceBlobSha").lean();
-    if (after?.sourceBlobSha && after.sourceBlobSha !== before) written++;
+    const result = await commitFlowFile(
+      flow,
+      actorUserId,
+      `flow: export "${flow.slug}"`,
+    );
+    if (result === "written") written++;
+    else if (result === "unchanged") unchanged++;
+    else if (result === "skipped") skipped++;
+    else failed.push(flow.slug ?? String(flow._id));
   }
-  return { written, skipped };
+  return { written, unchanged, skipped, failed };
 }


### PR DESCRIPTION
Found by running `flows:export` against production for the first time, on the RealAdvisor workspace (31 flows). The format layer was already verified against all 31 rows in memory — that verification was correct and is not what failed. What failed is everything between the format and the mirror.

**Result of that run: 10 written, 21 threw `Maximum call stack size exceeded`, CLI printed `10 written, 0 skipped` and exited 0. Nothing reached `realadvisor/mako-workspace` — no `flows/` directory was ever created.**

## 1. No `.lean()` — the stack overflow

`exportWorkspaceFlows` did `Flow.find({ workspaceId })`, so every flow was a hydrated Mongoose document. `serializeFlowFile` ends at:

```ts
yaml.dump(doc, { lineWidth: 100, noRefs: true, sortKeys: false })
```

`noRefs: true` tells js-yaml to *duplicate* a repeated reference rather than emit an anchor — so on a circular structure it recurses until the stack gives out. `snakeKeys` passes `destination.table.partitioning` straight through via `Object.entries`, and on a hydrated document that is a subdocument carrying parent back-references.

That is why the split was exactly along BigQuery writers: only they have `partitioning` populated. Flows without one contain no subdocument on the serialized path and were fine. Nothing about the *format* was wrong.

## 2. The CLI reported success while a third of the workspace failed

`commitFlowFile`'s catch exists so a failed mirror never fails a user's mutation — correct in the request path, wrong in a backfill CLI, where it downgraded 21 hard failures to warnings. The export then inferred "written" by comparing `sourceBlobSha` before and after, so a failure counted as neither written nor skipped and vanished from the totals.

`commitFlowFile` now returns `"written" | "unchanged" | "skipped" | "failed"`, the export collects failed slugs, and the CLI prints them and exits non-zero.

## 3. The mirror push never flushed

`queueMirrorPush` is fire-and-forget by design. The CLI exited before it ran, so even the 10 successful commits stayed in the local bare repo. A fully successful export would have pushed nothing while reporting success. The CLI now awaits `mirrorPushNow`, which shares the same per-workspace serialization and cannot race an in-flight push.

## Also

Output now distinguishes `unchanged` from `written`. The export is idempotent, so a re-run over already-exported flows previously printed zeros that read like failure.

## Verification

- `tsc --noEmit`: 70 errors, matching master's baseline exactly — zero introduced. (The build uses `tsconfig.build.json`, which excludes tests; the raw count includes them.)
- `flow-config-files` format tests pass.
- Also fixes one error that arrived with #920: `app.request` is typed `Response | Promise<Response>`, so `req()` in `connector-reveal-secret.test.ts` didn't satisfy its own `Promise<Response>` return type. It passed CI because the build config excludes tests. That is the same class of gap #912 exists to close.

## Not yet done

The export has **not** been re-run. Once this lands I'll run it again and report the real counts, the commit sha, and whether the mirror push lands — plus any divergence from the in-memory prediction, which is the most valuable thing that run can produce.

Diagnosis follows mako-58's format work in #911; the run that exposed it was mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB