### PR TITLE
fix(test): req() in the reveal-secret spec did not satisfy its own type

### DIFF
--- a/api/src/routes/connector-reveal-secret.test.ts
+++ b/api/src/routes/connector-reveal-secret.test.ts
@@ -26,7 +26,15 @@
  * Real routes + real Mongo (mongodb-memory-server); only auth, the
  * workspace service, and the connector registry are mocked.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { Hono } from "hono";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
@@ -80,11 +88,15 @@ function req(
   path: string,
   body: unknown,
 ): Promise<Response> {
-  return app.request(`/api/workspaces/${workspaceId}/connectors${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  // `app.request` is typed `Response | Promise<Response>`; normalise it so the
+  // helper satisfies its own return type.
+  return Promise.resolve(
+    app.request(`/api/workspaces/${workspaceId}/connectors${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
 }
 
 beforeAll(async () => {
@@ -150,11 +162,9 @@ describe("the decryption oracle is gone", () => {
     // Cross-tenant, now expressed the only way it still can be: name a
     // connector id that exists, from a workspace the caller is not in.
     const theirs = await seedConnector(WS_THEIRS);
-    const res = await req(
-      WS_MINE,
-      `/${theirs._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${theirs._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(404);
     expect(await res.text()).not.toContain(SECRET);
   });
@@ -164,22 +174,18 @@ describe("reveal-secret is admin/owner only", () => {
   it("a VIEWER is refused — membership is not enough", async () => {
     const mine = await seedConnector(WS_MINE);
     ctx.role = "viewer";
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(403);
     expect(await res.text()).not.toContain(SECRET);
   });
 
   it("an owner reveals their own connector's secret", async () => {
     const mine = await seedConnector(WS_MINE);
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "api_key" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "api_key",
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       success: boolean;
@@ -192,11 +198,9 @@ describe("reveal-secret is admin/owner only", () => {
 
   it("only fields the schema declares secret may be revealed", async () => {
     const mine = await seedConnector(WS_MINE);
-    const res = await req(
-      WS_MINE,
-      `/${mine._id.toString()}/reveal-secret`,
-      { field: "account" },
-    );
+    const res = await req(WS_MINE, `/${mine._id.toString()}/reveal-secret`, {
+      field: "account",
+    });
     expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
`app.request` is typed `Response | Promise<Response>`, so `req()` declared `Promise<Response>` and returned a union. Flagged by `tsc --noEmit` since #920 landed; master is at 71 errors, this returns it to the long-standing 70.

It passed CI because the build uses `tsconfig.build.json`, which excludes test files. That is the same gap #912 exists to close, one layer down: there a test ran in no runner, here a test type-checks in no config.

Found while fixing the flows exporter (#922, now closed in favour of #923); unrelated to flows, so landing it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB