### PR TITLE
fix(security): the database list handed every member a live credential

### DIFF
--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -25,7 +25,7 @@ import { Types } from "mongoose";
 import { loggers } from "../logging";
 import { ConsoleManager } from "../utils/console-manager";
 import {
-  maskPasswordInConnectionString,
+  connectionStringGroupKey,
   redactConnectionSecrets,
   restoreKeptSecrets,
 } from "../utils/connection-secrets";
@@ -418,7 +418,10 @@ workspaceDatabaseRoutes.openapi(
 
       // Transform to API response format without connection details for security
       const transformedDatabases = databases.map((db: IDatabaseConnection) => {
-        // Create masked hostKey for grouping per database type
+        // Create a credential-free hostKey for grouping per database type.
+        // This response goes to EVERY member of the workspace, so the key is
+        // derived host-only (see connectionStringGroupKey) rather than masked:
+        // masking is fail-open on formats we cannot parse.
         let hostKey: string;
         let hostName: string;
         const conn: any = db.connection || {};
@@ -427,7 +430,7 @@ workspaceDatabaseRoutes.openapi(
           hostKey = `bigquery://${projectId}`;
           hostName = `BigQuery (${projectId})`;
         } else if (conn.connectionString) {
-          hostKey = maskPasswordInConnectionString(conn.connectionString);
+          hostKey = connectionStringGroupKey(conn.connectionString);
           hostName =
             db.type === "mongodb" ? "MongoDB Atlas" : db.type.toUpperCase();
         } else {

--- a/api/src/utils/connection-secrets.test.ts
+++ b/api/src/utils/connection-secrets.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   SECRET_KEPT,
+  connectionStringGroupKey,
   redactConnectionSecrets,
   restoreKeptSecrets,
 } from "./connection-secrets";
@@ -89,6 +90,51 @@ assert.equal(
     .connectionString,
   SECRET_KEPT,
 );
+
+// --- the explorer's grouping key never carries a credential -----------------
+
+// GET /databases (the list) is open to EVERY workspace member, unlike
+// GET /databases/{id}. It used to group by a password-masked connection
+// string, which is fail-open: the query-parameter and DSN shapes above came
+// back verbatim, credential included, to anyone who could open the explorer.
+// The key is host-only now, so there is no credential left to fail open with.
+const SECRET_IN_KEY = "hunter2";
+for (const dsn of [
+  "clickhouse://mako:hunter2@db.example.com:8443/analytics",
+  "clickhouse:https://host.example.com:8443/db?password=hunter2",
+  "clickhouse://host.example.com:8443/db?password=hunter2",
+  "host=db.example.com;port=9000;user=mako;password=hunter2",
+  "sqlserver://host/db;pwd=hunter2",
+  "mongodb://host/db?authSource=admin&secret=shh",
+  "not a uri at all",
+]) {
+  assert.ok(
+    !connectionStringGroupKey(dsn).includes(SECRET_IN_KEY),
+    `group key must not carry the credential: ${dsn}`,
+  );
+}
+
+// It still groups: the key is stable, and two connections to the same host
+// share it however their credentials differ.
+assert.equal(
+  connectionStringGroupKey("clickhouse://a:pw1@db.example.com:8443/analytics"),
+  connectionStringGroupKey("clickhouse://b:pw2@db.example.com:8443/other"),
+);
+assert.notEqual(
+  connectionStringGroupKey("clickhouse://db.example.com:8443/db"),
+  connectionStringGroupKey("clickhouse://other.example.com:8443/db"),
+);
+// Unparseable strings still group with themselves rather than collapsing
+// together into one bucket.
+assert.equal(
+  connectionStringGroupKey("host=a;password=x"),
+  connectionStringGroupKey("host=a;password=x"),
+);
+assert.notEqual(
+  connectionStringGroupKey("host=a;password=x"),
+  connectionStringGroupKey("host=b;password=x"),
+);
+assert.equal(connectionStringGroupKey(""), "unknown");
 
 // Provably credential-free URIs stay legible — over-redacting these would cost
 // the edit dialog its usefulness for nothing.

--- a/api/src/utils/connection-secrets.ts
+++ b/api/src/utils/connection-secrets.ts
@@ -15,6 +15,7 @@
  *
  * Pure functions, no I/O — the route and its tests both import from here.
  */
+import { createHash } from "node:crypto";
 
 /** Matches `scheme://user:password@` — capture 2 is the password. */
 export const CONNECTION_STRING_PASSWORD =
@@ -33,7 +34,13 @@ export const SECRET_KEPT = "__mako_secret_kept__";
 const SECRET_FIELD =
   /pass(word|wd)?$|secret|token|api[_-]?key|private[_-]?key|service_account|credential/i;
 
-export function maskPasswordInConnectionString(connectionString: string) {
+/**
+ * NOT exported: masking is fail-OPEN — it only recognises `scheme://user:pass@`
+ * and hands back anything else untouched. Reachable only through
+ * {@link redactConnectionString}, which decides when it is safe to trust.
+ * Exporting it once already put a live credential in the list response.
+ */
+function maskPasswordInConnectionString(connectionString: string) {
   if (!connectionString) return connectionString;
   // protocol://[username:password@]host[:port][/database][?options] — covers
   // mongodb://, mongodb+srv://, postgresql://, mysql://, clickhouse://, ...
@@ -77,6 +84,35 @@ export function redactConnectionString(connectionString: string): string {
     return connectionString;
   }
   return SECRET_KEPT;
+}
+
+/**
+ * A stable, credential-free key identifying the HOST a connection string points
+ * at, for grouping connections in the explorer.
+ *
+ * The list route used to group by `maskPasswordInConnectionString(...)`, which
+ * masks only `scheme://user:pass@` and returns everything else verbatim — so a
+ * ClickHouse string carrying its credential as a query parameter went into the
+ * response in full. That is the same fail-open masking {@link
+ * redactConnectionString} was written to replace, and the list route is the
+ * worse place for it: `GET /{id}` is gated to roles that may edit connections,
+ * while listing is open to every member of the workspace.
+ *
+ * A grouping key never needed the credential, so it does not get one. A URI
+ * yields `scheme://host:port` — userinfo, path and query dropped, which is
+ * legible and groups the way the explorer wants. Anything unparseable falls
+ * back to a digest: still stable, still groups identical strings together, and
+ * reveals nothing about a format we could not prove safe.
+ */
+export function connectionStringGroupKey(connectionString: string): string {
+  if (!connectionString) return "unknown";
+  try {
+    const url = new URL(connectionString);
+    if (url.host) return `${url.protocol}//${url.host}`;
+  } catch {
+    // Not a parseable URI — fall through to the digest.
+  }
+  return `opaque:${createHash("sha256").update(connectionString).digest("hex").slice(0, 16)}`;
 }
 
 /** Strip every credential from a decrypted connection, keeping its shape. */


### PR DESCRIPTION
Audit of every route that reads a `DatabaseConnection` but does not redact, asked for after #915: "I grepped for one shape and found nothing" is not proof. It found one live exposure, in the route nobody re-checked.

## The hole

`GET /api/workspaces/:id/databases` — the list behind the database explorer — built its `hostKey` grouping value with `maskPasswordInConnectionString`, which recognises only `scheme://user:pass@` and hands back every other shape untouched:

| stored shape | `hostKey` in the list response |
| --- | --- |
| `clickhouse://svc:PASS@host:8443/db` | `clickhouse://svc:*****@host:8443/db` |
| `https://host:8443/?user=svc&password=PASS` | **returned verbatim** |
| `Server=host;Uid=svc;Pwd=PASS;` | **returned verbatim** |

The second row is the shape that defeated #909 and prompted the fail-closed rewrite in #915 — the same two production ClickHouse connections.

#915 replaced that masker with `redactConnectionString` and wired it into `GET /{id}`. It never reached this call site. **This is the worse of the two:** `GET /{id}` is gated to `owner|admin|member` on the reasoning that connection internals are for people who may edit connections; the list is behind `requireWorkspace` alone — every member of any role, today's `viewer` and tomorrow's `reader` included — and the client fetches it on every load of the explorer.

## The fix

A grouping key never needed a credential, so it no longer has one. `connectionStringGroupKey` returns `scheme://host:port` for a parseable URI (userinfo, path and query dropped) and a sha256 prefix for anything else — stable, still groups identical hosts together, reveals nothing about a format we could not prove safe.

The route keeps its gate. Every member legitimately needs the database list; what they did not need was the password. `hostKey` is a grouping key, declared in the frontend types and never rendered (`hostName` is what's displayed), so nothing user-visible changes.

**`maskPasswordInConnectionString` is no longer exported.** It is fail-open by construction and safe only behind `redactConnectionString`'s decision about when to trust it. Exporting it is precisely what let a second call site keep the bug that #915 had just fixed; tsc now prevents a third. That is the structural half of this fix and the part worth keeping.

## The rest of the audit — clean, and why

Six files query `DatabaseConnection` with no redaction call. All clean, each for a structural reason rather than by luck:

| file | queries | what makes it clean |
| --- | --- | --- |
| `agent.routes.ts` | 1 | `.select({type, name, sqlDialect})` — the `connection` subdocument is never loaded |
| `dbt.routes.ts` | 1 | `.select("type")` — same |
| `notebook-data.ts` | 2 | `/sources` is `.select("_id name type")` with a comment saying why; `/read` passes the doc to the driver and streams Arrow |
| `database-tree.ts` | 5 | doc goes to drivers; only `connection.project_id` is read, into `{language, template}` |
| `consoles.ts` | 4 | two use only `_id`; two pass the doc to execution and read `connection.database` (a database name) |
| `flows.ts` | 11 | existence checks, `.type`, `.name`; `connection.project_id` and `connection.location` for BigQuery. `connectionName`/`connectionType` are the only connection-derived fields in any response |

I also swept the agent-tool surface, since that is where a `reader` tier will live: `summarizeConnectionForListing` and `resolveDatabases` take the whole `connection` object but build results field-by-field — id, name, type, dialect, host, databaseName, project — never a spread.

**The error-echo shape**, checked empirically rather than by grep — no connection string reaches a logger anywhere in the API, and connect-failure messages from all four client libraries carry the host, not the credential:

```
mongodb   : getaddrinfo ENOTFOUND nonexistent.invalid   (also: bad scheme / bad option — no URI in message)
clickhouse: getaddrinfo ENOTFOUND nonexistent.invalid
pg        : getaddrinfo ENOTFOUND nonexistent.invalid
mysql2    : getaddrinfo ENOTFOUND nonexistent.invalid
```

## Verification

`api` tsc clean (70 pre-existing errors on the base commit, unchanged — measured against the base, not assumed), `app` tsc clean, full `pnpm --filter api test` chain green (18 files, 178 tests), coverage guard at 138 files. The new assertions were mutation-checked by restoring the old masker: they fail on the query-parameter shape, which is the one that matters.

Tests use synthetic strings of the production shapes; no real credential appears in this PR or in anything I ran.

## Not verified

I checked the six route files named in the audit plus the agent-tool surface. Services, `sync-cdc/`, and the Inngest flow paths also load connections; they are background workers with no HTTP response body, so they were out of scope here, and I have not traced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBu5kWvdBipSVJfxKpapGh
