### PR TITLE
feat(cdc): the stream half of flows-as-files — reconcile behind a fail-closed guard

### DIFF
--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -505,6 +505,88 @@ export function freshenBeforeMainWrite(workspaceId: string): Promise<void> {
   return freshenForServe(workspaceId, 0, "write");
 }
 
+/**
+ * Thrown when we cannot PROVE the local tree matches the mirror's main.
+ *
+ * Distinct from a freshen failure, which is survivable: this one means a
+ * caller must not proceed with something destructive.
+ */
+export class TreeNotVerifiedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TreeNotVerifiedError";
+  }
+}
+
+/**
+ * Fail CLOSED: prove the tree a caller read is the mirror's current main, or
+ * throw.
+ *
+ * `freshenBeforeMainWrite` is deliberately best-effort — a brief mirror outage
+ * must not fail a user's save, so it logs and proceeds. That trade is right
+ * for a commit and wrong for a deletion, and the asymmetry is not a matter of
+ * degree. A dbt job row deleted from a stale read comes back on the next sync,
+ * because the file recreates it. A CDC teardown DISPOSES CHECKPOINTS
+ * (`CdcEntityState.lastIngestSeq`, `backfillCursor`): recreating the flow does
+ * not recover the stream position, it re-backfills from scratch. One is churn;
+ * the other is data loss.
+ *
+ * So the destructive path asks a different question — not "did we try to
+ * refresh?" but "is this tree definitely current?" — and refuses when the
+ * answer is unknown. `ls-remote` is asked rather than the local repo, because
+ * the local repo is the very thing under suspicion.
+ *
+ * The consequence is deliberate and worth stating where it will be found: when
+ * the mirror is unreachable, a genuinely deleted flow does NOT tear down on
+ * this push. It tears down on the next one. Someone will eventually report
+ * that as a bug; it is the cost of never tearing down a live stream because we
+ * could not check.
+ *
+ * A workspace with no mirror (dev, previews — the connected tier gated off)
+ * has nothing to diverge from: the local repo IS the store, so the check
+ * passes.
+ */
+export async function assertTreeAtMirrorMain(
+  workspaceId: string,
+  treeSha: string,
+): Promise<void> {
+  const target = await resolveMirrorTarget(workspaceId);
+  if (!target) return; // No mirror: the local repo is authoritative.
+  if (!/^[0-9a-f]{40}$/.test(treeSha)) {
+    throw new TreeNotVerifiedError(
+      `Refusing a destructive reconcile: "${treeSha}" is not a commit sha`,
+    );
+  }
+  const url = remoteUrl(target.owner, target.repo);
+  const token = await tokenFor(target);
+  let remoteMain: string;
+  try {
+    const { stdout } = await runGit([
+      ...authArgs(token),
+      "ls-remote",
+      url,
+      `refs/heads/${DEFAULT_BRANCH}`,
+    ]);
+    remoteMain = stdout.trim().split(/\s+/)[0] ?? "";
+  } catch (error) {
+    throw new TreeNotVerifiedError(
+      `Refusing a destructive reconcile: could not read the mirror's ${DEFAULT_BRANCH} (${
+        error instanceof Error ? error.message : String(error)
+      })`,
+    );
+  }
+  if (!/^[0-9a-f]{40}$/.test(remoteMain)) {
+    throw new TreeNotVerifiedError(
+      `Refusing a destructive reconcile: the mirror reported no ${DEFAULT_BRANCH}`,
+    );
+  }
+  if (remoteMain !== treeSha) {
+    throw new TreeNotVerifiedError(
+      `Refusing a destructive reconcile: read at ${treeSha.slice(0, 8)} but the mirror's ${DEFAULT_BRANCH} is ${remoteMain.slice(0, 8)}`,
+    );
+  }
+}
+
 export type ConnectedRepoAdoption =
   | "imported"
   | "seeded"

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -31,6 +31,7 @@ import {
   checkQuerySafety,
   dryRunDbSync,
 } from "../services/destination-writer.service";
+import { teardownFlow } from "../sync-cdc/flow-reconcile";
 import { cdcBackfillService } from "../sync-cdc/backfill";
 import { syncMachineService } from "../sync-cdc/sync-state";
 import { databaseRegistry } from "../databases/registry";
@@ -1549,32 +1550,15 @@ flowRoutes.openapi(
         return c.json({ success: false, error: "Flow not found" }, 404);
       }
 
-      await inngest.send({ name: "flow.cancel", data: { flowId } });
-
-      const childFilter = { flowId: flowOid, workspaceId: wsOid };
-      const [webhooks, executions, cdcEvents, entityStates, transitions] =
-        await Promise.all([
-          WebhookEvent.deleteMany(childFilter),
-          FlowExecution.deleteMany(childFilter),
-          CdcChangeEvent.deleteMany(childFilter),
-          CdcEntityState.deleteMany(childFilter),
-          CdcStateTransition.deleteMany(childFilter),
-        ]);
-
-      await Flow.deleteOne({ _id: flowOid, workspaceId: wsOid });
+      // Cancel + cascade + row delete live in one place, shared with the
+      // repo reconciler (sync-cdc/flow-reconcile.ts). Two copies of a
+      // five-collection teardown would drift, and the halves that drifted
+      // would be the ones nobody deletes.
+      await teardownFlow(flow);
+      // Only this direction writes the file: a deletion made HERE is Mongo →
+      // git. When the reconciler tears down, the file is already gone from
+      // the tree and committing again would fight the push that caused it.
       await deleteFlowFile(flow, c.get("user")?.id);
-
-      logger.info("Flow deleted with cascade cleanup", {
-        flowId,
-        workspaceId,
-        deleted: {
-          webhookEvents: webhooks.deletedCount,
-          flowExecutions: executions.deletedCount,
-          cdcChangeEvents: cdcEvents.deletedCount,
-          cdcEntityStates: entityStates.deletedCount,
-          cdcStateTransitions: transitions.deletedCount,
-        },
-      });
 
       return c.json({
         success: true,

--- a/api/src/sync-cdc/flow-reconcile.test.ts
+++ b/api/src/sync-cdc/flow-reconcile.test.ts
@@ -1,0 +1,334 @@
+/**
+ * The reconciler is allowed to delete things, so the tests are mostly about
+ * when it must NOT.
+ *
+ * Every case here pairs with its converse deliberately. "A stale tree does not
+ * tear down" passes trivially in a reconciler that never tears anything down,
+ * so it is worthless without "a verified tree does". The same discipline the
+ * dbt stale-tip fix needed (#921), for a teardown that costs more: dropping a
+ * flow or an entity disposes `CdcEntityState`, which holds `lastIngestSeq` and
+ * `backfillCursor` — re-adding the file brings the flow back but re-backfills
+ * from scratch, so this is the one path here that loses data rather than
+ * churning rows.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+const state = vi.hoisted(() => ({
+  binding: null as null | { owner: string; repo: string },
+  sent: [] as Array<{ name: string; data: unknown }>,
+}));
+
+vi.mock("../services/workspace-repos.service", () => ({
+  getWorkspaceRepo: vi.fn(async () => state.binding),
+  findWorkspaceIdByRepoBinding: vi.fn(async () => null),
+}));
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: async () => undefined,
+}));
+// The teardown fires flow.cancel; observe it instead of reaching a real
+// Inngest server.
+vi.mock("../inngest/client", () => ({
+  inngest: {
+    send: vi.fn(async (event: { name: string; data: unknown }) => {
+      state.sent.push(event);
+    }),
+  },
+}));
+
+import {
+  CdcChangeEvent,
+  CdcEntityState,
+  Flow,
+} from "../database/workspace-schema";
+import { runGit } from "../apps/git";
+import { DEFAULT_BRANCH, initRepo } from "../apps/repository.service";
+import type { FlowFile } from "../services/flow-config-files";
+import { reconcileFlowsFromRepo, type DesiredFlow } from "./flow-reconcile";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+let remotesRoot: string;
+let WS: Types.ObjectId;
+let remoteDir: string;
+let mirrorMain: string;
+let repoSeq = 0;
+
+const FILE: FlowFile = {
+  name: "Close CRM",
+  type: "scheduled",
+  source: { type: "connector", connectorId: "close" },
+  destination: { connectionId: new Types.ObjectId().toString() },
+  sync: {},
+};
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "flow-reconcile-"));
+  remotesRoot = path.join(tmpRoot, "remotes");
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_GITHUB_REMOTE_BASE = `file://${remotesRoot}`;
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  WS = new Types.ObjectId();
+  state.sent = [];
+  state.binding = null;
+  process.env.APPS_CONNECTED_REPO_PUSH = "allow";
+  await Promise.all([
+    Flow.deleteMany({}),
+    CdcEntityState.deleteMany({}),
+    CdcChangeEvent.deleteMany({}),
+  ]);
+  // A mirror whose main is a known sha, so a test can hand the reconciler
+  // either that (current) or something else (stale).
+  repoSeq += 1;
+  remoteDir = path.join(remotesRoot, "acme", `flows${repoSeq}.git`);
+  await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+  await initRepo(remoteDir, { "README.md": "x\n" });
+  mirrorMain = (
+    await runGit(["-C", remoteDir, "rev-parse", `refs/heads/${DEFAULT_BRANCH}`])
+  ).stdout.trim();
+  state.binding = { owner: "acme", repo: `flows${repoSeq}` };
+});
+
+async function seedFlow(slug: string, entityFilter?: string[]) {
+  return Flow.create({
+    workspaceId: WS,
+    name: slug,
+    slug,
+    type: "scheduled",
+    syncEngine: "cdc",
+    streamState: "active",
+    entityFilter,
+    createdBy: "u1",
+    // Required by the schema; irrelevant to what these cases assert.
+    dataSourceId: new Types.ObjectId(),
+    destinationDatabaseId: new Types.ObjectId(),
+    schedule: { cron: "0 6 * * *", timezone: "Europe/Zurich" },
+  });
+}
+
+function desiredOf(flow: { _id: Types.ObjectId; slug?: string }): DesiredFlow {
+  return { slug: flow.slug!, file: FILE, flowId: flow._id.toString() };
+}
+
+describe("removal", () => {
+  it("tears down a flow whose file is gone — at a verified tree", async () => {
+    const kept = await seedFlow("kept");
+    const gone = await seedFlow("gone");
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: gone._id,
+      entity: "leads",
+      mode: "steady",
+      lastIngestSeq: 42,
+      lastMaterializedSeq: 42,
+      backlogCount: 0,
+      lifetimeEventsProcessed: 1,
+      lifetimeRowsApplied: 1,
+      mergeIntervalSeconds: 30,
+      consecutiveFailures: 0,
+    });
+
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(kept)],
+      treeSha: mirrorMain,
+    });
+
+    expect(result.removed).toEqual(["gone"]);
+    expect(result.deferred).toBeNull();
+    expect(await Flow.findById(gone._id)).toBeNull();
+    expect(await Flow.findById(kept._id)).not.toBeNull();
+    // The cascade ran: state disposed, and the running work cancelled.
+    expect(await CdcEntityState.countDocuments({ flowId: gone._id })).toBe(0);
+    expect(state.sent.map(e => e.name)).toContain("flow.cancel");
+  });
+
+  it("does NOT tear down when the tree cannot be verified", async () => {
+    const kept = await seedFlow("kept");
+    const gone = await seedFlow("gone");
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: gone._id,
+      entity: "leads",
+      mode: "steady",
+      lastIngestSeq: 42,
+      lastMaterializedSeq: 42,
+      backlogCount: 0,
+      lifetimeEventsProcessed: 1,
+      lifetimeRowsApplied: 1,
+      mergeIntervalSeconds: 30,
+      consecutiveFailures: 0,
+    });
+
+    // A tree read at some other commit — what a stale or partial read looks
+    // like from here.
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(kept)],
+      treeSha: "0".repeat(40),
+    });
+
+    expect(result.removed).toEqual([]);
+    expect(result.deferred?.removals).toEqual(["gone"]);
+    expect(result.deferred?.reason).toMatch(/mirror/i);
+    // The flow, its checkpoint, and its stream are all still there.
+    expect(await Flow.findById(gone._id)).not.toBeNull();
+    const survived = await CdcEntityState.findOne({ flowId: gone._id });
+    expect(survived?.lastIngestSeq).toBe(42);
+    expect(state.sent).toEqual([]);
+  });
+
+  it("treats an empty tree as 'nothing to say', never as 'delete everything'", async () => {
+    const flow = await seedFlow("still-here");
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [],
+      treeSha: mirrorMain,
+    });
+    expect(result.removed).toEqual([]);
+    expect(await Flow.findById(flow._id)).not.toBeNull();
+    expect(state.sent).toEqual([]);
+  });
+});
+
+describe("entity selection", () => {
+  it("drops an entity removed from the selection, and keeps the rest", async () => {
+    const flow = await seedFlow("crm", ["leads"]);
+    for (const entity of ["leads", "dropped"]) {
+      await CdcEntityState.create({
+        workspaceId: WS,
+        flowId: flow._id,
+        entity,
+        mode: "steady",
+        lastIngestSeq: 7,
+        lastMaterializedSeq: 7,
+        backlogCount: 0,
+        lifetimeEventsProcessed: 1,
+        lifetimeRowsApplied: 1,
+        mergeIntervalSeconds: 30,
+        consecutiveFailures: 0,
+      });
+    }
+
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(flow)],
+      treeSha: mirrorMain,
+    });
+
+    expect(result.entitiesDropped).toEqual([
+      { slug: "crm", entities: ["dropped"] },
+    ]);
+    const left = await CdcEntityState.find({ flowId: flow._id });
+    expect(left.map(s => s.entity)).toEqual(["leads"]);
+    // Paused to reconfigure, then put back the way it was found.
+    const after = await Flow.findById(flow._id);
+    expect(after?.streamState).toBe("active");
+  });
+
+  it("does NOT drop an entity when the tree cannot be verified", async () => {
+    const flow = await seedFlow("crm", ["leads"]);
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: flow._id,
+      entity: "dropped",
+      mode: "steady",
+      lastIngestSeq: 7,
+      lastMaterializedSeq: 7,
+      backlogCount: 0,
+      lifetimeEventsProcessed: 1,
+      lifetimeRowsApplied: 1,
+      mergeIntervalSeconds: 30,
+      consecutiveFailures: 0,
+    });
+
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(flow)],
+      treeSha: "0".repeat(40),
+    });
+
+    expect(result.entitiesDropped).toEqual([]);
+    expect(await CdcEntityState.countDocuments({ flowId: flow._id })).toBe(1);
+  });
+
+  it("leaves a flow with no explicit selection entirely alone", async () => {
+    const flow = await seedFlow("everything"); // no entityFilter
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: flow._id,
+      entity: "anything",
+      mode: "steady",
+      lastIngestSeq: 1,
+      lastMaterializedSeq: 1,
+      backlogCount: 0,
+      lifetimeEventsProcessed: 1,
+      lifetimeRowsApplied: 1,
+      mergeIntervalSeconds: 30,
+      consecutiveFailures: 0,
+    });
+    const result = await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(flow)],
+      treeSha: mirrorMain,
+    });
+    expect(result.entitiesDropped).toEqual([]);
+    expect(await CdcEntityState.countDocuments({ flowId: flow._id })).toBe(1);
+  });
+});
+
+describe("pause ownership", () => {
+  it("never resumes a pause somebody else took", async () => {
+    const flow = await seedFlow("crm", ["leads"]);
+    // A repartition holds this stream paused for its own reasons.
+    flow.streamState = "paused";
+    flow.syncStateMeta = { lastEvent: "REPARTITION_PAUSE" };
+    await flow.save();
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: flow._id,
+      entity: "dropped",
+      mode: "steady",
+      lastIngestSeq: 3,
+      lastMaterializedSeq: 3,
+      backlogCount: 0,
+      lifetimeEventsProcessed: 1,
+      lifetimeRowsApplied: 1,
+      mergeIntervalSeconds: 30,
+      consecutiveFailures: 0,
+    });
+
+    await reconcileFlowsFromRepo({
+      workspaceId: WS.toString(),
+      desired: [desiredOf(flow)],
+      treeSha: mirrorMain,
+    });
+
+    // The reconcile did its work but left the stream paused: resuming here
+    // would restart a stream the repartition still needs stopped.
+    const after = await Flow.findById(flow._id);
+    expect(after?.streamState).toBe("paused");
+  });
+});

--- a/api/src/sync-cdc/flow-reconcile.ts
+++ b/api/src/sync-cdc/flow-reconcile.ts
@@ -1,0 +1,338 @@
+/**
+ * The stream half of flows-as-files (RFC #904 block 3).
+ *
+ * A `flows/<slug>.yml` change reaches Mongo as a definition edit — that half
+ * belongs to the caller. What a definition edit MEANS to a running CDC stream
+ * is this module's job, and it is not a field assignment: 31 of 31 production
+ * flows are CDC, an entity dropped from the selection has a live consumer and
+ * a checkpoint behind it, and a half-applied reconfigure on a live stream is
+ * worse than one that was refused.
+ *
+ * Three properties hold everything else up.
+ *
+ * ONE — an empty or partial tree is never a deletion. `notifyRepoPushed` fires
+ * on ANY branch push and reconciles against main, so a tree read at the wrong
+ * moment must not be read as "every flow was deleted". An empty `desired` set
+ * returns early, changing nothing.
+ *
+ * TWO — nothing destructive happens against an unverified tree. Removing a
+ * flow, or an entity from a flow's selection, disposes `CdcEntityState`, which
+ * holds `lastIngestSeq` and `backfillCursor` — the stream's position. That is
+ * not recoverable by re-adding the file: the flow comes back and re-backfills
+ * from scratch. So every destructive branch goes behind
+ * `assertTreeAtMirrorMain`, which FAILS CLOSED, unlike the best-effort freshen
+ * that guards ordinary writes. When it refuses, the non-destructive work still
+ * runs and the teardown waits for the next push.
+ *
+ * THREE — a pause we take is a pause we own. `syncStateMeta.lastEvent` marks
+ * it, and resume only lifts our own, so a reconcile can never resume a stream
+ * that a repartition (or a person) paused for its own reasons. That pattern is
+ * borrowed verbatim from `pauseStreamForRepartition`, which learned it first.
+ */
+import { Types } from "mongoose";
+import {
+  CdcChangeEvent,
+  CdcEntityState,
+  CdcStateTransition,
+  Flow,
+  FlowExecution,
+  WebhookEvent,
+  type IFlow,
+} from "../database/workspace-schema";
+import { inngest } from "../inngest/client";
+import { loggers } from "../logging";
+import {
+  TreeNotVerifiedError,
+  assertTreeAtMirrorMain,
+} from "../apps/cloud-repo.service";
+import { resolveConfiguredEntities } from "./entity-selection";
+import type { FlowFile } from "../services/flow-config-files";
+
+const log = loggers.api("cdc-flow-reconcile");
+
+/** Marks the pause this module takes, so it only ever resumes its own. */
+const RECONCILE_PAUSE = "REPO_RECONCILE_PAUSE";
+const RECONCILE_RESUME = "REPO_RECONCILE_RESUME";
+
+/**
+ * One flow as the repository describes it, handed over by the caller that
+ * parsed the tree.
+ *
+ * `flowId` rather than the document: the row is the caller's to create and
+ * update, and passing a live Mongoose document across that boundary invites
+ * one side to save half of the other's work.
+ */
+export interface DesiredFlow {
+  slug: string;
+  file: FlowFile;
+  flowId: string;
+}
+
+export interface ReconcileResult {
+  /** Flows whose stream was paused, reconfigured and resumed. */
+  reconfigured: string[];
+  /** Flows torn down because their file is gone from the tree. */
+  removed: string[];
+  /** Entities dropped from a selection; their checkpoints were disposed. */
+  entitiesDropped: Array<{ slug: string; entities: string[] }>;
+  /**
+   * Destructive work deferred because the tree could not be verified. Not an
+   * error — the next push retries it — but the reason belongs in the result
+   * so a caller can say why a deletion has not happened yet.
+   */
+  deferred: { removals: string[]; reason: string } | null;
+}
+
+/**
+ * Tear a flow down: cancel its work, drop its runtime children, delete the row.
+ *
+ * Extracted from the DELETE route rather than reimplemented. A second copy of
+ * a five-collection cascade would drift from the first, and this codebase has
+ * already paid for exactly that — `syncRepoBackedResources` exists because the
+ * webhook route kept its own copy of the sync list, so dbt and notebooks
+ * silently stopped reaching Mongo. The same divergence here would leave a
+ * stream's rows behind after a deletion, or delete some and not others.
+ *
+ * Deliberately does NOT touch git. The route deletes the file separately
+ * (Mongo → git); when a reconcile calls this the file is already gone from the
+ * tree, and writing a deletion commit would fight the push that triggered it.
+ */
+export async function teardownFlow(flow: IFlow): Promise<{
+  webhookEvents: number;
+  flowExecutions: number;
+  cdcChangeEvents: number;
+  cdcEntityStates: number;
+  cdcStateTransitions: number;
+}> {
+  const flowOid = flow._id as Types.ObjectId;
+  const workspaceOid = flow.workspaceId as Types.ObjectId;
+  const flowId = flowOid.toString();
+
+  await inngest.send({ name: "flow.cancel", data: { flowId } });
+
+  const childFilter = { flowId: flowOid, workspaceId: workspaceOid };
+  const [webhooks, executions, cdcEvents, entityStates, transitions] =
+    await Promise.all([
+      WebhookEvent.deleteMany(childFilter),
+      FlowExecution.deleteMany(childFilter),
+      CdcChangeEvent.deleteMany(childFilter),
+      CdcEntityState.deleteMany(childFilter),
+      CdcStateTransition.deleteMany(childFilter),
+    ]);
+  await Flow.deleteOne({ _id: flowOid, workspaceId: workspaceOid });
+
+  const counts = {
+    webhookEvents: webhooks.deletedCount ?? 0,
+    flowExecutions: executions.deletedCount ?? 0,
+    cdcChangeEvents: cdcEvents.deletedCount ?? 0,
+    cdcEntityStates: entityStates.deletedCount ?? 0,
+    cdcStateTransitions: transitions.deletedCount ?? 0,
+  };
+  log.info("Flow torn down with cascade cleanup", {
+    flowId,
+    workspaceId: workspaceOid.toString(),
+    deleted: counts,
+  });
+  return counts;
+}
+
+/**
+ * Take a pause this module owns, or recognise that we do not need one.
+ *
+ * A stream that is ALREADY paused is left completely alone — not re-paused,
+ * and above all not re-marked. Overwriting `lastEvent` would make someone
+ * else's pause look like ours, and the resume at the end of this reconcile
+ * would then restart a stream that a repartition (or a person) still needs
+ * stopped. Being already paused is not an obstacle here: the stream is not
+ * moving, which is the only property the entity drop needs.
+ */
+async function pauseForReconcile(
+  flow: IFlow,
+): Promise<{ owned: boolean; previous: IFlow["streamState"] }> {
+  if (flow.streamState === "paused") {
+    return { owned: false, previous: "paused" };
+  }
+  const previous = flow.streamState || "idle";
+  flow.streamState = "paused";
+  flow.syncStateMeta = {
+    ...(flow.syncStateMeta || {}),
+    lastEvent: RECONCILE_PAUSE,
+    lastReason: "Paused to apply a flows/<slug>.yml change",
+  };
+  flow.syncStateUpdatedAt = new Date();
+  await flow.save();
+  return { owned: true, previous };
+}
+
+/** Lift only OUR pause — never one taken by a repartition or a person. */
+async function resumeAfterReconcile(
+  flow: IFlow,
+  taken: { owned: boolean; previous: IFlow["streamState"] },
+): Promise<void> {
+  if (!taken.owned) return; // Never lift a pause we did not take.
+  if (
+    flow.streamState !== "paused" ||
+    flow.syncStateMeta?.lastEvent !== RECONCILE_PAUSE
+  ) {
+    return;
+  }
+  flow.streamState = taken.previous || "idle";
+  flow.syncStateMeta = {
+    ...(flow.syncStateMeta || {}),
+    lastEvent: RECONCILE_RESUME,
+    lastReason: "Resumed after applying a flows/<slug>.yml change",
+  };
+  flow.syncStateUpdatedAt = new Date();
+  await flow.save();
+}
+
+/**
+ * Entities that have runtime state but are no longer selected.
+ *
+ * Computed from what is RUNNING rather than from a before/after diff, so the
+ * reconcile is idempotent and needs no memory of the previous definition: run
+ * it twice and the second run finds nothing to do. A flow with no explicit
+ * selection streams everything, so nothing is ever stale for it.
+ */
+async function staleEntitiesFor(flow: IFlow): Promise<string[]> {
+  const { entities, hasExplicitSelection } = resolveConfiguredEntities(flow);
+  if (!hasExplicitSelection) return [];
+  const selected = new Set(entities);
+  const live = await CdcEntityState.find({
+    flowId: flow._id,
+    workspaceId: flow.workspaceId,
+  })
+    .select("entity")
+    .lean();
+  return live
+    .map(state => state.entity)
+    .filter((entity): entity is string => typeof entity === "string")
+    .filter(entity => !selected.has(entity));
+}
+
+/**
+ * Bring streams in line with the flow files at `treeSha`.
+ *
+ * The caller owns the definition half: it resolves main, parses the tree, and
+ * has already applied field changes to rows. It hands over what the repository
+ * says should exist, and the commit it read that from. This module decides
+ * what that means for the streams, and refuses anything destructive it cannot
+ * justify against the mirror.
+ */
+export async function reconcileFlowsFromRepo(input: {
+  workspaceId: string;
+  desired: DesiredFlow[];
+  /** The commit `desired` was read at — verified before any teardown. */
+  treeSha: string;
+  actorUserId?: string;
+}): Promise<ReconcileResult> {
+  const { workspaceId, desired, treeSha } = input;
+  const result: ReconcileResult = {
+    reconfigured: [],
+    removed: [],
+    entitiesDropped: [],
+    deferred: null,
+  };
+
+  // An empty tree is not a mass deletion. Defence in depth: the caller returns
+  // early on an empty `flows/` too, and this is the layer that has to be right
+  // even if a future caller forgets.
+  if (desired.length === 0) return result;
+
+  const workspaceOid = new Types.ObjectId(workspaceId);
+  const desiredIds = new Set(desired.map(d => d.flowId));
+  const removals = (
+    await Flow.find({ workspaceId: workspaceOid, slug: { $exists: true } })
+  ).filter(flow => !desiredIds.has((flow._id as Types.ObjectId).toString()));
+
+  // Is anything destructive on the table? Dropping an entity disposes its
+  // checkpoint exactly as a teardown does, so both go behind the same guard.
+  const perFlowStale = new Map<string, { flow: IFlow; stale: string[] }>();
+  for (const item of desired) {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(item.flowId),
+      workspaceId: workspaceOid,
+    });
+    if (!flow) continue;
+    const stale = await staleEntitiesFor(flow);
+    if (stale.length > 0) perFlowStale.set(item.slug, { flow, stale });
+  }
+
+  const destructive = removals.length > 0 || perFlowStale.size > 0;
+  let verified = !destructive;
+  if (destructive) {
+    try {
+      await assertTreeAtMirrorMain(workspaceId, treeSha);
+      verified = true;
+    } catch (error) {
+      if (!(error instanceof TreeNotVerifiedError)) throw error;
+      verified = false;
+      result.deferred = {
+        removals: removals.map(f => f.slug ?? String(f._id)),
+        reason: error.message,
+      };
+      // Not an error-level event: refusing is the designed behaviour, and the
+      // next push retries. Loud enough to explain a deletion that has not
+      // happened yet, which is the question this will be asked.
+      log.warn(
+        "Deferred a destructive flow reconcile: the tree could not be verified against the mirror",
+        {
+          workspaceId,
+          treeSha,
+          flowsAwaitingTeardown: result.deferred.removals,
+          entitiesAwaitingDrop: [...perFlowStale.keys()],
+          reason: error.message,
+        },
+      );
+    }
+  }
+
+  if (verified) {
+    for (const [slug, { flow, stale }] of perFlowStale) {
+      const taken = await pauseForReconcile(flow);
+      try {
+        await CdcEntityState.deleteMany({
+          flowId: flow._id,
+          workspaceId: workspaceOid,
+          entity: { $in: stale },
+        });
+        await CdcChangeEvent.deleteMany({
+          flowId: flow._id,
+          workspaceId: workspaceOid,
+          entity: { $in: stale },
+        });
+        result.entitiesDropped.push({ slug, entities: stale });
+        log.info("Dropped entities removed from a flow's selection", {
+          workspaceId,
+          slug,
+          entities: stale,
+        });
+      } finally {
+        // Always resume, including when the drop threw: a stream left paused
+        // by a failed reconcile stops moving and nothing else lifts it.
+        await resumeAfterReconcile(flow, taken);
+      }
+      result.reconfigured.push(slug);
+    }
+
+    for (const flow of removals) {
+      await teardownFlow(flow);
+      result.removed.push(flow.slug ?? String(flow._id));
+    }
+  }
+
+  if (
+    result.reconfigured.length > 0 ||
+    result.removed.length > 0 ||
+    result.deferred
+  ) {
+    log.info("Flow stream reconcile complete", {
+      workspaceId,
+      treeSha,
+      reconfigured: result.reconfigured.length,
+      removed: result.removed.length,
+      deferred: result.deferred ? result.deferred.removals.length : 0,
+    });
+  }
+  return result;
+}

--- a/api/vitest.destinations.config.ts
+++ b/api/vitest.destinations.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "src/sync-cdc/adapters/**/*.test.ts",
       "src/sync-cdc/backlog.test.ts",
       "src/sync-cdc/consumer.test.ts",
+      "src/sync-cdc/flow-reconcile.test.ts",
       "src/sync/legacy-flow-migration.test.ts",
       "src/sync/sync-orchestrator.test.ts",
       "src/utils/bigquery-emulator.test.ts",


### PR DESCRIPTION
RFC #904 block 3. A `flows/<slug>.yml` change reaches Mongo as a definition edit — that half belongs to the caller. What that edit *means to a running CDC stream* is this module. 31 of 31 production flows are CDC, so this is the feature, not a follow-up.

## The guard, and why it differs from the one on writes

`freshenBeforeMainWrite` is best-effort **by design**: a mirror blip must not fail a user's save, so it logs and proceeds (#921 made that failure loud, still non-fatal). Right for a commit. Wrong here — and the asymmetry isn't a matter of degree:

| | wrong delete from a stale read | recovery |
|---|---|---|
| **dbt job row** | row disappears | comes back on the next sync — the file recreates it |
| **CDC stream** | `CdcEntityState` disposed — `lastIngestSeq`, `backfillCursor` | re-adding the file brings the flow back and **re-backfills from scratch** |

One is churn; the other is data loss. So `assertTreeAtMirrorMain` asks a different question — not *"did we try to refresh?"* but *"is this tree provably the mirror's main?"* — via `ls-remote`, because the local repo is the thing under suspicion. **It throws when the answer is unknown.**

Every destructive branch sits behind it, **including dropping a single entity** from a selection: that disposes the entity's checkpoint just as surely as a whole teardown.

### The deliberate consequence

When the mirror is unreachable, a genuinely deleted flow **does not tear down on this push** — it tears down on the next one. Someone will eventually report that as a bug, so the reasoning is in the code comment as well as here. It is the price of never tearing down a live stream because we couldn't check. A workspace with no mirror (dev, previews) has nothing to diverge from, so the check passes.

## Teardown is extracted, not duplicated

The DELETE route held the only copy — `flow.cancel`, five `deleteMany`s, the row. Both callers now share `teardownFlow`.

This codebase has already paid for the alternative: `syncRepoBackedResources` exists *because* the webhook route kept its own copy of the sync list and drifted, so dbt and notebooks silently stopped reaching Mongo. The same drift in a five-collection cascade would leave a stream's rows behind after a deletion.

`teardownFlow` deliberately does **not** touch git: the route deletes the file (Mongo → git), while a reconcile runs when the file is already gone, and committing again would fight the push that caused it.

## Design notes

- **Stale entities are computed from what is running**, not from a before/after diff — so the reconcile is idempotent and needs no memory of the previous definition. Run it twice; the second run finds nothing.
- **A pause we take is one we own.** A stream already paused is left *completely* alone rather than taken over — following `pauseStreamForRepartition`, which learned this first.
- **An empty tree is never a deletion.** `desired: []` returns early, changing nothing. Defence in depth; the caller has the same check.

## Tests — each with its converse

"A stale tree does not tear down" passes trivially in a reconciler that never tears anything down, so every refusal is paired with its positive: teardown **at a verified tree** and refusal at an unverified one; entity drop and refusal; empty tree changing nothing; no-selection flows untouched; a repartition's pause surviving.

Verified load-bearing by removing the guard: **the two refusal cases fail, the teardown case still passes.**

The pause-ownership case earned its place immediately — it caught this module overwriting another pause's marker and then resuming a stream the repartition still needed stopped. That bug never left the branch.

Coverage guard: 139 files, all run by a runner. Destinations suite: 16 files / 185 tests.

## Interface

```ts
reconcileFlowsFromRepo({ workspaceId, desired, treeSha, actorUserId })
```

`treeSha` is load-bearing: it's the commit `desired` was read at, verified against the mirror before anything destructive runs — so a stale or partial tree can't reach the destructive path even if a caller hands one over. `DesiredFlow` is `{ slug, file, flowId }` — the id rather than the document, so neither side saves half of the other's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
