### PR TITLE
fix(app): the rail said Settings was active while an app tab was open

### DIFF
--- a/app/src/components/Sidebar.rail-state.test.tsx
+++ b/app/src/components/Sidebar.rail-state.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+/**
+ * The rail answers two questions and must not conflate them.
+ *
+ * Reported: the address bar said /apps/ubiflow and an app tab was open, but
+ * the rail highlighted Settings — read as "Settings is the active app".
+ *
+ * The divergence itself is CORRECT and deliberate: the open explorer is a
+ * panel you are browsing, not the thing you are looking at. Browsing the
+ * Databases tree while editing a console is a real workflow, and a reload
+ * restores the panel you had rather than the one the URL implies (UrlSync's
+ * isReload note — an earlier attempt at "the URL wins on reload" would have
+ * reintroduced the bug that comment documents, reloading with an app tab open
+ * bouncing you off Source Control).
+ *
+ * So the fix is signalling, not behaviour: the rail marks BOTH the open panel
+ * and the explorer that holds the open tab. This pins that they are reported
+ * independently, which is the property the single-highlight version lacked.
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/analytics", () => ({
+  trackEvent: vi.fn(),
+  resetIdentity: vi.fn(),
+}));
+vi.mock("../contexts/auth-context", () => ({
+  useAuth: () => ({ user: { id: "u1", email: "a@b.c" }, logout: vi.fn() }),
+}));
+vi.mock("../contexts/workspace-context", () => ({
+  useWorkspace: () => ({
+    currentWorkspace: { id: "ws1", name: "W" },
+    workspaces: [],
+    switchWorkspace: vi.fn(),
+  }),
+}));
+
+import Sidebar from "./Sidebar";
+import { useUIStore } from "../store/uiStore";
+import { useConsoleStore } from "../store/consoleStore";
+
+/** The rail button for a view, by its stable data-view hook. */
+const rail = (container: HTMLElement, view: string) =>
+  container.querySelector<HTMLElement>(`[data-view="${view}"]`);
+
+const state = (el: HTMLElement | null) => ({
+  openExplorer: el?.getAttribute("data-open-explorer"),
+  ownsActiveTab: el?.getAttribute("data-owns-active-tab"),
+});
+
+describe("sidebar rail: open panel vs the explorer holding the open tab", () => {
+  beforeEach(() => {
+    // The reported situation: Settings panel open, an APP tab in the editor.
+    useUIStore.setState({ leftPane: "settings", leftPaneOpen: true });
+    useConsoleStore.setState({
+      activeTabId: "t1",
+      tabs: {
+        t1: {
+          id: "t1",
+          kind: "app",
+          title: "Ubiflow",
+          content: "",
+          metadata: { appId: "app1" },
+        },
+      } as never,
+    });
+  });
+  afterEach(cleanup);
+
+  it("marks Apps as holding the open tab while Settings is the open panel", () => {
+    const { container } = render(<Sidebar />);
+
+    // Settings: the panel on screen, but NOT what the user is looking at.
+    expect(state(rail(container, "settings"))).toEqual({
+      openExplorer: "true",
+      ownsActiveTab: "false",
+    });
+
+    // Apps: not the open panel, but it holds the open tab. Without this the
+    // rail said only "Settings", which is what read as "the active app".
+    expect(state(rail(container, "apps"))).toEqual({
+      openExplorer: "false",
+      ownsActiveTab: "true",
+    });
+  });
+
+  it("reports both on one item when the panel and the open tab agree", () => {
+    useUIStore.setState({ leftPane: "apps", leftPaneOpen: true });
+    const { container } = render(<Sidebar />);
+
+    expect(state(rail(container, "apps"))).toEqual({
+      openExplorer: "true",
+      ownsActiveTab: "true",
+    });
+  });
+
+  it("marks nothing when the open tab has no sidebar home", () => {
+    // Settings and plan tabs deliberately map to no explorer, so nothing
+    // should claim to hold them.
+    useConsoleStore.setState({
+      activeTabId: "t2",
+      tabs: {
+        t2: {
+          id: "t2",
+          kind: "settings",
+          title: "Members",
+          content: "",
+          settingsSection: "members",
+        },
+      } as never,
+    });
+    const { container } = render(<Sidebar />);
+
+    const marked = container.querySelectorAll(
+      '[data-owns-active-tab="true"]',
+    ).length;
+    expect(marked).toBe(0);
+    // The open panel is still reported — collapsing that would be the
+    // opposite bug.
+    expect(state(rail(container, "settings")).openExplorer).toBe("true");
+  });
+
+  it("clears the open-panel mark when the pane is collapsed", () => {
+    useUIStore.setState({ leftPane: "settings", leftPaneOpen: false });
+    const { container } = render(<Sidebar />);
+
+    expect(state(rail(container, "settings")).openExplorer).toBe("false");
+    // …but the app tab is still open, so the rail still says where it lives.
+    expect(state(rail(container, "apps")).ownsActiveTab).toBe("true");
+  });
+});

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -25,24 +25,45 @@ import { useRepoStore } from "../store/repoStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { trackEvent, resetIdentity } from "../lib/analytics";
 import { useIsMobile } from "../hooks/useIsMobile";
+import { tabRevealTarget } from "../lib/explorer-reveal";
 
+/**
+ * The rail answers TWO questions, and conflating them is confusing.
+ *
+ * `isActive` is "this explorer's panel is the one on screen". `ownsActiveTab`
+ * is "the tab you are looking at lives in here". They are independent by
+ * design — browsing the Databases tree while editing a console is a real
+ * workflow, and a reload deliberately restores the panel you had rather than
+ * the one the URL implies (see UrlSync's isReload note).
+ *
+ * With only the selected-background state, a rail showing Settings while the
+ * address bar said /apps/ubiflow read as "Settings is the active app". So the
+ * two facts now look different: selected background for the open panel, brand
+ * colour for the explorer holding the open tab.
+ */
 const NavButton = styled(Button, {
-  shouldForwardProp: prop => prop !== "isActive",
-})<{ isActive?: boolean }>(({ theme, isActive }) => ({
-  minWidth: 40,
-  width: 40,
-  height: 40,
-  padding: 0,
-  borderRadius: 8,
-  backgroundColor: isActive ? theme.palette.action.selected : "transparent",
-  color: isActive ? theme.palette.text.primary : theme.palette.text.secondary,
-  "&:hover": {
-    backgroundColor: isActive
-      ? theme.palette.action.selected
-      : theme.palette.action.hover,
-  },
-  transition: "all 0.2s ease",
-}));
+  shouldForwardProp: prop => prop !== "isActive" && prop !== "ownsActiveTab",
+})<{ isActive?: boolean; ownsActiveTab?: boolean }>(
+  ({ theme, isActive, ownsActiveTab }) => ({
+    minWidth: 40,
+    width: 40,
+    height: 40,
+    padding: 0,
+    borderRadius: 8,
+    backgroundColor: isActive ? theme.palette.action.selected : "transparent",
+    color: isActive
+      ? theme.palette.text.primary
+      : ownsActiveTab
+        ? theme.palette.primary.main
+        : theme.palette.text.secondary,
+    "&:hover": {
+      backgroundColor: isActive
+        ? theme.palette.action.selected
+        : theme.palette.action.hover,
+    },
+    transition: "all 0.2s ease",
+  }),
+);
 
 // Views that can appear in the sidebar navigation. Extends the core AppView
 // union with additional sidebar-specific entries that don't directly map to
@@ -309,6 +330,15 @@ function Sidebar() {
   // the last-selected view retained across collapse — to decide which icon
   // is highlighted, so collapsing the pane clears the highlight.
   const activeExplorer = useUIStore(selectActiveExplorer);
+  // Which explorer holds the tab currently in the editor. Returns a primitive
+  // so this only re-renders when the answer actually changes, not on every
+  // keystroke in the tab. Tabs with no sidebar home (settings, plans) map to
+  // null and mark nothing.
+  const activeTabExplorer = useConsoleStore(state => {
+    const id = state.activeTabId;
+    const tab = id ? state.tabs[id] : null;
+    return tabRevealTarget(tab)?.explorer ?? null;
+  });
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
   const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
   const setLeftPane = useUIStore(state => state.setLeftPane);
@@ -371,11 +401,26 @@ function Sidebar() {
           {topNavigationItems.map(item => {
             const Icon = item.icon;
             const isActive = activeExplorer === item.view;
+            const ownsActiveTab = activeTabExplorer === item.view;
 
             return (
-              <Tooltip key={item.view} title={item.label} placement="right">
+              <Tooltip
+                key={item.view}
+                title={
+                  ownsActiveTab && !isActive
+                    ? `${item.label} — holds the open tab`
+                    : item.label
+                }
+                placement="right"
+              >
                 <NavButton
                   isActive={isActive}
+                  ownsActiveTab={ownsActiveTab}
+                  // Stable hooks for tests: the two states are otherwise only
+                  // visible as emotion-generated colours.
+                  data-view={item.view}
+                  data-open-explorer={isActive ? "true" : "false"}
+                  data-owns-active-tab={ownsActiveTab ? "true" : "false"}
                   onClick={() => handleNavigation(item.view as NavigationView)}
                   onMouseEnter={
                     item.view === "dashboards"
@@ -446,11 +491,26 @@ function Sidebar() {
             // Settings is now a real explorer — track `activeExplorer` like
             // every other rail so collapsing the pane clears the highlight.
             const isActive = activeExplorer === item.view;
+            const ownsActiveTab = activeTabExplorer === item.view;
 
             return (
-              <Tooltip key={item.view} title={item.label} placement="right">
+              <Tooltip
+                key={item.view}
+                title={
+                  ownsActiveTab && !isActive
+                    ? `${item.label} — holds the open tab`
+                    : item.label
+                }
+                placement="right"
+              >
                 <NavButton
                   isActive={isActive}
+                  ownsActiveTab={ownsActiveTab}
+                  // Stable hooks for tests: the two states are otherwise only
+                  // visible as emotion-generated colours.
+                  data-view={item.view}
+                  data-open-explorer={isActive ? "true" : "false"}
+                  data-owns-active-tab={ownsActiveTab ? "true" : "false"}
                   onClick={() => handleNavigation(item.view as NavigationView)}
                 >
                   <Icon strokeWidth={1.5} />


### PR DESCRIPTION
## Reported

The address bar read `/apps/ubiflow` and an app tab was in the editor, but the rail highlighted **Settings** — which reads as "Settings is the active app".

## The divergence is correct; the signalling wasn't

A highlighted rail item means *"this explorer's panel is on screen"*, not *"this is what you are looking at"*. Those are independent on purpose:

- browsing the Databases tree while editing a console is a real workflow
- `UrlSync` deliberately restores the panel you had over the one the URL implies — its `isReload` comment records the bug that came from doing otherwise: *"reloading with an app tab open bounced you off the Source Control panel"*

**I wrote the obvious fix first — "the URL wins on reload" — and threw it away**, because it reintroduces exactly that documented bug.

The real defect is that one highlight carried two independent facts, so whenever they disagreed the rail asserted the wrong one. And because `leftPane` is persisted, the stale state outlives the session that caused it — which is why it reads as broken rather than merely surprising.

## The fix

The rail shows both:

| state | appearance |
|---|---|
| panel on screen | selected background (unchanged) |
| holds the open tab | brand colour + "— holds the open tab" tooltip |

Nothing moves, no workflow changes, and the rail stops contradicting the address bar.

## Testing a visual change

Both states are exposed as `data-open-explorer` / `data-owns-active-tab`. They are otherwise visible only as emotion-generated colours, and asserting computed colours would pin the theme rather than the behaviour.

Four cases: the reported situation (Settings panel + app tab), agreement on one item, a tab with no sidebar home marking nothing, and a collapsed pane clearing the panel mark while still reporting where the open tab lives. The first fails without the change.

Verified: app suite 64 files / 440 tests green, `tsc` clean, lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ajB96gkaoHq3u6gHm7LRJ
