### PR TITLE
feat(flows): flows require a repo, and a push reconciles them

### DIFF
--- a/api/src/apps/repo-backed-resources.test.ts
+++ b/api/src/apps/repo-backed-resources.test.ts
@@ -73,12 +73,27 @@ assert.ok(
   "fetchFromCloud must run BEFORE syncRepoBackedResources: dbt's sync deletes jobs missing from the tree it reads, so reacting to a tree that predates the push would remove live jobs",
 );
 
-// Flows are Mongo → git only until RFC #904 block 3 flips authority. This is a
-// deliberate exclusion, and it is recorded here so that adding a flow sync is
-// a conscious act rather than an oversight in the other direction.
+// RFC #904 block 3 flipped authority: `flows/<slug>.yml` is now the
+// definition, so flows belong in the shared list like every other repo-backed
+// resource. This assertion used to pin the OPPOSITE — that flows were
+// deliberately excluded — and it failed the moment the sync was wired in,
+// which is exactly what it was for: the change had to be a conscious act.
+// It now pins the same property from the other side.
 assert.ok(
-  !shared.includes("syncFlows") && !shared.includes("flow-config.service"),
-  "flows are deliberately not synced from the repo yet (RFC #904 block 3) — see flow-config.service.ts",
+  shared.includes("flow-sync.service"),
+  "flows must be synced from the repo (RFC #904 block 3) — see services/flow-sync.service.ts",
+);
+
+// A flow is a running stream, not a row: a file missing from the tree tears
+// down a CDC stream and disposes its checkpoints, which re-backfills rather
+// than resuming. The ordering asserted above for dbt therefore matters more
+// here, and the same `fetchFromCloud` → `syncRepoBackedResources` guarantee
+// covers both — flows ride the same call deliberately rather than getting a
+// second, separately-ordered one.
+assert.ok(
+  shared.indexOf("flow-sync.service") >
+    shared.indexOf("syncConsolesIndexFromRepo"),
+  "flows must be inside syncRepoBackedResources, not called ahead of it",
 );
 
 console.log("repo-backed resource sync tests passed");

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -214,11 +214,12 @@ export function notifyRepoPushed(workspaceId: string, userId: string): void {
  * against a stale tree would not merely miss an update, it would remove live
  * jobs and deregister their schedules.
  *
- * Flows are deliberately NOT here. `flows/<slug>.yml` is Mongo → git only
- * until RFC #904 block 3 adds the push reactor and flips authority; reading
- * it back now would make the file authoritative ahead of the CDC
- * pause/reconfigure/resume that a stream-shaped resource needs
- * (services/flow-config.service.ts).
+ * Flows (RFC #904 block 3) are the most dangerous entry in this list, because
+ * a flow is a running stream rather than a row: a file missing from the tree
+ * means a CDC teardown and checkpoint disposal, which re-backfills rather than
+ * resuming. Two guards make that safe, and both live below this call — an
+ * empty `flows/` changes nothing, and every destructive branch is behind a
+ * fail-closed assertion that the tree really is the mirror's main.
  */
 export function syncRepoBackedResources(
   workspaceId: string,
@@ -255,6 +256,26 @@ export function syncRepoBackedResources(
     .then(m => m.syncNotebooksFromRepo(workspaceId, userId))
     .catch(error => {
       logger.warn("Notebook sync after push failed", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  // Flow definitions (RFC #904 block 3): `flows/<slug>.yml` is authoritative,
+  // so an external edit reconfigures a live CDC stream and a removed file
+  // tears one down. Caught like the others — one resource's bad YAML must not
+  // stop the rest — and a refused teardown is reported, not silently skipped.
+  void import("../services/flow-sync.service")
+    .then(m => m.syncFlowsFromRepo(workspaceId))
+    .then(result => {
+      if (result.deferred.length > 0) {
+        logger.warn("Flow teardown deferred; will retry on the next push", {
+          workspaceId,
+          slugs: result.deferred,
+        });
+      }
+    })
+    .catch(error => {
+      logger.warn("Flow sync after push failed", {
         workspaceId,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -32,6 +32,8 @@ import {
   dryRunDbSync,
 } from "../services/destination-writer.service";
 import { teardownFlow } from "../sync-cdc/flow-reconcile";
+import { RepoRequiredError, appsRequireConnectedRepo } from "../apps/config";
+import { resolveMirrorTarget } from "../apps/cloud-repo.service";
 import { cdcBackfillService } from "../sync-cdc/backfill";
 import { syncMachineService } from "../sync-cdc/sync-state";
 import { databaseRegistry } from "../databases/registry";
@@ -63,6 +65,31 @@ const findFlow = findInWorkspace(Flow);
 
 const logger = loggers.inngest("flow");
 
+/**
+ * RFC #904 decision 1: a connected repo is REQUIRED for flows.
+ *
+ * `flows/<slug>.yml` is the definition, so a workspace without a repo has
+ * nowhere durable to keep one — there is no Mongo fallback and no second
+ * definition path. Flows follow consoles and dbt into `RepoRequiredError`
+ * rather than silently writing a definition that only exists in a database
+ * (apps.md §17).
+ *
+ * Deciding it now costs one workspace's configuration — ours, which has a
+ * repo — and stops being free the moment flows have external users. That is
+ * the opposite of the position consoles were in when they hit this.
+ */
+async function assertFlowRepo(workspaceId: string): Promise<void> {
+  if (!appsRequireConnectedRepo()) return;
+  if (!(await resolveMirrorTarget(workspaceId))) throw new RepoRequiredError();
+}
+
+/** 412 with the actionable message, as consoles and the prompt already do. */
+function repoRequired(c: AuthenticatedContext, error: RepoRequiredError) {
+  return c.json(
+    { success: false, code: error.code, error: error.message },
+    error.status as 412,
+  );
+}
 export const flowRoutes = createRouter();
 
 type RequestContextLike = {
@@ -692,6 +719,9 @@ flowRoutes.openapi(
           400,
         );
       }
+      // A flow's definition lives in the repo, so refuse before creating one
+      // that would have nowhere durable to live (RFC #904 decision 1).
+      await assertFlowRepo(workspaceId);
       // TODO: Get userId from authentication
       const userId = "system";
       const body = await c.req.json();
@@ -1090,6 +1120,9 @@ flowRoutes.openapi(
           : {}),
       });
     } catch (error) {
+      // The repo gate is a precondition, not a failure: 412 with an
+      // actionable message rather than a 500 the user cannot act on.
+      if (error instanceof RepoRequiredError) return repoRequired(c, error);
       logger.error("Error creating flow", { error });
       return c.json(
         {
@@ -1189,6 +1222,15 @@ flowRoutes.openapi(
     try {
       const workspaceId = c.req.param("workspaceId");
       const flowId = c.req.param("flowId");
+      if (!workspaceId) {
+        return c.json(
+          { success: false, error: "Workspace ID is required" },
+          400,
+        );
+      }
+      // An edit rewrites `flows/<slug>.yml`; refuse when there is no repo to
+      // write it to (RFC #904 decision 1).
+      await assertFlowRepo(workspaceId);
       const body = await c.req.json();
 
       // Find and validate flow
@@ -1508,6 +1550,9 @@ flowRoutes.openapi(
           : {}),
       });
     } catch (error) {
+      // The repo gate is a precondition, not a failure: 412 with an
+      // actionable message rather than a 500 the user cannot act on.
+      if (error instanceof RepoRequiredError) return repoRequired(c, error);
       logger.error("Error updating flow", { error });
       return c.json(
         {

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -1,12 +1,18 @@
 /**
- * Flow definitions mirrored into the workspace repo (RFC #904, block 2).
+ * Flow definitions mirrored into the workspace repo (RFC #904).
  *
- * **Direction, for now: Mongo → git only.** The rows stay authoritative;
- * every in-product mutation writes its `flows/<slug>.yml` through here so
- * the files can be verified against real flows before anything depends on
- * them. Block 3 adds the push reactor and flips authority — including the
- * CDC pause/reconfigure/resume that a stream-shaped resource needs and a
- * dbt job does not.
+ * **This is the git-ward half only.** Every in-product mutation writes its
+ * `flows/<slug>.yml` through here. The other direction — a push making the
+ * FILE authoritative — landed with block 3 and lives elsewhere:
+ * `flow-sync.service.ts` maps a file back onto a row, and
+ * `sync-cdc/flow-reconcile.ts` reconciles the running stream behind a
+ * fail-closed guard. Both are reached from `syncRepoBackedResources`.
+ *
+ * So this file is no longer "Mongo → git only" in the sense block 2 meant.
+ * What remains true is narrower and still load-bearing: nothing here reads a
+ * file, and the tolerance below (a failed mirror never fails a user's
+ * mutation) is deliberately NOT shared by the read path, where a refused
+ * write is a refusal rather than a warning.
  *
  * Structure mirrors `dbt/dbt-config.service.ts` deliberately: same commit
  * primitives, same "no repo, no write-through" tolerance, same


### PR DESCRIPTION
The last piece of RFC #904 block 3. #929 (definition mapper) and #930 (CDC reconciler) both landed, but nothing called them — so `flows/<slug>.yml` still was not authoritative.

## Wiring

Flows join `syncRepoBackedResources`, the one list **both** push routes call — Mako's git endpoint and the GitHub webhook — so a resource cannot be wired into one and not the other (#924 exists because that had already happened to dbt and notebooks). The comment reserving flows' place in that list is deleted; it was written to be.

An external edit now reconfigures a live CDC stream, and a removed file tears one down. That makes flows the most dangerous entry in the list, so it is worth being explicit that the guards protecting it live **below** this call rather than at it:

| Guard | Where | Effect |
|---|---|---|
| empty `flows/` changes nothing | #929 | a partial tree cannot read as "every flow deleted" |
| `assertTreeAtMirrorMain` | #930 | destructive work refused unless the tree IS the mirror's main |

A refused teardown is logged with its slugs and retried on the next push — deferred, not silently skipped.

## Repo required

RFC decision 1: a flow's definition lives in the repo, so a workspace without one has nowhere durable to keep it. Create and update now refuse with `RepoRequiredError` — the same 412 and actionable message consoles, dbt and the custom prompt already use (apps.md §17) — rather than writing a definition that exists only in Mongo. There is no second definition path.

Deciding this now costs exactly one workspace's configuration, ours, which has a repo. It stops being free the moment flows have external users, which is precisely the position consoles were in when they hit `RepoRequiredError` retroactively.

Both handlers map the error to **412** rather than letting it fall into the generic 500 branch: the gate is a precondition the caller can act on, not an unexpected failure.

## Verification

- `tsc --noEmit`: 70 errors, matching master's baseline exactly — zero introduced.
- Coverage guard: 140 files, all run by a runner.
- `pnpm openapi:sync` produces no drift — the change adds no route and alters no schema.
- The PUT handler gained the missing `workspaceId` guard it needed for the gate to typecheck; create already had one.

## RFC #904 after this

Block 1 (#906) → block 2 (#911, #923, 31 files backfilled) → block 3 (#929, #930, this) → block 4 (#928). Complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB