### PR TITLE
fix(flows): a webhook flow created from a file had nowhere to receive

### DIFF
--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -43,6 +43,7 @@ import {
   freshenBeforeMainWrite,
 } from "../apps/cloud-repo.service";
 import { Flow, type IFlow } from "../database/workspace-schema";
+import { generateWebhookEndpoint } from "../utils/webhook.utils";
 import {
   parseFlowFile,
   slugFromFlowFilePath,
@@ -54,6 +55,49 @@ import {
 } from "../sync-cdc/flow-reconcile";
 
 const logger = loggers.api("flow-sync");
+
+/**
+ * The inbound URL a file-born webhook flow needs, or null when none should be
+ * minted.
+ *
+ * `applyDefinition` writes only `webhookConfig.enabled`, because the endpoint
+ * is inbound URL identity and the secret is a credential — neither belongs in
+ * a file and an EDIT must move neither. That is right for an update and left a
+ * CREATE broken: a file-born webhook flow saved with `enabled: true` and no
+ * endpoint has nowhere for Stripe to POST. It looks configured and receives
+ * nothing, and webhook is the majority case (17 of 31 production flows).
+ *
+ * So the endpoint is minted exactly once, when the row is first created, and
+ * derived from `workspaceId` + the flow's `_id` — never from the slug, so
+ * editing a file cannot move it.
+ *
+ * THE SECRET IS DELIBERATELY NOT MINTED. It is the provider's signing secret
+ * (Stripe's `whsec_...`), handed to `connector.verifyWebhook` by
+ * routes/webhooks.ts. A value invented here would fail signature verification
+ * on every real delivery while the flow looked fully configured — strictly
+ * worse than the empty string, which at least fails honestly. It arrives from
+ * the user, or from the Stripe-managed path that stores `signingSecret`
+ * returned by Stripe's own API.
+ *
+ * On renames: a renamed FILE is a different flow by construction — the slug is
+ * identity and this module matches on it, so a new slug finds no row and mints
+ * its own endpoint. Changing a flow's `name:` does not move the file, so that
+ * row and its endpoint are untouched. Preserving an inbound URL across a file
+ * rename would need identity inside the file, and is a separate change.
+ */
+export function mintedWebhookEndpoint(args: {
+  isNew: boolean;
+  type: string | undefined;
+  workspaceId: string;
+  flowId: string;
+  existingEndpoint?: string;
+}): string | null {
+  if (!args.isNew) return null;
+  if (args.type !== "webhook") return null;
+  // Belt and braces: never overwrite one that somehow already exists.
+  if (args.existingEndpoint) return null;
+  return generateWebhookEndpoint(args.workspaceId, args.flowId);
+}
 
 export interface FlowSyncResult {
   created: number;
@@ -270,6 +314,22 @@ export async function syncFlowsFromRepo(
       });
       result.invalid.push(slug);
       continue;
+    }
+    // A file-born webhook flow needs an inbound URL, and this is the only
+    // place one may be minted. `isNew` is the create/update distinction: an
+    // update must leave the endpoint exactly where it is.
+    const mintedEndpoint = mintedWebhookEndpoint({
+      isNew,
+      type: (doc as IFlow).type,
+      workspaceId,
+      flowId: String((doc as IFlow)._id),
+      existingEndpoint: (doc as IFlow).webhookConfig?.endpoint,
+    });
+    if (mintedEndpoint) {
+      (doc as IFlow).webhookConfig = {
+        ...((doc as IFlow).webhookConfig ?? {}),
+        endpoint: mintedEndpoint,
+      } as IFlow["webhookConfig"];
     }
     (doc as IFlow).sourceBlobSha = sha;
     await doc.save();

--- a/api/src/services/flow-sync.test.ts
+++ b/api/src/services/flow-sync.test.ts
@@ -12,8 +12,11 @@
  * its own, and never writes runtime state from a file.
  */
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import { parseFlowFile, serializeFlowFile } from "./flow-config-files";
+import { mintedWebhookEndpoint } from "./flow-sync.service";
 
 const FILE = `name: orders → warehouse
 type: scheduled
@@ -77,6 +80,106 @@ async function main(): Promise<void> {
   assert.equal(
     parseFlowFile(FILE.replace("name: orders → warehouse", "name: ''")),
     null,
+  );
+
+  // ---- the inbound URL a file-born webhook flow needs -------------------
+  //
+  // `applyDefinition` writes only `webhookConfig.enabled` — right for an EDIT
+  // (the endpoint is inbound URL identity, the secret is a credential, neither
+  // belongs in a file) and wrong for a CREATE, which saved `enabled: true`
+  // with no endpoint: configured-looking and unreachable, on the majority case
+  // (17 of 31 production flows are webhook).
+  const WS = "6a2bd881b6f8c41ea17e9bc7";
+  const ID = "69c2719490eb18199aafa882";
+
+  const created = mintedWebhookEndpoint({
+    isNew: true,
+    type: "webhook",
+    workspaceId: WS,
+    flowId: ID,
+  });
+  assert.ok(created, "a file-born webhook flow must get an inbound URL");
+  // Derived from workspaceId + _id, never the slug — which is what makes an
+  // edit unable to move it.
+  assert.ok(
+    created.endsWith(`/api/webhooks/${WS}/${ID}`),
+    `endpoint must address the flow by id, got ${created}`,
+  );
+
+  // An UPDATE must leave it exactly where it is. This is the assertion that
+  // protects live integrations: 17 production flows have external systems
+  // POSTing to a URL that must not move when someone edits the file.
+  assert.equal(
+    mintedWebhookEndpoint({
+      isNew: false,
+      type: "webhook",
+      workspaceId: WS,
+      flowId: ID,
+      existingEndpoint: "https://api.example.com/api/webhooks/w/f",
+    }),
+    null,
+    "an edit must never re-mint an endpoint",
+  );
+  assert.equal(
+    mintedWebhookEndpoint({
+      isNew: false,
+      type: "webhook",
+      workspaceId: WS,
+      flowId: ID,
+    }),
+    null,
+    "not-new is decisive on its own, endpoint present or not",
+  );
+
+  // Non-webhook flows get nothing, and a row that somehow already carries one
+  // is never overwritten.
+  for (const type of ["scheduled", "manual", undefined]) {
+    assert.equal(
+      mintedWebhookEndpoint({ isNew: true, type, workspaceId: WS, flowId: ID }),
+      null,
+      `a ${String(type)} flow must not get a webhook endpoint`,
+    );
+  }
+  assert.equal(
+    mintedWebhookEndpoint({
+      isNew: true,
+      type: "webhook",
+      workspaceId: WS,
+      flowId: ID,
+      existingEndpoint: "https://api.example.com/api/webhooks/w/f",
+    }),
+    null,
+    "an existing endpoint is never overwritten, new row or not",
+  );
+
+  // The SECRET is never minted here. It is the provider's signing secret
+  // (Stripe's whsec_...), checked by connector.verifyWebhook — a value we
+  // invented would fail verification on every real delivery while the flow
+  // looked configured. This function returns a URL and nothing else, so there
+  // is no place for one to appear.
+  assert.equal(typeof created, "string");
+
+  // …and the create path actually CALLS it. The helper passing proves nothing
+  // on its own: this whole bug was a mapper that deliberately did not write
+  // the endpoint, with everything it did write working fine. A refactor that
+  // drops the call would leave every assertion above green. Driving the real
+  // sync needs git and Mongo, so the wiring is pinned at the source level.
+  const source = readFileSync(
+    path.join(__dirname, "flow-sync.service.ts"),
+    "utf8",
+  );
+  const syncBody = source.slice(
+    source.indexOf("export async function syncFlowsFromRepo"),
+  );
+  assert.match(
+    syncBody,
+    /mintedWebhookEndpoint\(\{[\s\S]*?isNew,/,
+    "syncFlowsFromRepo must mint through the helper, passing isNew",
+  );
+  assert.doesNotMatch(
+    syncBody,
+    /webhookConfig[\s\S]{0,120}secret/,
+    "the sync path must never write a webhook secret — it is the provider's",
   );
 
   console.log("flow-sync: all assertions passed");

--- a/api/src/utils/webhook.utils.ts
+++ b/api/src/utils/webhook.utils.ts
@@ -44,7 +44,11 @@ export function verifyWebhookSignature(
  * Parse webhook payload to extract entity ID and type
  */
 export function parseWebhookPayload(
-  provider: string,
+  // Unused, like the deprecated sibling above: kept for the signature until
+  // the last caller moves to connector.extractWebhookData(). Underscored so
+  // it survives a strict noUnusedParameters check — this module is now in the
+  // app's typecheck graph, which is stricter than the api's.
+  _provider: string,
   payload: any,
 ): {
   entityId: string;


### PR DESCRIPTION
## The bug

A flow created from `flows/<slug>.yml` was saved with `webhookConfig.enabled: true` and **no endpoint**. Nothing could POST to it — configured-looking and dead, on the majority case: **17 of 31 production flows are webhook**. It also breaks the headline scenario of the agent-authored-flows RFC, where someone says "add a Stripe connector and sync it to BigQuery" and Stripe has nowhere to send anything.

`applyDefinition` writes only `webhookConfig.enabled`, deliberately: the endpoint is inbound URL identity and the secret is a credential, so neither belongs in a file and an **edit** must move neither. Correct for an update; never completed for a create. `generateWebhookEndpoint` was called only from `routes/flows.ts`, so the file-born path minted nothing.

The endpoint is now minted **exactly once**, when the row is first created, derived from `workspaceId` + `_id` — never the slug, so editing a file cannot move it.

## The secret is not minted, and that's the load-bearing decision

The assignment asked for "an endpoint (and secret)". There is no secret to mint. It is the **provider's** signing secret (Stripe's `whsec_…`), handed to `connector.verifyWebhook` by `routes/webhooks.ts`; `routes/flows.ts` takes it from the user, and the Stripe-managed path stores `signingSecret` returned by Stripe's own API.

A value invented here would fail signature verification on **every real delivery** while the flow looked fully configured — strictly worse than the empty string, which at least fails honestly.

## On renames

A renamed **file** is a different flow by construction: the slug is identity (`flow-config-files.ts:6`) and this module matches on it, so a new slug finds no row, mints its own endpoint, and the old row is reconciled away. Changing a flow's **`name:`** does not move the file, so that row and its endpoint are untouched.

The RFC uses "rename" for both operations, which is what made this look like a case that needed pinning. Preserving an inbound URL across a *file* rename needs identity inside the file, and is a separate change.

## Tests

The create/update split, non-webhook flows getting nothing, and an existing endpoint never being overwritten.

Plus one that matters more than the rest: **the create path actually calls the helper.** The helper passing proves nothing on its own — this bug was a mapper that deliberately did not write the endpoint while everything it *did* write worked fine, and a refactor dropping the call would leave every unit assertion green. Driving the real sync needs git and Mongo, so the wiring is pinned at the source level.

## Scope — stated because it is easy to overclaim

This makes a file-born webhook flow **addressable**. Whether a newly created CDC row gets its stream started is untested and untouched here. "Webhook flows created from files now work" would be the wrong sentence; "they now have a URL" is the right one.

Verified: flow-sync, flow-config-files and flow-config-mongoose suites green, coverage guard green at 143 files, `tsc` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ajB96gkaoHq3u6gHm7LRJ
