### PR TITLE
fix(apps): a push refreshes what you are looking at, not everything you opened

### DIFF
--- a/app/src/store/appsStore.test.ts
+++ b/app/src/store/appsStore.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+/**
+ * The explorer's response to a workspace-wide change.
+ *
+ * Measured in production (2026-09-01 14:34Z): one `git push` produced 118
+ * requests in a single second against a ~10-15/s baseline — 33 files, 33
+ * branches, 32 status and a list — and Cloud Run refused 65 of them while it
+ * scaled from 3 instances to 13. The cause was not the endpoints being slow,
+ * though they are; it was this store refreshing every app it had EVER loaded,
+ * because `filesByApp` is pruned only when an app is deleted and never when a
+ * tab closes. The burst therefore scaled with how long somebody had been
+ * working rather than with what they were looking at.
+ *
+ * The herd cannot be reproduced offline, so what these assert is the property
+ * that removes it: the number of requests a workspace-wide event provokes does
+ * not grow with the size of the cache. The latency figures stay in the commit
+ * message as the evidence for why it matters, rather than being re-proved here.
+ *
+ * The second half matters as much as the first. Marking state stale instead of
+ * refetching it trades a request storm for a correctness bug unless something
+ * reliably re-reads: a tab that never unmounted would otherwise show state from
+ * before the push, silently and forever. So activation drains the stale set,
+ * and that is tested too.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const calls: string[] = [];
+
+vi.mock("../api", () => ({
+  api: {
+    GET: vi.fn(async (path: string) => {
+      calls.push(path);
+      return { data: { success: true, files: [], branches: [], status: {} } };
+    }),
+    POST: vi.fn(async () => ({ data: { success: true } })),
+  },
+  unwrapBody: (r: { data?: unknown }) => (r?.data ?? {}) as never,
+  ApiError: class extends Error {},
+  toErrorMessage: (e: unknown) => String(e),
+}));
+vi.mock("../apps-runtime/shell", () => ({
+  focusAppsTab: vi.fn(),
+  focusAppsFileTab: vi.fn(),
+  reconcileAppsTabs: vi.fn(),
+}));
+
+import { useAppsStore } from "./appsStore";
+import { useConsoleStore } from "./consoleStore";
+import { useUIStore } from "./uiStore";
+
+const WS = "6846e6a01b05af0948070582";
+
+/** A window that has browsed `n` apps this session — the real starting state. */
+function cacheApps(n: number): string[] {
+  const ids = Array.from({ length: n }, (_, i) => `app${i}`);
+  useAppsStore.setState(s => {
+    for (const id of ids) {
+      s.filesByApp[id] = [];
+      s.branchesByApp[id] = { current: "main", branches: [] } as never;
+    }
+  });
+  return ids;
+}
+
+function openAppTab(appId: string): string {
+  const id = `tab-${appId}`;
+  useConsoleStore.setState(s => {
+    s.tabs[id] = {
+      id,
+      title: appId,
+      content: "",
+      kind: "app",
+      metadata: { appId },
+    } as never;
+    s.tabOrder = [...s.tabOrder, id];
+  });
+  return id;
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  useAppsStore.setState({ filesByApp: {}, branchesByApp: {}, staleApps: {} });
+  useConsoleStore.setState({ tabs: {}, tabOrder: [], activeTabId: null });
+  useUIStore.setState({ currentWorkspaceId: WS } as never);
+});
+
+describe("a workspace-wide change", () => {
+  it("does not fan out across every app the window has cached", () => {
+    cacheApps(30);
+    const active = openAppTab("app7");
+    useConsoleStore.setState({ activeTabId: active });
+
+    useAppsStore.getState().markAllAppsStale();
+    // The old handler looped here and issued ~3 requests per cached app.
+    expect(useAppsStore.getState().staleApps["app0"]).toBe(true);
+    expect(Object.keys(useAppsStore.getState().staleApps)).toHaveLength(30);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("costs the same whether the window cached 5 apps or 50", () => {
+    // The property the fix exists for: cost independent of cache size. A
+    // batched endpoint would have kept this proportional, only with a smaller
+    // constant.
+    cacheApps(5);
+    useConsoleStore.setState({ activeTabId: openAppTab("app1") });
+    useAppsStore.getState().refreshAppIfStale(WS, "app1");
+    useAppsStore.getState().markAllAppsStale();
+    useAppsStore.getState().refreshAppIfStale(WS, "app1");
+    const few = calls.length;
+
+    calls.length = 0;
+    useAppsStore.setState({ filesByApp: {}, branchesByApp: {}, staleApps: {} });
+    cacheApps(50);
+    useAppsStore.getState().markAllAppsStale();
+    useAppsStore.getState().refreshAppIfStale(WS, "app1");
+    expect(calls.length).toBe(few);
+  });
+});
+
+describe("staleness is drained, not left to rot", () => {
+  it("refreshes an app when its tab becomes active", () => {
+    cacheApps(3);
+    const tab = openAppTab("app2");
+    useAppsStore.getState().markAllAppsStale();
+    expect(calls).toHaveLength(0);
+
+    // Switching to the tab is what re-reads. This is the case that would
+    // otherwise show pre-push state forever: the tab never unmounted, so
+    // nothing else would have refetched it.
+    useConsoleStore.setState({ activeTabId: tab });
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(useAppsStore.getState().staleApps["app2"]).toBeUndefined();
+  });
+
+  it("does nothing for an app that is not stale", () => {
+    cacheApps(3);
+    useAppsStore.getState().refreshAppIfStale(WS, "app1");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("leaves the other apps stale until they are looked at", () => {
+    cacheApps(3);
+    const tab = openAppTab("app0");
+    useAppsStore.getState().markAllAppsStale();
+    useConsoleStore.setState({ activeTabId: tab });
+
+    const stale = useAppsStore.getState().staleApps;
+    expect(stale["app0"]).toBeUndefined();
+    expect(stale["app1"]).toBe(true);
+    expect(stale["app2"]).toBe(true);
+  });
+});

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -16,6 +16,8 @@ import { persist } from "zustand/middleware";
 import { api, unwrapBody, ApiError, toErrorMessage as message } from "../api";
 import { focusAppsTab, reconcileAppsTabs } from "../apps-runtime/shell";
 import { onRealtimeEvent } from "./lib/realtime-channel";
+import { useConsoleStore } from "./consoleStore";
+import { useUIStore } from "./uiStore";
 
 export interface AppMeta {
   id: string;
@@ -210,6 +212,15 @@ interface AppsStore {
 
   filesByApp: Record<string, AppFileEntry[]>;
   /**
+   * Apps whose cached per-app state is known to be out of date.
+   *
+   * A workspace-wide change marks every loaded app instead of refetching it.
+   * The set is drained by {@link AppsStore.refreshAppIfStale}, which the
+   * active tab calls on activation — so "stale" is never a resting state for
+   * something on screen, only for something nobody is looking at.
+   */
+  staleApps: Record<string, true>;
+  /**
    * Set when the server capped an app's listing — { shown, total }. A
    * 100k-file folder (a committed node_modules, a data dump) renders its
    * first files plus this notice instead of crashing the tree.
@@ -328,6 +339,15 @@ interface AppsStore {
   fetchStatus: (workspaceId: string, appId: string) => Promise<void>;
   fetchHistory: (workspaceId: string, appId: string) => Promise<void>;
   fetchBranches: (workspaceId: string, appId: string) => Promise<void>;
+  /**
+   * Refetch an app's cached state, but only if a workspace change marked it
+   * stale. Called when an app tab becomes active, which is what makes
+   * "invalidate, don't refetch" safe: nothing on screen stays stale, and the
+   * work happens for one app at a time instead of for every app at once.
+   */
+  refreshAppIfStale: (workspaceId: string, appId: string) => void;
+  /** Mark every loaded app stale — a workspace-wide change touched them all. */
+  markAllAppsStale: () => void;
   /** Fetch (or refresh) the cookie-free URL for an app's published build. */
   fetchViewUrl: (workspaceId: string, appId: string) => Promise<void>;
   /** Enter or leave edit mode for an app (see `editingByApp`). */
@@ -513,6 +533,7 @@ export const useAppsStore = create<AppsStore>()(
       appsLoading: false,
       error: null,
       filesByApp: {},
+      staleApps: {},
       filesTruncatedByApp: {},
       fileContents: {},
       selectedFile: {},
@@ -1076,6 +1097,40 @@ export const useAppsStore = create<AppsStore>()(
         if (editing) {
           void get().fetchFiles(workspaceId, appId);
           void get().fetchStatus(workspaceId, appId);
+        }
+      },
+
+      markAllAppsStale: () => {
+        ensureActivationDrain();
+        set(s => {
+          for (const appId of Object.keys(s.filesByApp)) {
+            s.staleApps[appId] = true;
+          }
+          for (const appId of Object.keys(s.branchesByApp)) {
+            s.staleApps[appId] = true;
+          }
+        });
+      },
+
+      refreshAppIfStale: (workspaceId, appId) => {
+        const state = get();
+        if (!state.staleApps[appId]) return;
+        set(s => {
+          delete s.staleApps[appId];
+        });
+        if (state.filesByApp[appId]) {
+          void state.fetchFiles(workspaceId, appId);
+          void state.fetchStatus(workspaceId, appId);
+        }
+        if (state.branchesByApp[appId]) {
+          void state.fetchBranches(workspaceId, appId);
+        }
+        const selected = state.selectedFile[appId];
+        if (selected) {
+          const entry = state.fileContents[`${appId}\u0000${selected}`];
+          if (entry && !entry.dirty) {
+            void state.openFile(workspaceId, appId, selected);
+          }
         }
       },
 
@@ -1939,28 +1994,95 @@ onRealtimeEvent("app.updated", "appsStore", (event, ctx) => {
   // Explorer list (titles, new/deleted apps).
   void v2.fetchApps(workspaceId);
   if (event.origin === "lifecycle") return;
-  // §10 monorepo: appId "" = workspace-wide (a workspace worktree
-  // changed; it may span apps) — refresh every app this window has
-  // loaded. A non-empty appId scopes to that app as before.
-  const appIds = event.appId ? [event.appId] : Object.keys(v2.filesByApp);
-  for (const appId of appIds) {
-    // Only refresh heavier per-app state when this window has it loaded.
-    if (v2.filesByApp[appId]) {
-      void v2.fetchFiles(workspaceId, appId);
-      void v2.fetchStatus(workspaceId, appId);
-    }
-    if (v2.branchesByApp[appId]) {
-      void v2.fetchBranches(workspaceId, appId);
-    }
-    const selected = v2.selectedFile[appId];
-    if (selected) {
-      const entry = v2.fileContents[`${appId}\u0000${selected}`];
-      if (entry && !entry.dirty) {
-        void v2.openFile(workspaceId, appId, selected);
-      }
+
+  // A NAMED app is refreshed immediately — one app, three requests, which is
+  // what the event is for.
+  if (event.appId) {
+    refreshAppNow(workspaceId, event.appId);
+    return;
+  }
+
+  // §10 monorepo: appId "" = workspace-wide (a workspace worktree changed; it
+  // may span apps). This used to refresh every app the window had loaded, in
+  // one tick. `filesByApp` is a cache that grows all session — it is pruned
+  // only when an app is DELETED, never when a tab closes — so the burst scaled
+  // with how long somebody had been working rather than with what they were
+  // looking at. Measured in production: a single push produced 118 requests in
+  // one second (33 files + 33 branches + 32 status + a list) against a ~10-15
+  // baseline, and Cloud Run refused 65 of them while it scaled.
+  //
+  // So: mark them stale and refresh only what is on screen. Every other app
+  // refetches when its tab is next activated, which is the first moment its
+  // freshness matters to anyone.
+  useAppsStore.getState().markAllAppsStale();
+  const active = activeAppId();
+  if (active) refreshAppNow(workspaceId, active);
+});
+
+/** Refresh one app's cached state now, ignoring whether it was marked stale. */
+function refreshAppNow(workspaceId: string, appId: string): void {
+  const v2 = useAppsStore.getState();
+  useAppsStore.setState(s => {
+    delete s.staleApps[appId];
+  });
+  if (v2.filesByApp[appId]) {
+    void v2.fetchFiles(workspaceId, appId);
+    void v2.fetchStatus(workspaceId, appId);
+  }
+  if (v2.branchesByApp[appId]) {
+    void v2.fetchBranches(workspaceId, appId);
+  }
+  const selected = v2.selectedFile[appId];
+  if (selected) {
+    const entry = v2.fileContents[`${appId}\u0000${selected}`];
+    if (entry && !entry.dirty) {
+      void v2.openFile(workspaceId, appId, selected);
     }
   }
-});
+}
+
+/** Same source notebookStore reads, so the app shell has one answer. */
+function currentWorkspaceId(): string | null {
+  return useUIStore.getState().currentWorkspaceId ?? null;
+}
+
+/** The app the user is actually looking at, if the active tab is an app. */
+function activeAppId(): string | null {
+  const console = useConsoleStore.getState();
+  const tab = console.activeTabId ? console.tabs[console.activeTabId] : null;
+  if (!tab || tab.kind !== "app") return null;
+  const appId = (tab.metadata as { appId?: unknown } | undefined)?.appId;
+  return typeof appId === "string" && appId ? appId : null;
+}
+
+/**
+ * Draining the stale set is what makes marking safe.
+ *
+ * Without it, "invalidate, don't refetch" trades a request storm for a
+ * correctness bug: someone switching back to a tab that never unmounted would
+ * be shown state from before the push, silently and indefinitely. Activation
+ * is the right trigger rather than mount, precisely because the tab that
+ * stayed mounted is the one that would otherwise never re-read.
+ *
+ * Registered on first use rather than at import. Subscribing at module scope
+ * made importing this store fail outright wherever consoleStore is mocked
+ * without a `subscribe` — a real breakage (UrlSync's suite) caused by a side
+ * effect that had no reason to run before anything could be stale.
+ */
+let activationDrainRegistered = false;
+function ensureActivationDrain(): void {
+  if (activationDrainRegistered) return;
+  if (typeof useConsoleStore.subscribe !== "function") return;
+  activationDrainRegistered = true;
+  useConsoleStore.subscribe((state, previous) => {
+    if (state.activeTabId === previous.activeTabId) return;
+    const appId = activeAppId();
+    if (!appId) return;
+    const workspaceId = currentWorkspaceId();
+    if (!workspaceId) return;
+    useAppsStore.getState().refreshAppIfStale(workspaceId, appId);
+  });
+}
 
 onRealtimeEvent("app.box-state", "appsStore", event => {
   useAppsStore.getState().applyBoxState(event.userId, event.state);


### PR DESCRIPTION
## The measurement

Production, 2026-09-01 14:34Z — one `git push` produced:

| | |
|---|---|
| Requests in a single second | **118** (33 files + 33 branches + 32 status + list) against a ~10–15/s baseline |
| Refused by Cloud Run | **65 × 429**, all inside a 13-second window |
| Instances | scaled **3 → 13** of a 15 ceiling |
| Minute-averaged rate | only **562/min** — which is why it read as a capacity shortfall and isn't one |

## The cause

`app.updated` in `appsStore`. A push emits a **workspace-wide** event (no `appId`), and the handler looped over `Object.keys(filesByApp)` — every app the window had *ever* opened — firing `fetchFiles` + `fetchStatus` (+ `fetchBranches`) each, same tick, undebounced.

`filesByApp` is pruned only when an app is **deleted**, never when a tab closes. So the cache grows monotonically for the session, and **the burst scaled with how long someone had been working rather than with what they were looking at.**

## The fix

Mark stale; refresh only the app whose tab is active. Everything else refetches when its tab is next activated — the first moment its freshness matters to anyone. **Cost stops being proportional to the cache.**

### Why not the batched endpoint I originally proposed

`/files` costs **4.57s median, p90 15.59s** — measured in a *quiet* window, so that's its resting cost, not congestion — because it lists the sandbox working copy: an **E2B round trip per app**. Batching thirty of those doesn't remove thirty round trips, it serialises them into one request that takes as long as all of them, where today they at least run in parallel.

And it would have left the amplifier — the loop's **scope** — untouched, keeping cost proportional to the cache with a smaller constant. The original proposal treated the symptom visible in the logs; this treats the cause visible in the code.

### Draining is the half that makes it safe

"Invalidate, don't refetch" trades a request storm for a **correctness bug** unless something reliably re-reads: a tab that never unmounted would show pre-push state silently and forever. So **activation** drains the stale set — not mount, precisely because the still-mounted tab is the one that would otherwise never re-read.

The drain subscribes on **first staleness rather than at import**. Subscribing at module scope broke `UrlSync`'s suite outright (consoleStore is mocked there without `subscribe`) — a fair verdict on running a side effect before anything could possibly be stale.

## Tests

The herd can't be reproduced offline, so these assert the **property**, not the incident:

- the request count for a workspace-wide event **does not grow between a 5-app and a 50-app cache** — the proportionality that a batched endpoint would have kept
- activation **refreshes** a stale app
- apps nobody looked at **stay** stale

The latency figures stay in the commit message as evidence, rather than as test expectations they'd re-prove badly.

Verified load-bearing: disabling the drain fails two of the five.

Frontend suite: 65 files / 445 tests. `app test:unit` was wired into CI by #912, so this actually runs — before tonight it wouldn't have.

## Not in this PR

The frontend DRY debt (per-explorer loading and caches, no shared primitive) is the same root and deliberately left alone: bundling a refactor into a production-herd fix makes the fix hostage to a much larger review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ph93bxCXuNfpYdioJthA1
