### PR TITLE
fix(flows): a NEW flow file never created a row — createdBy was required and never set

### DIFF
--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -265,7 +265,7 @@ export function syncRepoBackedResources(
   // tears one down. Caught like the others — one resource's bad YAML must not
   // stop the rest — and a refused teardown is reported, not silently skipped.
   void import("../services/flow-sync.service")
-    .then(m => m.syncFlowsFromRepo(workspaceId))
+    .then(m => m.syncFlowsFromRepo(workspaceId, userId))
     .then(result => {
       if (result.deferred.length > 0) {
         logger.warn("Flow teardown deferred; will retry on the next push", {

--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `syncFlowsFromRepo` against a real repo and a real Mongoose model.
+ *
+ * The existing `flow-sync.test.ts` asserts on the module's SOURCE TEXT. That
+ * is how a create path that had never once worked stayed green: `createdBy`
+ * is required on `FlowSchema`, `new Flow({ workspaceId, slug })` never set
+ * it, and `save()` threw a ValidationError that escaped the per-file loop —
+ * so the first NEW `flows/<slug>.yml` anyone pushed created no row, skipped
+ * every file after it, skipped the reconciler, and logged one WARN. Every
+ * production verification had been of EXISTING flows, where the row already
+ * carried a `createdBy` from the UI.
+ *
+ * So these cases drive the real function: a bare repo, a commit on main, a
+ * memory Mongo, and assertions on what rows exist afterwards.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+// No connected GitHub repo: the mirror helpers become no-ops and the
+// reconciler has nothing destructive to verify against (no removals here).
+vi.mock("./workspace-repos.service", () => ({
+  getWorkspaceRepo: vi.fn(async () => null),
+  findWorkspaceIdByRepoBinding: vi.fn(async () => null),
+}));
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: async () => undefined,
+}));
+vi.mock("../inngest/client", () => ({
+  inngest: { send: vi.fn(async () => undefined) },
+}));
+
+import { Flow } from "../database/workspace-schema";
+import {
+  DEFAULT_BRANCH,
+  commitBlobsOnBranch,
+  initRepo,
+  repoDirFor,
+} from "../apps/repository.service";
+import { syncFlowsFromRepo } from "./flow-sync.service";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+let WS: string;
+
+const CONNECTOR = new Types.ObjectId().toString();
+const DEST = new Types.ObjectId().toString();
+
+/** A complete, loadable CDC flow in the on-disk (snake_case) format. */
+function flowYaml(name: string, extra = ""): string {
+  return [
+    `name: ${name}`,
+    "type: webhook",
+    "source:",
+    "  type: connector",
+    `  connector_id: ${CONNECTOR}`,
+    "destination:",
+    `  connection_id: ${DEST}`,
+    "  table:",
+    "    schema: raw_close",
+    "    create_if_not_exists: true",
+    "backfill_schedule:",
+    "  cron: 0 3 * * *",
+    "  timezone: UTC",
+    "webhook:",
+    "  enabled: true",
+    "sync:",
+    "  mode: incremental",
+    "  write_mode: append_dedup",
+    "  engine: cdc",
+    "entities:",
+    "  layouts:",
+    "    - entity: leads",
+    "      partitionField: _syncedAt",
+    "      partitionGranularity: day",
+    "      enabled: true",
+    extra,
+    "",
+  ].join("\n");
+}
+
+async function push(writes: Record<string, string>): Promise<void> {
+  await commitBlobsOnBranch(
+    repoDirFor(WS),
+    DEFAULT_BRANCH,
+    { writes },
+    { message: "laptop push" },
+  );
+}
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "flow-sync-repo-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  WS = new Types.ObjectId().toString();
+  await Flow.deleteMany({});
+  await initRepo(repoDirFor(WS), { "README.md": "x\n" });
+});
+
+describe("a NEW flow file creates a row", () => {
+  it("through Mako's git endpoint, authored by whoever pushed", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+
+    const result = await syncFlowsFromRepo(WS, "user-42");
+
+    expect(result.created).toBe(1);
+    expect(result.invalid).toEqual([]);
+    const row = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+    expect(row).not.toBeNull();
+    expect(row!.createdBy).toBe("user-42");
+    expect(row!.type).toBe("webhook");
+    expect(row!.syncEngine).toBe("cdc");
+    expect(row!.backfillSchedule?.enabled).toBe(true);
+    expect(row!.backfillSchedule?.cron).toBe("0 3 * * *");
+    // #939: a file-born webhook flow is addressable, and derives from the id.
+    expect(row!.webhookConfig?.endpoint).toContain(`/${WS}/${row!._id}`);
+    // …and never carries a secret from the file (that is a credential).
+    expect(row!.webhookConfig?.secret).toBeFalsy();
+  });
+
+  it("from a push made directly on GitHub, with no actor to attribute", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+
+    // routes/github.routes.ts calls syncRepoBackedResources(workspaceId) with
+    // no userId — the webhook does not carry a Mako user.
+    const result = await syncFlowsFromRepo(WS);
+
+    expect(result.created).toBe(1);
+    const row = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+    // Same author the dbt job sync uses for the same situation.
+    expect(row?.createdBy).toBe("sync");
+  });
+
+  it("is idempotent: the second sync of the same tree touches nothing", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+    await syncFlowsFromRepo(WS, "user-42");
+    const again = await syncFlowsFromRepo(WS, "user-42");
+    expect(again).toMatchObject({ created: 0, updated: 0, unchanged: 1 });
+  });
+});
+
+describe("one bad file is that file's problem", () => {
+  it("a file that parses but cannot be saved does not stop the others", async () => {
+    await push({
+      // Sorted first by the tree walk, so it fails BEFORE the good one.
+      "flows/a-bad-one.yml": flowYaml("Bad").replace(
+        "write_mode: append_dedup",
+        "write_mode: not_a_real_mode", // outside the schema enum → save() throws
+      ),
+      "flows/z-good-one.yml": flowYaml("Good"),
+    });
+
+    const result = await syncFlowsFromRepo(WS, "user-42");
+
+    expect(result.invalid).toEqual(["a-bad-one"]);
+    expect(result.created).toBe(1);
+    expect(await Flow.countDocuments({ workspaceId: WS })).toBe(1);
+    expect(await Flow.findOne({ workspaceId: WS, slug: "z-good-one" })).not.toBeNull();
+  });
+
+  it("a connector NAME where an id belongs is refused, not thrown", async () => {
+    await push({
+      "flows/a-by-name.yml": flowYaml("By name").replace(
+        `connector_id: ${CONNECTOR}`,
+        "connector_id: close", // not an ObjectId → new ObjectId() throws
+      ),
+      "flows/z-good-one.yml": flowYaml("Good"),
+    });
+
+    const result = await syncFlowsFromRepo(WS, "user-42");
+
+    expect(result.invalid).toEqual(["a-by-name"]);
+    expect(result.created).toBe(1);
+    expect(await Flow.countDocuments({ workspaceId: WS })).toBe(1);
+  });
+
+  it("a failed save on an EXISTING row keeps that row as it was", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+    await syncFlowsFromRepo(WS, "user-42");
+    const before = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+
+    await push({
+      "flows/close-to-bigquery.yml": flowYaml("Renamed").replace(
+        "write_mode: append_dedup",
+        "write_mode: not_a_real_mode",
+      ),
+    });
+    const result = await syncFlowsFromRepo(WS, "user-42");
+
+    expect(result.invalid).toEqual(["close-to-bigquery"]);
+    const after = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+    expect(after!.name).toBe(before!.name);
+    expect(after!.writeMode).toBe(before!.writeMode);
+    expect(after!.sourceBlobSha).toBe(before!.sourceBlobSha);
+  });
+});

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -229,9 +229,18 @@ function applyDefinition(doc: IFlow, file: FlowFile): string | null {
  *
  * Idempotent: a file whose blob sha matches the row's `sourceBlobSha` costs a
  * read and nothing else.
+ *
+ * `actorUserId` is whoever pushed, when the push came through Mako's own git
+ * endpoint; a push made directly on GitHub arrives as a webhook with no actor
+ * and gets the same `"sync"` author the dbt job sync uses. It only matters on
+ * CREATE: `createdBy` is required on the schema, and a new row without one
+ * does not fail quietly — `save()` throws, and before this was threaded that
+ * throw escaped the per-file loop, so a single new file aborted the rest of
+ * the push's sync and the reconciler with it. Nothing anyone could see.
  */
 export async function syncFlowsFromRepo(
   workspaceId: string,
+  actorUserId?: string,
 ): Promise<FlowSyncResult> {
   const empty: FlowSyncResult = {
     created: 0,
@@ -304,8 +313,20 @@ export async function syncFlowsFromRepo(
     }
 
     const isNew = !row;
-    const doc = row ?? new Flow({ workspaceId, slug });
-    const refusal = applyDefinition(doc as IFlow, parsed);
+    const doc =
+      row ??
+      new Flow({ workspaceId, slug, createdBy: actorUserId ?? "sync" });
+    // `applyDefinition` refuses with a reason, but it can also THROW: an id
+    // that is not an ObjectId (`connector_id: close` — a name where an id
+    // belongs, the likeliest agent mistake) fails inside `new ObjectId()`.
+    // Same treatment as a refusal; see the save() catch below for why it
+    // must not escape.
+    let refusal: string | null;
+    try {
+      refusal = applyDefinition(doc as IFlow, parsed);
+    } catch (error) {
+      refusal = error instanceof Error ? error.message : String(error);
+    }
     if (refusal) {
       logger.warn("Flow file cannot be applied; keeping current row", {
         workspaceId,
@@ -332,7 +353,24 @@ export async function syncFlowsFromRepo(
       } as IFlow["webhookConfig"];
     }
     (doc as IFlow).sourceBlobSha = sha;
-    await doc.save();
+    // One file's failure is that file's problem. `save()` can still throw for
+    // a file that parsed and applied — a value outside a schema enum, an id
+    // that is not an ObjectId — and letting that escape would skip every file
+    // after it AND the reconcile below, for the whole push. The row that
+    // exists is kept (the failed save is not applied); a new one is simply
+    // not created, and since it never reached `desired` there is nothing for
+    // the reconciler to tear down either way.
+    try {
+      await doc.save();
+    } catch (error) {
+      logger.warn("Flow file could not be saved; keeping current row", {
+        workspaceId,
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      result.invalid.push(slug);
+      continue;
+    }
     if (isNew) {
       result.created++;
       // A row created in this pass has no id until now, so its desired entry

--- a/api/vitest.destinations.config.ts
+++ b/api/vitest.destinations.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
       "src/sync-cdc/backlog.test.ts",
       "src/sync-cdc/consumer.test.ts",
       "src/sync-cdc/flow-reconcile.test.ts",
+      // The push reactor's create path, against a real repo and the real model.
+      "src/services/flow-sync.repo.test.ts",
       "src/sync/legacy-flow-migration.test.ts",
       "src/sync/sync-orchestrator.test.ts",
       "src/utils/bigquery-emulator.test.ts",


### PR DESCRIPTION
## The bug

`api/src/services/flow-sync.service.ts` built a brand-new row as `new Flow({ workspaceId, slug })`. `createdBy` is `required: true` on `FlowSchema` (`workspace-schema.ts:2583`) with no default, no pre-save hook, no plugin. So `doc.save()` threw a `ValidationError`, and the throw escaped the per-file loop: the first **new** `flows/<slug>.yml` in a push created no row, skipped every file sorted after it, skipped `reconcileFlowsFromRepo` entirely, and produced one WARN line in `worktree.service.ts:276`.

Reproduced directly: `new Flow({...file fields...}).validateSync()` → `errors: ['createdBy']`.

**Why it survived:** every production verification of flows-as-code (31 synced, 0 streams touched) was of *existing* flows, whose rows carry a `createdBy` from the UI. The create-from-file path had never once worked, and `flow-sync.test.ts` asserts on the module's source text, so nothing exercised it against the model. This is RFC `agent-authored-flows.md` gap 5 ("make it live is unproven for a NEW flow") — it turned out to be unproven because it was impossible.

## The fix

1. **`syncFlowsFromRepo(workspaceId, actorUserId?)`.** `worktree.service.ts:268` already had `userId` in scope and passed it to the dbt and notebook siblings on the lines above — just not to this one. GitHub-direct pushes (`github.routes.ts:159`) arrive with no actor and get `createdBy: "sync"`, the same author `dbt-config.service.ts:326` uses for the same situation.
2. **Per-file isolation.** `applyDefinition` can throw (`connector_id: close` — a *name* where an id belongs, the likeliest agent mistake — fails inside `new ObjectId()`), and `save()` can throw (a value outside a schema enum; a layout without `partitionField`). Both are caught per file: slug → `result.invalid`, existing row kept as it was, remaining files and the reconcile still run. The `.catch` comment in `worktree.service.ts` already promised "one resource's bad YAML must not stop the rest" — it was true across resources and false within flows.

Safety of isolation w.r.t. teardown: an existing row's `desired` entry is pushed *before* the save, so a failed update cannot read as a deletion; a failed create never had a row, so there is nothing to tear down.

## Verification

New `flow-sync.repo.test.ts` drives the real function: real bare repo, `commitBlobsOnBranch` onto main, memory Mongo, real model. Six cases:

- new file through the git endpoint → row created, `createdBy` = pusher, `webhookConfig.endpoint` derives from the id (#939), no secret
- new file from a GitHub-direct push → `createdBy: "sync"`
- second sync of the same tree → `unchanged: 1`, nothing else
- bad file sorted first (enum violation) → `invalid: [bad]`, the good one still created
- `connector_id: close` → refused, the good one still created
- failed save on an existing row → name, writeMode, sourceBlobSha unchanged

**All six fail against master's service** (verified by stashing the service change and rerunning) **and pass here.**

- `api` tsc: 74 errors, identical to master's 74 (baseline; none in touched files)
- `flow-sync.test.ts`, `flow-config-files.test.ts`, `test-coverage.test.ts` pass; the new file is registered in `vitest.destinations.config.ts`

## What this does NOT do

It makes a file-born flow **exist**. Whether it then runs is field-driven and needs no create event: `flowSchedulerFunction` (cron `*/5`) picks up rows with `schedule.cron`, `cdcScheduledBackfillFunction` picks up `syncEngine: cdc` + `backfillSchedule.enabled`. A file with `backfill_schedule:` will start its first backfill within 5 minutes of the row existing. A webhook flow is addressable but the provider secret must still be set in the UI (deliberately never from the file) and the provider pointed at the minted URL.

Also surfaced, not fixed here: `validateFlowFiles` does not run schema validation, so a layout without `partitionField` passes the validator and fails at save. The validator should hydrate a doc and `validateSync()` it — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB
