### PR TITLE
feat(flows): check_flow_files — one MCP call that says what a flows/ change would do

### DIFF
--- a/api/src/agent-lib/tools/flow-file-tools.test.ts
+++ b/api/src/agent-lib/tools/flow-file-tools.test.ts
@@ -1,0 +1,471 @@
+/**
+ * `check_flow_files`: the pre-push check an agent authoring `flows/<slug>.yml`
+ * calls before it commits.
+ *
+ * Two kinds of assertion here, and the second kind is the point.
+ *
+ * BEHAVIOUR — above all, that a PARTIAL input never reports a teardown. The
+ * plan derives removals from absence, so a tool that read "the two files I
+ * changed" as "the whole of flows/" would tell an agent it is about to delete
+ * every other pipeline in the workspace. The converse is pinned too: a
+ * deletion the caller actually asks about IS reported, because a check that
+ * never reports a teardown passes the first test trivially and is worthless.
+ *
+ * WIRING — that the tool is registered, classified, bridged and reachable.
+ * The two functions this composes were both shipped, tested and unreachable:
+ * `dryRunFlowReconcile` had zero non-test callers. A green unit test on the
+ * helper is exactly what that failure looks like, so the tool is exercised
+ * through the MCP toolset the server actually builds, not just through its
+ * own export.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+const state = vi.hoisted(() => ({
+  sent: [] as Array<{ name: string; data: unknown }>,
+}));
+
+// No mirror: `ensureLocalRepo` must not reach for a remote, and the local
+// bare repo below is authoritative.
+vi.mock("../../services/workspace-repos.service", () => ({
+  getWorkspaceRepo: vi.fn(async () => null),
+  findWorkspaceIdByRepoBinding: vi.fn(async () => null),
+}));
+// A read-only tool must send no events. Observed rather than assumed.
+vi.mock("../../inngest/client", () => ({
+  inngest: {
+    send: vi.fn(async (event: { name: string; data: unknown }) => {
+      state.sent.push(event);
+    }),
+  },
+}));
+
+import {
+  CdcEntityState,
+  Connector,
+  DatabaseConnection,
+  Flow,
+} from "../../database/workspace-schema";
+import { initRepo, repoDirFor } from "../../apps/repository.service";
+import { checkFlowFiles, createFlowFileTools } from "./flow-file-tools";
+import { buildMakoMcpToolset } from "../../mcp/mako-mcp-server";
+import {
+  MCP_BRIDGE_POLICY,
+  assertBridgePolicyCovers,
+  assertBridgePolicyNotStale,
+  mcpExposedToolNames,
+  mcpReadOnlyHint,
+} from "../../mcp/bridge-policy";
+import { collectLiveAgentToolNames } from "../../mcp/bridge-inventory";
+import { DEFERRED_BUILTIN_TOOL_NAMES } from "../../agents/modes/registry";
+import { unifiedAgentFactory } from "../../agents/unified";
+import { READ_ONLY_TOOL_NAMES } from "@mako/agent-tools";
+import type { AgentContext } from "../../agents/types";
+
+let mongo: MongoMemoryServer;
+let tmpRoot: string;
+let WS: Types.ObjectId;
+let CONNECTOR: Types.ObjectId;
+let DEST: Types.ObjectId;
+
+/** A file that parses, resolves, and produces a row the schema accepts. */
+function flowYaml(name: string, entities?: string[]): string {
+  const lines = [
+    `name: ${name}`,
+    "type: scheduled",
+    "source:",
+    "  type: connector",
+    `  connector_id: ${CONNECTOR.toString()}`,
+    "destination:",
+    `  connection_id: ${DEST.toString()}`,
+    "sync:",
+    "  mode: incremental",
+    "  engine: cdc",
+  ];
+  if (entities) {
+    lines.push("entities:", "  filter:");
+    for (const entity of entities) lines.push(`    - ${entity}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function seedRow(slug: string, entityFilter?: string[]) {
+  return Flow.create({
+    workspaceId: WS,
+    slug,
+    name: slug,
+    type: "scheduled",
+    sourceType: "connector",
+    dataSourceId: CONNECTOR,
+    destinationDatabaseId: DEST,
+    syncEngine: "cdc",
+    // No cron, matching a file with no `schedule:` block — `schedule.cron` is
+    // required only while the schedule is enabled.
+    schedule: { enabled: false },
+    entityFilter,
+    createdBy: "u1",
+  });
+}
+
+/** Everything a read must leave exactly as it found it. */
+async function snapshot() {
+  return JSON.stringify({
+    flows: await Flow.find({}).sort({ slug: 1 }).lean(),
+    entities: await CdcEntityState.find({}).sort({ entity: 1 }).lean(),
+  });
+}
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "flow-file-tools-"));
+  process.env.APPS_GIT_ROOT = path.join(tmpRoot, "repos");
+  process.env.APPS_SANDBOX_PROVIDER = "local";
+  process.env.ENCRYPTION_KEY =
+    process.env.ENCRYPTION_KEY ??
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+}, 120_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  WS = new Types.ObjectId();
+  CONNECTOR = new Types.ObjectId();
+  DEST = new Types.ObjectId();
+  state.sent = [];
+  await Promise.all([
+    Flow.deleteMany({}),
+    CdcEntityState.deleteMany({}),
+    Connector.deleteMany({}),
+    DatabaseConnection.deleteMany({}),
+  ]);
+  await Connector.create({
+    _id: CONNECTOR,
+    workspaceId: WS,
+    name: "Close",
+    type: "close",
+    config: {},
+    settings: { rate_limit_delay_ms: 100, sync_batch_size: 100 },
+    createdBy: "u1",
+  });
+  await DatabaseConnection.create({
+    _id: DEST,
+    workspaceId: WS,
+    name: "Warehouse",
+    type: "bigquery",
+    connection: { projectId: "p", keyFilename: "k" },
+    createdBy: "u1",
+  });
+});
+
+/** Seed the workspace repo's main with the given files. */
+async function seedRepo(files: Record<string, string>) {
+  await fs.rm(path.join(tmpRoot, "repos"), { recursive: true, force: true });
+  await initRepo(repoDirFor(WS.toString()), {
+    "README.md": "x\n",
+    ...files,
+  });
+}
+
+describe("partial input never reports a phantom teardown", () => {
+  it("reads the rest of flows/ from the repo and merges the caller's files on top", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha"),
+      "flows/beta.yml": flowYaml("beta"),
+      "flows/gamma.yml": flowYaml("gamma"),
+    });
+    await seedRow("alpha");
+    await seedRow("beta");
+    await seedRow("gamma");
+
+    // The agent edited ONE of three files and passes only that one — the
+    // case that would report a two-flow teardown under directory semantics.
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [{ path: "flows/beta.yml", contents: flowYaml("beta renamed") }],
+    });
+
+    expect(result.wouldTeardown).toEqual([]);
+    expect(result.preExisting.wouldTeardown).toEqual([]);
+    expect(result.wouldCreate).toEqual([]);
+    expect(result.overlay.replaced).toEqual(["flows/beta.yml"]);
+    expect(result.baseline.flowFiles).toBe(3);
+    expect(result.ok).toBe(true);
+  });
+
+  it("still reports a teardown the caller actually asks about", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha"),
+      "flows/beta.yml": flowYaml("beta"),
+    });
+    await seedRow("alpha");
+    await seedRow("beta");
+
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [],
+      deletedPaths: ["flows/beta.yml"],
+    });
+
+    expect(result.wouldTeardown).toEqual(["beta"]);
+    expect(result.overlay.deleted).toEqual(["flows/beta.yml"]);
+    expect(
+      result.notes.some(n => n.includes("disposes its CDC checkpoints")),
+    ).toBe(true);
+  });
+
+  it("attributes a fileless flow to the repo, not to the caller", async () => {
+    // `orphan` has a row and no file: a push tears it down with or without
+    // this change, so it must not be reported as caused by these files.
+    await seedRepo({ "flows/alpha.yml": flowYaml("alpha") });
+    await seedRow("alpha");
+    await seedRow("orphan");
+
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [{ path: "flows/alpha.yml", contents: flowYaml("alpha v2") }],
+    });
+
+    expect(result.wouldTeardown).toEqual([]);
+    expect(result.preExisting.wouldTeardown).toEqual(["orphan"]);
+  });
+});
+
+describe("the destructive half an agent cannot see otherwise", () => {
+  it("reports an entity dropped from the selection BEFORE the row is applied", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha", ["leads", "contacts"]),
+    });
+    const row = await seedRow("alpha", ["leads", "contacts"]);
+    for (const entity of ["leads", "contacts"]) {
+      await CdcEntityState.create({
+        workspaceId: WS,
+        flowId: row._id,
+        entity,
+        lastIngestSeq: 5,
+      });
+    }
+
+    // Same directory, one entity removed from the file. Nothing has been
+    // applied to the row yet — reading the row would answer "nothing would
+    // happen", which is the failure mode this exists to catch.
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [
+        { path: "flows/alpha.yml", contents: flowYaml("alpha", ["leads"]) },
+      ],
+    });
+
+    expect(result.wouldReconfigure).toEqual([
+      { slug: "alpha", entities: ["contacts"] },
+    ]);
+
+    // And the converse: the same file unchanged plans nothing.
+    const unchanged = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [
+        {
+          path: "flows/alpha.yml",
+          contents: flowYaml("alpha", ["leads", "contacts"]),
+        },
+      ],
+    });
+    expect(unchanged.wouldReconfigure).toEqual([]);
+    expect(unchanged.overlay.unchanged).toEqual(["flows/alpha.yml"]);
+  });
+
+  it("says the guard is UNEVALUATED before a push, never verified", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha"),
+      "flows/beta.yml": flowYaml("beta"),
+    });
+    await seedRow("alpha");
+    await seedRow("beta");
+
+    const destructive = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [],
+      deletedPaths: ["flows/beta.yml"],
+    });
+    expect(destructive.guard.required).toBe(true);
+    expect(destructive.guard.verdict).toBe("unevaluated");
+    expect(destructive.guard.reason).toMatch(/have not been pushed/);
+
+    const harmless = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [{ path: "flows/alpha.yml", contents: flowYaml("alpha v2") }],
+    });
+    expect(harmless.guard.verdict).toBe("not-needed");
+  });
+});
+
+describe("the three validation layers", () => {
+  it("catches an id that does not resolve in this workspace", async () => {
+    await seedRepo({});
+    const stranger = new Types.ObjectId().toString();
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [
+        {
+          path: "flows/new-one.yml",
+          contents: flowYaml("new one").replace(CONNECTOR.toString(), stranger),
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    expect(
+      result.problems.some(p => p.reason.includes("does not name a connector")),
+    ).toBe(true);
+  });
+
+  it("catches a file the row schema would refuse on save", async () => {
+    await seedRepo({});
+    // Parses, every id resolves — and `entityLayouts.0.partitionField` is
+    // required, so `doc.save()` throws and the push silently changes nothing.
+    const contents = `${flowYaml("layouts")}entities:\n  layouts:\n    - entity: leads\n`;
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [{ path: "flows/layouts.yml", contents }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.problems.some(p => p.reason.includes("partitionField"))).toBe(
+      true,
+    );
+  });
+
+  it("treats a file that does not parse as the removal the push path makes it", async () => {
+    // The reactor drops an unparseable file from its desired set while
+    // leaving the rest of the tree in it, and the reconciler reads that
+    // absence as a removal. So a YAML typo in an existing flow's file is a
+    // teardown, not a no-op — a pre-existing behaviour this check surfaces
+    // rather than hides. (`beta` keeps the desired set non-empty; an EMPTY
+    // one returns early and is never a deletion.)
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha"),
+      "flows/beta.yml": flowYaml("beta"),
+    });
+    await seedRow("alpha");
+    await seedRow("beta");
+
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [{ path: "flows/alpha.yml", contents: "name: [broken" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.wouldTeardown).toEqual(["alpha"]);
+    expect(result.notes.some(n => n.includes("does not parse"))).toBe(true);
+  });
+});
+
+describe("read-only", () => {
+  it("changes nothing and sends nothing, including for a teardown", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha", ["leads", "contacts"]),
+      "flows/beta.yml": flowYaml("beta"),
+    });
+    const row = await seedRow("alpha", ["leads", "contacts"]);
+    await seedRow("beta");
+    await CdcEntityState.create({
+      workspaceId: WS,
+      flowId: row._id,
+      entity: "contacts",
+      lastIngestSeq: 9,
+    });
+
+    const before = await snapshot();
+    const result = await checkFlowFiles({
+      workspaceId: WS.toString(),
+      files: [
+        { path: "flows/alpha.yml", contents: flowYaml("alpha", ["leads"]) },
+      ],
+      deletedPaths: ["flows/beta.yml"],
+    });
+    // The call planned the two destructive operations…
+    expect(result.wouldTeardown).toEqual(["beta"]);
+    expect(result.wouldReconfigure).toEqual([
+      { slug: "alpha", entities: ["contacts"] },
+    ]);
+    // …and performed neither.
+    expect(await snapshot()).toBe(before);
+    expect(state.sent).toEqual([]);
+    expect(await Flow.countDocuments({ workspaceId: WS })).toBe(2);
+  });
+});
+
+describe("wiring: registered, classified, bridged, reachable", () => {
+  it("is classified everywhere a built-in tool must be", () => {
+    // Bridge policy: classified, and classified as BRIDGED.
+    expect(MCP_BRIDGE_POLICY.check_flow_files?.status).toBe("bridge");
+    expect(mcpExposedToolNames()).toContain("check_flow_files");
+    assertBridgePolicyCovers(collectLiveAgentToolNames());
+    assertBridgePolicyNotStale(collectLiveAgentToolNames());
+    // Inventory: the factory is one the policy tests actually walk.
+    expect(collectLiveAgentToolNames()).toContain("check_flow_files");
+    // Tier policy (CLAUDE.md): core | mode | deferred, or permanently dormant.
+    expect(DEFERRED_BUILTIN_TOOL_NAMES).toContain("check_flow_files");
+    // Read-only classification drives the plan-mode gate and the MCP hint.
+    expect(READ_ONLY_TOOL_NAMES.has("check_flow_files")).toBe(true);
+    expect(mcpReadOnlyHint("check_flow_files", "read")).toBe(true);
+  });
+
+  it("is registered by the in-product agent factory", () => {
+    const tools = unifiedAgentFactory({
+      workspaceId: WS.toString(),
+      userId: "u1",
+      consoles: [],
+    } as unknown as AgentContext).tools;
+    expect(Object.keys(tools)).toContain("check_flow_files");
+  });
+
+  it("is reachable — and correct — through the MCP toolset the server builds", async () => {
+    await seedRepo({
+      "flows/alpha.yml": flowYaml("alpha"),
+      "flows/beta.yml": flowYaml("beta"),
+    });
+    await seedRow("alpha");
+    await seedRow("beta");
+
+    const toolset = buildMakoMcpToolset({
+      workspaceId: WS.toString(),
+      scopes: ["mcp"],
+    } as Parameters<typeof buildMakoMcpToolset>[0]);
+    const exposed = toolset.check_flow_files as unknown as {
+      execute: (input: unknown) => Promise<Record<string, unknown>>;
+    };
+    expect(exposed).toBeTruthy();
+
+    const result = await exposed.execute({
+      files: [{ path: "flows/gamma.yml", contents: flowYaml("gamma") }],
+    });
+    // The same partial-input property, asserted through the bridged tool:
+    // one new file, two untouched flows, no teardown.
+    expect(result.wouldCreate).toEqual(["gamma"]);
+    expect(result.wouldTeardown).toEqual([]);
+    expect((result.overlay as { added: string[] }).added).toEqual([
+      "flows/gamma.yml",
+    ]);
+  });
+
+  it("exposes exactly one tool from its own factory", () => {
+    expect(Object.keys(createFlowFileTools(WS.toString()))).toEqual([
+      "check_flow_files",
+    ]);
+  });
+});

--- a/api/src/agent-lib/tools/flow-file-tools.ts
+++ b/api/src/agent-lib/tools/flow-file-tools.ts
@@ -1,0 +1,425 @@
+/**
+ * `check_flow_files` — what a `flows/<slug>.yml` change would do, before it is
+ * pushed.
+ *
+ * RFC `rfcs/agent-authored-flows.md` items 1 and 2 shipped the two halves of
+ * this answer and left both out of reach of the agent the RFC is about:
+ * `validateFlowFiles` had one caller, a CLI in the *mako* monorepo, while the
+ * person in the scenario has the *workspace* repo checked out; and
+ * `dryRunFlowReconcile` had no non-test caller at all. This is the MCP-facing
+ * surface the RFC's design asks for ("an MCP tool — for the agent").
+ *
+ * Three layers behind one call: it parses, it resolves the ids against this
+ * workspace, and it hydrates the row the file would produce and asks mongoose
+ * whether that row is valid — a file can clear the first two and still be
+ * refused by `doc.save()` (a layout with no `partition_field`, a `write_mode`
+ * outside the enum), which the push path swallows as "keeping current row".
+ *
+ * ONE tool, not two, and deliberately so. An agent that can call the validator
+ * alone will call the validator alone: it answers "will this load", which is
+ * the reassuring half. The half worth having is the destructive one — a
+ * missing file is a stream teardown, an entity dropped from a selection
+ * disposes that entity's checkpoint, and neither is recoverable by putting
+ * the file back (the flow returns and re-backfills from scratch).
+ *
+ * THE INPUT IS AN OVERLAY, NOT A DIRECTORY. `wouldTeardown` is computed from
+ * ABSENCE, so a tool that took "the files you are proposing" and treated them
+ * as the whole of `flows/` would report a catastrophic teardown every time an
+ * agent passed the two files it edited. So the rest of the directory is read
+ * from the workspace repo at main and the caller's files are merged on top of
+ * it, and a teardown is only ever ATTRIBUTED to the caller when they said so:
+ *   - `deletedPaths` names the file, or
+ *   - the file they passed cannot be parsed, which the push path treats as
+ *     absence (see `preExisting`/`notes` — that behaviour is a trap and this
+ *     tool's job is to show it, not to hide it).
+ * Everything else lands in `preExisting`, which says "true of the repo before
+ * your change". Two independent mechanisms, because the failure they prevent
+ * is an agent being told it is about to delete a workspace's data pipelines.
+ *
+ * Read-only, end to end: it reads Mongo and the local repo cache, and calls
+ * `dryRunFlowReconcile`, which shares its decision function with the real
+ * reconciler but performs none of the writes. It does not freshen the local
+ * repo either — a read is not allowed to reset a shared clone.
+ */
+import { tool } from "ai";
+import { z } from "zod";
+
+import { loggers } from "../../logging";
+import {
+  parseFlowFile,
+  slugFromFlowFilePath,
+} from "../../services/flow-config-files";
+import {
+  hydrateFlowRow,
+  readFlowFilesAtMain,
+} from "../../services/flow-sync.service";
+import {
+  validateFlowFiles,
+  type FlowFileProblem,
+} from "../../services/flow-validate.service";
+import {
+  dryRunFlowReconcile,
+  type PlannedFlow,
+  type ReconcilePlan,
+} from "../../sync-cdc/flow-reconcile";
+
+const logger = loggers.api("flow-file-tools");
+
+export interface ProposedFlowFile {
+  path: string;
+  contents: string;
+}
+
+export interface CheckFlowFilesResult {
+  /** True when every proposed file parses and every id it names resolves. */
+  ok: boolean;
+  summary: string;
+  problems: FlowFileProblem[];
+  /** What the workspace repo's main says today — the baseline merged under. */
+  baseline: {
+    commit: string | null;
+    flowFiles: number;
+    note: string;
+  };
+  /** How the proposed files land on that baseline. */
+  overlay: {
+    added: string[];
+    replaced: string[];
+    unchanged: string[];
+    deleted: string[];
+  };
+  /** Caused by this change. */
+  wouldCreate: string[];
+  wouldReconfigure: Array<{ slug: string; entities: string[] }>;
+  wouldTeardown: string[];
+  guard: ReconcilePlan["guard"];
+  /** True of the repo already — a push would do this with or without you. */
+  preExisting: {
+    wouldCreate: string[];
+    wouldReconfigure: Array<{ slug: string; entities: string[] }>;
+    wouldTeardown: string[];
+  };
+  notes: string[];
+}
+
+function sortedDiff(
+  proposed: string[],
+  baseline: string[],
+): { caused: string[]; preExisting: string[] } {
+  const before = new Set(baseline);
+  return {
+    caused: proposed.filter(slug => !before.has(slug)).sort(),
+    preExisting: proposed.filter(slug => before.has(slug)).sort(),
+  };
+}
+
+/**
+ * The whole answer, as a value. Separated from the `tool()` wrapper so it can
+ * be exercised against a real repo + database without a model in the loop.
+ */
+export async function checkFlowFiles(input: {
+  workspaceId: string;
+  files: ProposedFlowFile[];
+  deletedPaths?: string[];
+}): Promise<CheckFlowFilesResult> {
+  const { workspaceId } = input;
+  const files = input.files ?? [];
+  const deletedPaths = input.deletedPaths ?? [];
+  const notes: string[] = [];
+  const problems: FlowFileProblem[] = [];
+
+  // ---- the baseline: everything else in flows/, so nothing looks deleted --
+  const baseline = await readFlowFilesAtMain(workspaceId, { freshen: false });
+  const baselineByPath = new Map(
+    baseline.files.map(f => [f.path, f.contents] as const),
+  );
+
+  // ---- structural + referential validation of the caller's files ---------
+  const validation = await validateFlowFiles({ workspaceId, files });
+  problems.push(...validation.problems);
+
+  // ---- and the layer neither of those covers: the model's own schema -----
+  // A file can parse, resolve every id it names, and still be refused by
+  // `doc.save()` — a layout with no `partition_field`, a `write_mode` outside
+  // the enum. The reactor logs that and keeps the current row, so the agent
+  // sees a green push and no flow.
+  const schemaProblems: FlowFileProblem[] = [];
+  for (const file of files) {
+    const slug = slugFromFlowFilePath(file.path);
+    if (!slug) continue;
+    const parsed = parseFlowFile(file.contents);
+    if (!parsed) continue; // Already reported by the structural layer.
+    const hydrated = hydrateFlowRow(parsed, {
+      workspaceId,
+      slug,
+      // Not in the file: `createdBy` is the acting user and the reactor
+      // supplies it. A placeholder keeps this layer reporting the file's
+      // problems rather than that one.
+      createdBy: "check",
+    });
+    if (hydrated.refusal) {
+      schemaProblems.push({
+        path: file.path,
+        slug,
+        reason: `the push reactor would refuse this file: ${hydrated.refusal}`,
+      });
+      continue;
+    }
+    for (const err of hydrated.schemaErrors) {
+      schemaProblems.push({
+        path: file.path,
+        slug,
+        reason: `\`${err.path}\`: ${err.message} — the flow row would fail to save, so the push would leave the flow unchanged`,
+      });
+    }
+  }
+  problems.push(...schemaProblems);
+
+  const deletedSlugs = new Set<string>();
+  for (const path of deletedPaths) {
+    const slug = slugFromFlowFilePath(path);
+    if (!slug) {
+      problems.push({
+        path,
+        reason: `\`${path}\` is not a flow file (\`flows/<slug>.yml\`), so deleting it removes no flow`,
+      });
+      continue;
+    }
+    if (!baselineByPath.has(path)) {
+      notes.push(
+        `\`${path}\` is not in the repo at main, so there is nothing to delete there.`,
+      );
+    }
+    deletedSlugs.add(slug);
+  }
+
+  // ---- overlay the proposal onto the baseline ----------------------------
+  const overlay = {
+    added: [] as string[],
+    replaced: [] as string[],
+    unchanged: [] as string[],
+    deleted: [] as string[],
+  };
+  /** Slug → the file that will be there after this change, and its origin. */
+  const proposedByPath = new Map<
+    string,
+    { contents: string; pendingApply: boolean }
+  >();
+  for (const [path, contents] of baselineByPath) {
+    proposedByPath.set(path, { contents, pendingApply: false });
+  }
+  for (const path of deletedPaths) {
+    if (proposedByPath.delete(path)) overlay.deleted.push(path);
+  }
+
+  /** Caller files whose contents cannot be loaded — absence, to the reactor. */
+  const unparseableSlugs = new Set<string>();
+  for (const file of files) {
+    const slug = slugFromFlowFilePath(file.path);
+    if (!slug) continue; // Already reported as a problem by the validator.
+    const before = baselineByPath.get(file.path);
+    if (before === undefined) overlay.added.push(file.path);
+    else if (before === file.contents) overlay.unchanged.push(file.path);
+    else overlay.replaced.push(file.path);
+    // A file identical to the one already committed applies nothing: the sync
+    // path short-circuits on a matching blob sha, so the row keeps its own
+    // selection. Anything else would be applied before the reconcile runs.
+    proposedByPath.set(file.path, {
+      contents: file.contents,
+      pendingApply: before !== file.contents,
+    });
+    if (!parseFlowFile(file.contents)) unparseableSlugs.add(slug);
+  }
+
+  const plannedFrom = (
+    entries: Iterable<[string, { contents: string; pendingApply: boolean }]>,
+  ): PlannedFlow[] => {
+    const planned: PlannedFlow[] = [];
+    for (const [path, { contents, pendingApply }] of entries) {
+      const slug = slugFromFlowFilePath(path);
+      if (!slug) continue;
+      const file = parseFlowFile(contents);
+      // A file that does not parse is left OUT, exactly as `syncFlowsFromRepo`
+      // leaves it out of its desired set. That is faithful rather than kind:
+      // the reconciler reads the resulting absence as a removal.
+      if (!file) continue;
+      planned.push({ slug, file, pendingApply });
+    }
+    return planned;
+  };
+
+  const baselineInvalid = baseline.files
+    .filter(f => !parseFlowFile(f.contents))
+    .map(f => f.path);
+  if (baselineInvalid.length > 0) {
+    notes.push(
+      `Already in the repo and not parseable: ${baselineInvalid.join(", ")}. The push path skips such a file, which the reconciler reads as absence — that is why they appear under preExisting.`,
+    );
+  }
+
+  // Two plans: the repo as it stands, and the repo with this change on top.
+  // The difference is what the change causes; the rest was already true.
+  // `treeSha` is deliberately omitted from both — see the guard note below.
+  const baselineEntries: Array<
+    [string, { contents: string; pendingApply: boolean }]
+  > = [...baselineByPath].map(([path, contents]) => [
+    path,
+    { contents, pendingApply: false },
+  ]);
+  const baselinePlan = await dryRunFlowReconcile({
+    workspaceId,
+    desired: plannedFrom(baselineEntries),
+  });
+  const proposedPlan = await dryRunFlowReconcile({
+    workspaceId,
+    desired: plannedFrom(proposedByPath.entries()),
+  });
+
+  const created = sortedDiff(
+    proposedPlan.wouldCreate,
+    baselinePlan.wouldCreate,
+  );
+  const reconfiguredBefore = new Map(
+    baselinePlan.wouldReconfigure.map(
+      r => [r.slug, r.entities.join("|")] as const,
+    ),
+  );
+  const reconfigureCaused: Array<{ slug: string; entities: string[] }> = [];
+  const reconfigurePreExisting: Array<{ slug: string; entities: string[] }> =
+    [];
+  for (const entry of proposedPlan.wouldReconfigure) {
+    if (reconfiguredBefore.get(entry.slug) === entry.entities.join("|")) {
+      reconfigurePreExisting.push(entry);
+    } else {
+      reconfigureCaused.push(entry);
+    }
+  }
+
+  // Teardown attribution is by explicit intent ONLY — the caller said "I
+  // deleted this", or handed over a file that cannot be loaded. A flow whose
+  // file is simply not in the repo is torn down by any push, with or without
+  // this change, and saying otherwise is the exact false alarm this tool must
+  // never raise.
+  const wouldTeardown = proposedPlan.wouldTeardown.filter(
+    slug => deletedSlugs.has(slug) || unparseableSlugs.has(slug),
+  );
+  const teardownPreExisting = proposedPlan.wouldTeardown.filter(
+    slug => !deletedSlugs.has(slug) && !unparseableSlugs.has(slug),
+  );
+
+  for (const slug of wouldTeardown) {
+    if (unparseableSlugs.has(slug)) {
+      notes.push(
+        `\`${slug}\`: the file you passed does not parse. Pushing it is worse than a no-op — the sync path skips an unparseable file, and the reconciler reads that absence as a removal, so the flow and its checkpoints go. Fix the file before committing.`,
+      );
+    }
+  }
+  if (teardownPreExisting.length > 0) {
+    notes.push(
+      `These flows have rows but no file in \`flows/\` at main: ${teardownPreExisting.join(", ")}. A push tears them down whether or not you change anything — that is not caused by these files.`,
+    );
+  }
+  if (
+    proposedPlan.wouldTeardown.length > 0 ||
+    proposedPlan.wouldReconfigure.length > 0
+  ) {
+    notes.push(
+      "A teardown deletes the flow and disposes its CDC checkpoints; a dropped entity disposes that entity's checkpoint. Re-adding the file brings the flow back and re-backfills from scratch.",
+    );
+  }
+  if (baseline.commit === null) {
+    notes.push(
+      "The workspace repo has no main branch on this instance yet, so the baseline is empty and nothing could be merged under your files.",
+    );
+  }
+
+  // `validation.ok` is already folded in: its problems are all in `problems`,
+  // and the schema layer adds the ones it cannot see.
+  const blocking = problems.filter(p => !p.reason.startsWith("note:"));
+  const ok = blocking.length === 0;
+  const summary = [
+    ok ? "files load" : "NOT loadable",
+    `${blocking.length} problem(s)`,
+    `create ${created.caused.length}`,
+    `reconfigure ${reconfigureCaused.length}`,
+    `teardown ${wouldTeardown.length}`,
+  ].join("; ");
+
+  return {
+    ok,
+    summary,
+    problems,
+    baseline: {
+      commit: baseline.commit,
+      flowFiles: baseline.files.length,
+      note: "Read from the workspace repo's main branch and merged under your files, so a flow you did not mention is never read as deleted.",
+    },
+    overlay,
+    wouldCreate: created.caused,
+    wouldReconfigure: reconfigureCaused,
+    wouldTeardown,
+    guard: proposedPlan.guard,
+    preExisting: {
+      wouldCreate: created.preExisting,
+      wouldReconfigure: reconfigurePreExisting,
+      wouldTeardown: teardownPreExisting,
+    },
+    notes,
+  };
+}
+
+export function createFlowFileTools(workspaceId: string) {
+  return {
+    check_flow_files: tool({
+      description: [
+        "Check proposed `flows/<slug>.yml` files BEFORE committing them: whether each parses, whether the connector/connection ids it names exist in this workspace, whether the flow row it describes would actually save, and what the resulting push would do to running syncs (create, reconfigure, tear down).",
+        "Pass ONLY the files you added or changed. The rest of `flows/` is read from the workspace repo's main branch and merged underneath yours, so a flow you do not mention is never read as deleted.",
+        "To check a DELETION, name its path in `deletedPaths`. That, or a file that fails to parse, is the only way a teardown is attributed to you — and a teardown deletes the flow and disposes its CDC checkpoints, which re-adding the file does not recover.",
+        "Read-only: nothing is created, changed, deleted, or committed, and this never pushes.",
+      ].join("\n"),
+      inputSchema: z.object({
+        files: z
+          .array(
+            z.object({
+              path: z
+                .string()
+                .describe(
+                  "Repo-relative path, e.g. `flows/stripe-to-bigquery.yml`. The slug in the filename is the flow's permanent identity.",
+                ),
+              contents: z
+                .string()
+                .describe("The full YAML you intend to commit."),
+            }),
+          )
+          .describe(
+            "The flow files you added or changed — NOT the whole directory.",
+          ),
+        deletedPaths: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Flow files you intend to DELETE, repo-relative. Omit unless you really mean to remove a flow.",
+          ),
+      }),
+      execute: async ({
+        files,
+        deletedPaths,
+      }: {
+        files: ProposedFlowFile[];
+        deletedPaths?: string[];
+      }) => {
+        try {
+          return await checkFlowFiles({ workspaceId, files, deletedPaths });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error";
+          logger.error("check_flow_files failed", {
+            workspaceId,
+            error: message,
+          });
+          return { error: `Failed to check flow files: ${message}` };
+        }
+      },
+    }),
+  };
+}

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -55,6 +55,12 @@ export const DEFERRED_BUILTIN_TOOL_DOMAINS: Readonly<Record<string, string>> = {
   delete_skill: "skills",
   list_skills: "skills",
   search_skills: "skills",
+  // Pre-push check for `flows/<slug>.yml` (RFC: agent-authored flows). Its
+  // audience is an agent with the WORKSPACE repo checked out, reaching Mako
+  // over MCP; in-chat it is registered and executable but stays out of the
+  // default working set, since the in-product flow surface is the form, not
+  // the file.
+  check_flow_files: "flows",
   // Deprecated single-field alias of set_multiple_fields (which updates one
   // or many fields). Its FIELD_PATHS enum makes it one of the heaviest
   // schemas in the catalog, so it stays out of the flow working set.

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -14,6 +14,7 @@ import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
 import { createFlowTools } from "../flow";
+import { createFlowFileTools } from "../../agent-lib/tools/flow-file-tools";
 import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 import { createWebTools } from "../../agent-lib/tools/web-tools";
 import { UNIFIED_SYSTEM_PROMPT, buildCurrentScreenContext } from "./prompt";
@@ -38,6 +39,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     { chatId: context.chatId },
   );
   const flowTools = createFlowTools(workspaceId, context.toolExecutionContext);
+  const flowFileTools = createFlowFileTools(workspaceId);
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId, userId);
   const skillTools = createSkillTools(workspaceId, userId);
   const consoleSearchTools = createConsoleSearchTools(
@@ -85,6 +87,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     ...clientNotebookTools,
     ...serverNotebookTools,
     ...flowUniqueTools,
+    ...flowFileTools,
     ...selfDirectiveTools,
     ...skillTools,
     ...consoleSearchTools,

--- a/api/src/mcp/bridge-inventory.ts
+++ b/api/src/mcp/bridge-inventory.ts
@@ -17,6 +17,7 @@ import { createConsoleSearchTools } from "../agent-lib/tools/console-search-tool
 import { createDashboardSearchTools } from "../agent-lib/tools/dashboard-search-tools";
 import { createConnectorTools } from "../agent-lib/tools/connector-tools";
 import { createDbtServerTools } from "../agent-lib/tools/dbt-tools";
+import { createFlowFileTools } from "../agent-lib/tools/flow-file-tools";
 import { createMemberTools } from "../agent-lib/tools/member-tools";
 import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
 import { createScheduleQueryTool } from "../agent-lib/tools/schedule-query-tool";
@@ -88,6 +89,7 @@ export function collectLiveAgentToolNames(): string[] {
   add(keysOf(createSkillTools(INVENTORY_WORKSPACE_ID)));
   add(keysOf(createSelfDirectiveTools(INVENTORY_WORKSPACE_ID)));
   add(keysOf(createConnectorTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createFlowFileTools(INVENTORY_WORKSPACE_ID)));
   // MCP-surface only (no mode lists them), but they are real server factories
   // and the bridge policy classifies them, so the inventory has to know them.
   add(keysOf(createMemberTools(INVENTORY_WORKSPACE_ID)));

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -301,6 +301,11 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   // agent can invent neither. Reads only, and neither returns a credential.
   list_connectors: bridge(),
   inspect_connector: bridge(),
+  // The pre-push check for flow files. Reads only — it says what a push
+  // WOULD do to running streams and performs none of it — so it is bridged
+  // next to the discovery pair it completes: discover ids, write the file,
+  // check it, then push.
+  check_flow_files: bridge(),
   query_duckdb: exclude(
     "client-only",
     "Queries in-browser DuckDB; MCP validates via sql_execute_query.",

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -47,6 +47,7 @@ import { createVersionHistoryTools } from "../agent-lib/tools/version-history-to
 import { createSkillTools } from "../agent-lib/tools/skill-tools";
 import { createSelfDirectiveTools } from "../agent-lib/tools/self-directive-tool";
 import { createConnectorTools } from "../agent-lib/tools/connector-tools";
+import { createFlowFileTools } from "../agent-lib/tools/flow-file-tools";
 import { createMemberTools } from "../agent-lib/tools/member-tools";
 import { createWebTools } from "../agent-lib/tools/web-tools";
 import { createDbtServerTools } from "../agent-lib/tools/dbt-tools";
@@ -205,11 +206,16 @@ export function buildMakoMcpCandidateTools(
   const dbtTools = createDbtServerTools(workspaceId, userId, { chatId });
   // Connector discovery for flow authoring (RFC: agent-authored flows).
   const connectorTools = createConnectorTools(workspaceId);
+  // The pre-push check for `flows/<slug>.yml` (RFC: agent-authored flows).
+  // The agent in that scenario has the WORKSPACE repo checked out, not this
+  // monorepo, so `pnpm flows:validate` is not a surface it can reach.
+  const flowFileTools = createFlowFileTools(workspaceId);
   // Gated by the members-write grant AND a live owner/admin check inside the
   // tools themselves — a key outlives the membership that justified it.
   const memberTools = createMemberTools(workspaceId, userId);
   return {
     ...connectorTools,
+    ...flowFileTools,
     ...appsTools,
     ...memberTools,
     ...consoleTools,

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -224,6 +224,119 @@ function applyDefinition(doc: IFlow, file: FlowFile): string | null {
   return null;
 }
 
+/** What a file would produce if it were written onto a fresh row. */
+export interface HydratedFlowRow {
+  /** Set when `applyDefinition` refuses the file outright. */
+  refusal: string | null;
+  /** Field-level schema failures, as mongoose would raise them on save. */
+  schemaErrors: Array<{ path: string; message: string }>;
+}
+
+/**
+ * Build the row a file would produce and ask the model whether it is valid —
+ * WITHOUT saving it.
+ *
+ * The third validation layer, and the one nothing else covers. Parsing and
+ * referential resolution (`flow-validate.service.ts`) both pass for a file
+ * whose `entities.layouts` entry has no `partition_field`, or whose
+ * `sync.write_mode` is outside the schema's enum; `doc.save()` in the push
+ * reactor then throws and the row is never written. A checker that certifies
+ * a file the reactor refuses is the silent-no-op failure the RFC exists to
+ * end, one layer further in.
+ *
+ * Uses the reactor's own `applyDefinition` rather than a second mapping, so
+ * the check cannot disagree with what it is predicting.
+ *
+ * `createdBy` is required on the schema and is not in the file (it is the
+ * acting user, supplied by the reactor); callers checking a file rather than
+ * creating one pass a placeholder so the check reports the file's problems
+ * and not that one.
+ */
+export function hydrateFlowRow(
+  file: FlowFile,
+  args: { workspaceId: string; slug: string; createdBy: string },
+): HydratedFlowRow {
+  const doc = new Flow({
+    workspaceId: new Types.ObjectId(args.workspaceId),
+    slug: args.slug,
+    createdBy: args.createdBy,
+  }) as unknown as IFlow;
+
+  const refusal = applyDefinition(doc, file);
+  if (refusal) return { refusal, schemaErrors: [] };
+
+  // validateSync() runs the schema's own validators in-process and touches no
+  // connection — the document is never saved and this function never writes.
+  const error = (
+    doc as unknown as {
+      validateSync: () =>
+        | { errors?: Record<string, { message?: string }> }
+        | undefined;
+    }
+  ).validateSync();
+  const errors = error?.errors ?? {};
+  return {
+    refusal: null,
+    schemaErrors: Object.entries(errors).map(([path, err]) => ({
+      path,
+      message: err?.message ?? "is invalid",
+    })),
+  };
+}
+
+/** Every `flows/*.yml` in the workspace repo at main, with the commit read. */
+export interface FlowFilesAtMain {
+  /** The commit the files were read at; null when there is no repo/main. */
+  commit: string | null;
+  files: Array<{ path: string; contents: string }>;
+}
+
+/**
+ * Read `flows/*.yml` from the workspace repo's main branch.
+ *
+ * Extracted so the push reactor below and the pre-push checker
+ * (`agent-lib/tools/flow-file-tools.ts`) read the same set the same way. A
+ * second copy of this walk is exactly the drift `syncRepoBackedResources`
+ * exists to prevent — and here it would be worse than a missed sync: the
+ * checker's whole job is to predict what the reactor will do, and a predictor
+ * reading a different set of files predicts nothing.
+ *
+ * `freshen` is the difference between the two callers and is deliberately
+ * explicit. The reactor is about to DELETE, so it must judge against the
+ * mirror's main rather than this instance's cache (#894/#897). The checker
+ * writes nothing and is not allowed to reset a shared local repo as a side
+ * effect of a read, so it takes the cache as it finds it and reports the
+ * commit it read.
+ */
+export async function readFlowFilesAtMain(
+  workspaceId: string,
+  options: { freshen: boolean },
+): Promise<FlowFilesAtMain> {
+  const none: FlowFilesAtMain = { commit: null, files: [] };
+
+  await ensureLocalRepo(workspaceId);
+  const repoDir = repoDirFor(workspaceId);
+  if (!(await repoExists(repoDir))) return none;
+  if (options.freshen) await freshenBeforeMainWrite(workspaceId);
+
+  const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
+  if (!head) return none;
+
+  const paths = (await listTree(repoDir, head))
+    .map(e => e.path)
+    .filter(p => slugFromFlowFilePath(p) !== null);
+  if (paths.length === 0) return { commit: head, files: [] };
+
+  const blobs = await readBlobsBatch(repoDir, head, paths);
+  return {
+    commit: head,
+    files: [...blobs.entries()].map(([path, buf]) => ({
+      path,
+      contents: buf.toString("utf8"),
+    })),
+  };
+}
+
 /**
  * Reconcile every flow row in a workspace against `flows/*.yml` at main.
  *
@@ -241,37 +354,28 @@ export async function syncFlowsFromRepo(
     deferred: [],
   };
 
-  await ensureLocalRepo(workspaceId);
-  const repoDir = repoDirFor(workspaceId);
-  if (!(await repoExists(repoDir))) return empty;
   // A reconcile that DELETES must be judged against the mirror's main, never
   // this instance's cache: `ensureLocalRepo` returns early once the directory
   // exists and never refreshes it.
-  await freshenBeforeMainWrite(workspaceId);
-
-  const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
+  const { commit: head, files } = await readFlowFilesAtMain(workspaceId, {
+    freshen: true,
+  });
   if (!head) return empty;
-
-  const paths = (await listTree(repoDir, head))
-    .map(e => e.path)
-    .filter(p => slugFromFlowFilePath(p) !== null);
 
   // No flows/ in the repo at all → this workspace has not adopted flows as
   // code. Leave Mongo alone. Without this an empty or partial tree would read
   // as "every flow was deleted" and tear down every running stream.
-  if (paths.length === 0) return empty;
+  if (files.length === 0) return empty;
 
   const result: FlowSyncResult = { ...empty, invalid: [] };
   const desired: DesiredFlow[] = [];
-  const blobs = await readBlobsBatch(repoDir, head, paths);
   const seen = new Set<string>();
 
-  for (const [path, buf] of blobs) {
+  for (const { path, contents } of files) {
     const slug = slugFromFlowFilePath(path);
     if (!slug) continue;
     seen.add(slug);
 
-    const contents = buf.toString("utf8");
     const sha = blobOid(contents);
     const parsedForDesired = parseFlowFile(contents);
     const row = await Flow.findOne({ workspaceId, slug });

--- a/api/src/sync-cdc/flow-reconcile.ts
+++ b/api/src/sync-cdc/flow-reconcile.ts
@@ -71,6 +71,25 @@ export interface PlannedFlow {
    * been created — an agent about to push has a file and no row.
    */
   flowId?: string;
+  /**
+   * True when this file has NOT been written onto its row yet, so the row's
+   * entity selection is still the old one.
+   *
+   * The live caller applies every changed definition before reconciling, so
+   * the row IS the file and reading the row is right. A pre-push dry-run has
+   * applied nothing: reading the row there would answer "what would happen if
+   * I pushed nothing", which for the one failure mode this exists to catch —
+   * an entity silently dropped from the selection — is always "nothing". The
+   * push would run `applyDefinition` first (it writes `entityFilter` and
+   * `entityLayouts` straight from the file), so for a file whose contents
+   * differ from the tree the FILE's selection is the honest prediction.
+   *
+   * Defaults to false, i.e. the live behaviour. A file identical to the one
+   * already in the tree must leave this false: the sync path short-circuits
+   * on a matching blob sha and applies nothing, so the row's own selection
+   * still stands.
+   */
+  pendingApply?: boolean;
 }
 
 /** A {@link PlannedFlow} the caller has already applied to a row. */
@@ -93,10 +112,17 @@ export interface ReconcilePlan {
    * Whether the fail-closed guard is engaged, and what it says. "would-defer"
    * is as real an answer as a teardown list — it means the destructive work
    * waits for a push where the tree can be verified.
+   *
+   * "unevaluated" is the pre-push answer and the only honest one there: the
+   * guard compares the commit the files were read at against the mirror's
+   * main, and files that have not been pushed are not a commit. Reporting
+   * "verified" for them — by handing the guard the mirror's current main —
+   * would be a true statement about the mirror dressed up as a promise about
+   * the caller's working tree.
    */
   guard: {
     required: boolean;
-    verdict: "not-needed" | "verified" | "would-defer";
+    verdict: "not-needed" | "verified" | "would-defer" | "unevaluated";
     reason?: string;
   };
 }
@@ -227,8 +253,17 @@ async function resumeAfterReconcile(
  * it twice and the second run finds nothing to do. A flow with no explicit
  * selection streams everything, so nothing is ever stale for it.
  */
-async function staleEntitiesFor(flow: IFlow): Promise<string[]> {
-  const { entities, hasExplicitSelection } = resolveConfiguredEntities(flow);
+async function staleEntitiesFor(
+  flow: IFlow,
+  /**
+   * Where the selection is read from. The row, normally — see
+   * {@link PlannedFlow.pendingApply} for the one case where the file is the
+   * honest source instead.
+   */
+  selection: Pick<IFlow, "entityFilter" | "entityLayouts">,
+): Promise<string[]> {
+  const { entities, hasExplicitSelection } =
+    resolveConfiguredEntities(selection);
   if (!hasExplicitSelection) return [];
   const selected = new Set(entities);
   const live = await CdcEntityState.find({
@@ -267,7 +302,11 @@ async function staleEntitiesFor(flow: IFlow): Promise<string[]> {
 async function computePlan(input: {
   workspaceId: string;
   desired: PlannedFlow[];
-  treeSha: string;
+  /**
+   * The commit `desired` was read at. Omitted only by a pre-push dry-run,
+   * where there is no such commit — see {@link ReconcilePlan.guard}.
+   */
+  treeSha?: string;
 }): Promise<{
   plan: ReconcilePlan;
   removals: IFlow[];
@@ -327,7 +366,15 @@ async function computePlan(input: {
   for (const item of desired) {
     const flow = bySlug.get(item.slug);
     if (!flow) continue;
-    const stale = await staleEntitiesFor(flow);
+    const stale = await staleEntitiesFor(
+      flow,
+      item.pendingApply
+        ? ({
+            entityFilter: item.file.entityFilter,
+            entityLayouts: item.file.entityLayouts,
+          } as unknown as Pick<IFlow, "entityFilter" | "entityLayouts">)
+        : flow,
+    );
     if (stale.length > 0) perFlowStale.set(item.slug, { flow, stale });
   }
 
@@ -336,9 +383,20 @@ async function computePlan(input: {
     required: false,
     verdict: "not-needed",
   };
-  if (required) {
+  if (required && treeSha === undefined) {
+    // Nothing to verify against: these files are not a commit. Saying so is
+    // the whole point — the alternative (hand the guard the mirror's current
+    // main, which of course matches itself) would report "verified" about a
+    // tree that does not contain the files being judged.
+    guard = {
+      required: true,
+      verdict: "unevaluated",
+      reason:
+        "The fail-closed mirror check runs at push time against the pushed commit. These files have not been pushed, so nothing can be verified yet: whether the destructive work above actually runs is decided when the push lands.",
+    };
+  } else if (required) {
     try {
-      await assertTreeAtMirrorMain(workspaceId, treeSha);
+      await assertTreeAtMirrorMain(workspaceId, treeSha as string);
       guard = { required: true, verdict: "verified" };
     } catch (error) {
       if (!(error instanceof TreeNotVerifiedError)) throw error;
@@ -378,11 +436,15 @@ async function computePlan(input: {
  *
  * Takes `flowId` optionally, so it answers before any row has been created —
  * which is the moment worth asking, i.e. before the push.
+ *
+ * `treeSha` is optional for the same reason. Omit it when the files are not a
+ * pushed commit, and the guard reports "unevaluated" rather than a verdict
+ * about some other tree.
  */
 export async function dryRunFlowReconcile(input: {
   workspaceId: string;
   desired: PlannedFlow[];
-  treeSha: string;
+  treeSha?: string;
 }): Promise<ReconcilePlan> {
   const { plan } = await computePlan(input);
   return plan;
@@ -415,7 +477,11 @@ export async function reconcileFlowsFromRepo(input: {
   const { plan, removals, perFlowStale } = await computePlan(input);
   const workspaceOid = new Types.ObjectId(workspaceId);
 
-  if (plan.guard.verdict === "would-defer") {
+  // Fail closed on ANY verdict that is not an affirmative "verified": the
+  // live path always passes a treeSha, so "unevaluated" cannot occur here —
+  // and if a future caller stops passing one, deferring is the safe way to
+  // find out rather than tearing streams down against an unchecked tree.
+  if (plan.guard.required && plan.guard.verdict !== "verified") {
     result.deferred = {
       removals: plan.wouldTeardown,
       reason: plan.guard.reason ?? "the tree could not be verified",

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
       "src/apps/workspace-skills.service.test.ts",
       "src/apps/box-state.service.test.ts",
       "src/apps/live-binding-guard.test.ts",
+      // Real git + mongo: the pre-push flow-file check reads the workspace
+      // repo at main and plans against live rows.
+      "src/agent-lib/tools/flow-file-tools.test.ts",
       "src/apps/preview.service.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",
       // These two were written as vitest suites but listed in no vitest

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -49,6 +49,10 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   // Version history reads
   "browse_version_history",
   "get_version_snapshot",
+  // Flow files: the pre-push check reads the repo + Mongo and calls the
+  // dry-run, which shares its decision function with the reconciler and
+  // performs none of its writes.
+  "check_flow_files",
   // Flow form reads + query validation/explanation (read-only by design)
   "get_form_state",
   "list_flow_tabs",


### PR DESCRIPTION
## What was unreachable

RFC `rfcs/agent-authored-flows.md` items 1 and 2 shipped two well-tested functions and left both out of reach of the agent the RFC is about — someone with their **workspace repo** checked out, talking to Mako over MCP.

```
$ grep -rn "validateFlowFiles\|dryRunFlowReconcile" --include='*.ts' api packages | grep -v '\.test\.ts'
api/src/services/flow-validate.service.ts:149:export async function validateFlowFiles(input: {
api/src/services/flow-validate.cli.ts:21:import { validateFlowFiles } from "./flow-validate.service";
api/src/services/flow-validate.cli.ts:48:    const result = await validateFlowFiles({ workspaceId, files });
api/src/sync-cdc/flow-reconcile.ts:382:export async function dryRunFlowReconcile(input: {
```

`validateFlowFiles` had exactly one caller: `pnpm flows:validate`, a CLI in **this** monorepo — the one repo the person in the scenario does not have. `dryRunFlowReconcile` had **zero non-test callers**: every reference outside its own definition was `flow-reconcile.test.ts`.

`check_flow_files` is the third surface the RFC's design names ("an MCP tool — for the agent"), and it composes both halves plus a third layer in one call — an agent that can call the validator alone will call the validator alone, and the destructive half is the point.

**Three layers, one answer:**
1. **Structural + referential** — `validateFlowFiles` (parses; connector/connection ids resolve in this workspace; slug free or already this flow's).
2. **The row schema** — hydrates the row the file would produce with the reactor's own `applyDefinition` and calls `validateSync()`. A file with an `entities.layouts` entry missing `partitionField` clears layers 1 and 2 of the shipped validator and then makes `doc.save()` throw, which the reactor swallows as "keeping current row" — a green push and no flow.
3. **The plan** — `dryRunFlowReconcile`: `wouldCreate` / `wouldReconfigure` / `wouldTeardown` / `guard`.

## The partial-input decision

**The input is an overlay, not a directory.** `wouldTeardown` is computed from *absence*, so a tool that took "the files I'm proposing" and read them as the whole of `flows/` would report a catastrophic teardown every time an agent passed the two files it edited. The tool reads the rest of `flows/` from the workspace repo at main (`readFlowFilesAtMain`, extracted from `syncFlowsFromRepo` so the checker and the thing it predicts read the same set the same way) and merges the caller's files on top.

Two independent mechanisms, because the failure being prevented is telling an agent it is about to delete a workspace's pipelines:

- **Overlay** — an unmentioned flow is still present in the desired set, so it is never a removal.
- **Attribution** — a teardown is attributed to the caller only when they said so: `deletedPaths` names the file, or the file they passed cannot be parsed (which the push path treats as absence). Everything else lands in `preExisting`, labelled "true of the repo before your change" — so even a stale local repo cache, or no repo at all, cannot manufacture an attributed teardown.

Tests that pin it (`api/src/agent-lib/tools/flow-file-tools.test.ts`):

- `reads the rest of flows/ from the repo and merges the caller's files on top` — three flows in the repo, three rows, caller passes **one** changed file: `wouldTeardown === []` and `preExisting.wouldTeardown === []`.
- `attributes a fileless flow to the repo, not to the caller` — a row with no file shows under `preExisting`, never as caused.
- `still reports a teardown the caller actually asks about` — the converse, because a check that never reports a teardown passes the first test trivially and is worthless.

## What the guard verdict means before a push

`assertTreeAtMirrorMain` compares *the commit the files were read at* against the mirror's main. A pre-push check has no such commit. Handing it the mirror's current main would make it compare the mirror to itself and answer "verified" — true about the mirror, and read as a promise about the caller's unpushed files.

So `dryRunFlowReconcile`'s `treeSha` is now optional, and omitting it yields a fourth verdict:

```
guard: {
  required: true,
  verdict: "unevaluated",
  reason: "The fail-closed mirror check runs at push time against the pushed commit.
           These files have not been pushed, so nothing can be verified yet: whether
           the destructive work above actually runs is decided when the push lands."
}
```

`reconcileFlowsFromRepo` (the live, destructive path) now defers on **any** verdict that is not an affirmative `"verified"`, rather than only on `"would-defer"` — the new variant cannot reach it today, and if a future caller stops passing a `treeSha`, deferring is the safe way to find that out.

## Also in here

- **`PlannedFlow.pendingApply`** — `staleEntitiesFor` reads the ROW's entity selection, which is correct on the live path (the caller applied the file first) and blind before a push: for an agent's headline failure mode (an entity silently dropped from `entityFilter`) the answer would always be "nothing happens". `pendingApply` says "this file has not been written to its row yet", and the plan then reads the selection from the FILE — exactly what `applyDefinition` would write. Defaults to `false`, so the live path is unchanged, and a file identical to the committed one keeps `false` (the sync path short-circuits on a matching blob sha and applies nothing).
- **Pre-existing behaviour surfaced, not fixed:** an unparseable file for an EXISTING flow is dropped from `syncFlowsFromRepo`'s desired set while the rest of the tree stays in it — so the reconciler reads the absence as a removal and a YAML typo tears the flow down. The tool reports it (`wouldTeardown` + a note) rather than hiding it. Fixing the reactor is a separate change.

## Wiring (the thing that was missing last time)

Both functions this composes were shipped, tested and unreachable, so the test asserts reachability rather than shape — `wiring: registered, classified, bridged, reachable`:

- `MCP_BRIDGE_POLICY.check_flow_files.status === "bridge"`, plus `assertBridgePolicyCovers` / `assertBridgePolicyNotStale` over the live inventory.
- `collectLiveAgentToolNames()` contains it (the factory is added to `bridge-inventory.ts`).
- `DEFERRED_BUILTIN_TOOL_NAMES` contains it — the CLAUDE.md tier policy — and `unifiedAgentFactory(...).tools` really registers it, so it is executable in-product and stays out of the default working set.
- `READ_ONLY_TOOL_NAMES` contains it, and `mcpReadOnlyHint` agrees.
- It is executed **through `buildMakoMcpToolset`**, the toolset the MCP server actually builds, and the partial-input property is asserted again there — not just on the exported helper.

Read-only is asserted, not claimed: a full snapshot of `Flow` + `CdcEntityState` before/after a call that plans both a teardown and an entity drop, plus a mocked `inngest.send` that must receive nothing.

## Checks

| Check | Result |
| --- | --- |
| `pnpm --filter api run test` (full chain + apps vitest) | **EXIT=0**, 19 files / 191 tests |
| `pnpm --filter api run test:destinations` (owns `flow-reconcile.test.ts`) | 16 files / 191 tests passed |
| `api/src/agent-lib/tools/flow-file-tools.test.ts` | 13/13 passed |
| `node_modules/.bin/tsc --noEmit -p api/tsconfig.json` | **70 errors — exactly the pre-existing baseline**, none in changed files (binary verified at `api/node_modules/.bin/tsc`) |
| `pnpm app:build` | ✅ built (the api-import-widens-the-app-typecheck trap) |
| `pnpm --filter api run lint` | 0 errors (94 pre-existing warnings) |
| `pnpm openapi:sync` | ran in the pre-commit hook; no output changes — no route or schema touched |

No migration, no database write, nothing run against dev Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB
