### PR TITLE
fix(flows): a YAML typo in an existing flow's file kept the row and tore down the stream

### DIFF
--- a/api/src/agent-lib/tools/flow-file-tools.test.ts
+++ b/api/src/agent-lib/tools/flow-file-tools.test.ts
@@ -349,13 +349,15 @@ describe("the three validation layers", () => {
     );
   });
 
-  it("treats a file that does not parse as the removal the push path makes it", async () => {
-    // The reactor drops an unparseable file from its desired set while
-    // leaving the rest of the tree in it, and the reconciler reads that
-    // absence as a removal. So a YAML typo in an existing flow's file is a
-    // teardown, not a no-op — a pre-existing behaviour this check surfaces
-    // rather than hides. (`beta` keeps the desired set non-empty; an EMPTY
-    // one returns early and is never a deletion.)
+  it("a file that does not parse is a no-op, not the teardown it used to be", async () => {
+    // The reactor used to drop an unparseable file from its desired set
+    // while leaving the rest of the tree in it, and the reconciler read that
+    // absence as a removal: a YAML typo in an existing flow's file tore the
+    // flow down and disposed its checkpoints. The reactor now stands the
+    // row's own definition in for the file, so the flow is present and
+    // unchanged — and this check must say the same, or it warns of a
+    // teardown that will not happen. (`beta` keeps the desired set
+    // non-empty; an EMPTY one returns early and is never a deletion.)
     await seedRepo({
       "flows/alpha.yml": flowYaml("alpha"),
       "flows/beta.yml": flowYaml("beta"),
@@ -369,7 +371,8 @@ describe("the three validation layers", () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.wouldTeardown).toEqual(["alpha"]);
+    expect(result.wouldTeardown).toEqual([]);
+    expect(result.preExisting.wouldTeardown).toEqual([]);
     expect(result.notes.some(n => n.includes("does not parse"))).toBe(true);
   });
 });

--- a/api/src/agent-lib/tools/flow-file-tools.ts
+++ b/api/src/agent-lib/tools/flow-file-tools.ts
@@ -45,7 +45,9 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { loggers } from "../../logging";
+import { Flow } from "../../database/workspace-schema";
 import {
+  flowToFile,
   parseFlowFile,
   slugFromFlowFilePath,
 } from "../../services/flow-config-files";
@@ -212,7 +214,7 @@ export async function checkFlowFiles(input: {
     if (proposedByPath.delete(path)) overlay.deleted.push(path);
   }
 
-  /** Caller files whose contents cannot be loaded — absence, to the reactor. */
+  /** Caller files whose contents cannot be loaded — a no-op, to the reactor. */
   const unparseableSlugs = new Set<string>();
   for (const file of files) {
     const slug = slugFromFlowFilePath(file.path);
@@ -231,19 +233,32 @@ export async function checkFlowFiles(input: {
     if (!parseFlowFile(file.contents)) unparseableSlugs.add(slug);
   }
 
-  const plannedFrom = (
+  const plannedFrom = async (
     entries: Iterable<[string, { contents: string; pendingApply: boolean }]>,
-  ): PlannedFlow[] => {
+  ): Promise<PlannedFlow[]> => {
     const planned: PlannedFlow[] = [];
     for (const [path, { contents, pendingApply }] of entries) {
       const slug = slugFromFlowFilePath(path);
       if (!slug) continue;
       const file = parseFlowFile(contents);
-      // A file that does not parse is left OUT, exactly as `syncFlowsFromRepo`
-      // leaves it out of its desired set. That is faithful rather than kind:
-      // the reconciler reads the resulting absence as a removal.
-      if (!file) continue;
-      planned.push({ slug, file, pendingApply });
+      if (file) {
+        planned.push({ slug, file, pendingApply });
+        continue;
+      }
+      // A file that does not parse KEEPS the current row, in both halves:
+      // `syncFlowsFromRepo` stands the row's own definition in for it so the
+      // reconciler sees the flow present and unchanged. Model that exactly —
+      // the row's definition, nothing pending — so the plan matches what the
+      // push does. With no row there is nothing to keep, and nothing to
+      // create either.
+      const row = await Flow.findOne({ workspaceId, slug });
+      if (!row) continue;
+      planned.push({
+        slug,
+        file: flowToFile(row),
+        flowId: String(row._id),
+        pendingApply: false,
+      });
     }
     return planned;
   };
@@ -253,7 +268,7 @@ export async function checkFlowFiles(input: {
     .map(f => f.path);
   if (baselineInvalid.length > 0) {
     notes.push(
-      `Already in the repo and not parseable: ${baselineInvalid.join(", ")}. The push path skips such a file, which the reconciler reads as absence — that is why they appear under preExisting.`,
+      `Already in the repo and not parseable: ${baselineInvalid.join(", ")}. A push keeps their current rows untouched, in both definition and stream; nothing about them changes until the file parses again.`,
     );
   }
 
@@ -268,11 +283,11 @@ export async function checkFlowFiles(input: {
   ]);
   const baselinePlan = await dryRunFlowReconcile({
     workspaceId,
-    desired: plannedFrom(baselineEntries),
+    desired: await plannedFrom(baselineEntries),
   });
   const proposedPlan = await dryRunFlowReconcile({
     workspaceId,
-    desired: plannedFrom(proposedByPath.entries()),
+    desired: await plannedFrom(proposedByPath.entries()),
   });
 
   const created = sortedDiff(
@@ -296,23 +311,21 @@ export async function checkFlowFiles(input: {
   }
 
   // Teardown attribution is by explicit intent ONLY — the caller said "I
-  // deleted this", or handed over a file that cannot be loaded. A flow whose
-  // file is simply not in the repo is torn down by any push, with or without
-  // this change, and saying otherwise is the exact false alarm this tool must
-  // never raise.
-  const wouldTeardown = proposedPlan.wouldTeardown.filter(
-    slug => deletedSlugs.has(slug) || unparseableSlugs.has(slug),
+  // deleted this". A flow whose file is simply not in the repo is torn down
+  // by any push, with or without this change, and saying otherwise is the
+  // exact false alarm this tool must never raise. An unparseable file is
+  // neither: the push keeps that row as it is.
+  const wouldTeardown = proposedPlan.wouldTeardown.filter(slug =>
+    deletedSlugs.has(slug),
   );
   const teardownPreExisting = proposedPlan.wouldTeardown.filter(
-    slug => !deletedSlugs.has(slug) && !unparseableSlugs.has(slug),
+    slug => !deletedSlugs.has(slug),
   );
 
-  for (const slug of wouldTeardown) {
-    if (unparseableSlugs.has(slug)) {
-      notes.push(
-        `\`${slug}\`: the file you passed does not parse. Pushing it is worse than a no-op — the sync path skips an unparseable file, and the reconciler reads that absence as a removal, so the flow and its checkpoints go. Fix the file before committing.`,
-      );
-    }
+  for (const slug of unparseableSlugs) {
+    notes.push(
+      `\`${slug}\`: the file you passed does not parse. Pushing it changes nothing — the sync keeps the current row (if any) untouched and logs a warning you will not see — so the edit you intended will silently not happen. Fix the file before committing.`,
+    );
   }
   if (teardownPreExisting.length > 0) {
     notes.push(
@@ -374,7 +387,7 @@ export function createFlowFileTools(workspaceId: string) {
       description: [
         "Check proposed `flows/<slug>.yml` files BEFORE committing them: whether each parses, whether the connector/connection ids it names exist in this workspace, whether the flow row it describes would actually save, and what the resulting push would do to running syncs (create, reconfigure, tear down).",
         "Pass ONLY the files you added or changed. The rest of `flows/` is read from the workspace repo's main branch and merged underneath yours, so a flow you do not mention is never read as deleted.",
-        "To check a DELETION, name its path in `deletedPaths`. That, or a file that fails to parse, is the only way a teardown is attributed to you — and a teardown deletes the flow and disposes its CDC checkpoints, which re-adding the file does not recover.",
+        "To check a DELETION, name its path in `deletedPaths`. That is the only way a teardown is attributed to you — and a teardown deletes the flow and disposes its CDC checkpoints, which re-adding the file does not recover.",
         "Read-only: nothing is created, changed, deleted, or committed, and this never pushes.",
       ].join("\n"),
       inputSchema: z.object({

--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -187,6 +187,32 @@ describe("one bad file is that file's problem", () => {
     expect(await Flow.countDocuments({ workspaceId: WS })).toBe(1);
   });
 
+  it("a YAML typo in an EXISTING flow's file is a no-op, not a teardown", async () => {
+    // The definition half always "kept the current row" for an unparseable
+    // file. The stream half did not: the row was left out of the desired set,
+    // the reconciler read that absence as a removal, and — guard permitting —
+    // tore the flow down and disposed its checkpoints. So `deferred` is the
+    // tell here: a reconciler that WANTS the removal but cannot verify the
+    // tree reports it there; one that never wanted it reports nothing.
+    await push({
+      "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery"),
+      "flows/other.yml": flowYaml("Other"),
+    });
+    await syncFlowsFromRepo(WS, "user-42");
+    const before = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+
+    await push({ "flows/close-to-bigquery.yml": "name: [broken\n" });
+    const result = await syncFlowsFromRepo(WS, "user-42");
+
+    expect(result.invalid).toEqual(["close-to-bigquery"]);
+    expect(result.deferred).toEqual([]);
+    const after = await Flow.findOne({ workspaceId: WS, slug: "close-to-bigquery" });
+    expect(after).not.toBeNull();
+    expect(after!.name).toBe(before!.name);
+    expect(after!.sourceBlobSha).toBe(before!.sourceBlobSha);
+    expect(await Flow.countDocuments({ workspaceId: WS })).toBe(2);
+  });
+
   it("a failed save on an EXISTING row keeps that row as it was", async () => {
     await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
     await syncFlowsFromRepo(WS, "user-42");

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -45,6 +45,7 @@ import {
 import { Flow, type IFlow } from "../database/workspace-schema";
 import { generateWebhookEndpoint } from "../utils/webhook.utils";
 import {
+  flowToFile,
   parseFlowFile,
   slugFromFlowFilePath,
   type FlowFile,
@@ -391,10 +392,16 @@ export async function syncFlowsFromRepo(
     // The desired set is EVERY file present, not only the changed ones: the
     // reconciler derives removals from it, so omitting an unchanged file would
     // read as "this flow was deleted" and tear down a live stream.
-    if (row && parsedForDesired) {
+    //
+    // That includes a file that does not PARSE. "Keeping the current row" has
+    // to mean the reconciler sees the row too, or the definition half keeps
+    // it while the stream half tears it down and disposes its checkpoints — a
+    // YAML typo as a teardown. So the row's own current definition stands in
+    // for the file: same slug, same selection, nothing stale, nothing removed.
+    if (row) {
       desired.push({
         slug,
-        file: parsedForDesired,
+        file: parsedForDesired ?? flowToFile(row),
         flowId: String(row._id),
       });
     }


### PR DESCRIPTION
## The bug

`syncFlowsFromRepo` logs "Flow file is invalid; keeping current row" for a file that does not parse. That was true of the definition mapper and false of what happened next: the row was left out of the **desired set** (`if (row && parsedForDesired)`) while every other file stayed in it, so `reconcileFlowsFromRepo` read the absence as a removal and — guard permitting — `teardownFlow` deleted the row and disposed its `CdcEntityState` checkpoints.

**A YAML typo in `flows/fr-close-bigquery-write.yml` was a teardown of a live production stream, with a re-backfill from scratch as the recovery.** The guard did not help: it verifies the tree against the mirror, and the tree with the typo in it is real.

Found by #944's author while modelling the push path for `check_flow_files`. The tool faithfully reported `wouldTeardown: ["alpha"]` for a broken file and pinned it in a test with a comment calling it "a pre-existing behaviour this check surfaces rather than hides". Correct call to surface rather than fix in that PR; this is the fix.

## The fix

The row's own current definition (`flowToFile(row)`) stands in for an unparseable file in the desired set — same slug, same `flowId`, same entity selection. To the reconciler the flow is present and unchanged: nothing stale, nothing removed. Which is what "keeping the current row" has to mean.

`check_flow_files` models the same thing (`plannedFrom` now looks the row up for an unparseable path), so it no longer warns of a teardown that will not happen. An unparseable file is reported for what it is: a silent no-op that needs fixing before the intended edit takes effect.

## Verification

New case in `flow-sync.repo.test.ts` (real bare repo, memory Mongo): push two good flows, sync, then push `name: [broken` over one of them, sync again.

- **Against master's service**: `expected null not to be null` — the row is **gone**. Not deferred: deleted. (Stashed the service change and re-ran to confirm.)
- **With this change**: row present, `name`/`sourceBlobSha` unchanged, `deferred: []`, 2 rows still in the workspace. `deferred` is the tell — a reconciler that *wanted* the removal but was refused would report it there.

`flow-file-tools.test.ts`: the pinned case is inverted (`wouldTeardown: []`, `preExisting.wouldTeardown: []`, "does not parse" note still present); 13/13 pass.

- `test:destinations` flow suites 7/7 + reconcile
- `api` tsc 70 = master's 70; eslint 0 errors on touched files
- `flow-sync.test.ts` source assertions pass

## Not changed

A file that parses but is **refused** (`connector_id` missing) or **fails to save** (enum violation) was already in the desired set before this — those paths were never a teardown. Only the parse failure had the hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgarrLMBK3hgWriXi565vB
