### PR TITLE
docs: fix dead sync CLI references, document flows-as-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ This IP is used by Mako's cloud service for all outbound database connections.
 | ----------------------- | ------------------------------------------------------------- |
 | `pnpm run dev`          | Start API, frontend, and Inngest dev server                   |
 | `pnpm run app:dev:scan` | Start the frontend with React Scan and render debug logging   |
-| `pnpm run sync`         | Run the interactive sync tool                                 |
 | `pnpm run migrate`      | Run database migrations                                       |
 | `pnpm run docker:up`    | Start the local notebook Python kernel (run notebook code cells) |
 | `pnpm run test`         | Run test suite                                                |

--- a/docs/src/content/docs/data-sync.md
+++ b/docs/src/content/docs/data-sync.md
@@ -78,17 +78,32 @@ Flows run on [Inngest](https://www.inngest.com/), a job queue that handles:
 
 The Inngest dev server runs locally at `http://localhost:8288` during development.
 
-## CLI
+## Flows as Code (git-based)
 
-You can trigger syncs from the command line:
+Flows can also be defined declaratively in a workspace's own git repo, as
+`flows/<slug>.yml` files. This is the mechanism an AI agent (Claude Code,
+Cursor, etc.) uses to add, edit, or remove flows without touching the UI.
 
-```bash
-# Run a specific sync
-pnpm run sync --connector stripe --entity customers
+- **The file is authoritative.** A push to `main` that changes `flows/<slug>.yml`
+  reconfigures the corresponding stream; a push that removes the file tears the
+  stream down and disposes its checkpoints — re-adding the file backfills from
+  scratch. Pushes to other branches have no effect.
+- **The filename slug is the flow's identity**, minted once and never changed.
+  Renaming a file is a delete-plus-create (new stream, new webhook URL if
+  applicable); the in-file `name:` field is the free-to-change display name.
+- **Credentials never live in the file.** Connectors and connections are
+  referenced by ObjectId only. Webhook secrets and endpoints are minted in
+  Mongo on first create and are never read from or written to the file.
+- **The connector itself must already exist** — created via the Mako UI
+  (Sources → Add). No MCP tool or CLI creates a connector; a flow file can
+  only reference one that already has an id.
+- Validate before pushing with the `check_flow_files` MCP tool, which reports
+  parse/id-resolution problems, schema issues, and the reconciliation plan
+  (`wouldCreate` / `wouldReconfigure` / `wouldTeardown`) against currently
+  running streams.
 
-# Run all syncs for a workspace
-pnpm run sync --workspace <workspace-id>
-```
+See the `flows-as-code` system skill (loaded automatically by MCP-connected
+agents) for the full file format and step-by-step workflow.
 
 ## Error Handling
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -64,26 +64,22 @@ mako/
 │   │   ├── connectors/   # ETL connectors (Stripe, Close, etc.)
 │   │   ├── databases/    # Query runner drivers
 │   │   ├── inngest/      # Background job functions
-│   │   ├── sync/         # Sync orchestrator & CLI
+│   │   ├── sync/         # Sync orchestrator (engine for flows; no CLI)
 │   │   └── routes/       # API route handlers
 ├── docs/          # Documentation (Astro Starlight)
 └── cloudflare/    # Cloudflare Workers config
 ```
 
-## Run Sync Manually
-
-Mako includes a CLI for running data sync flows:
+## Run Migrations
 
 ```bash
-# Interactive mode — prompts for source, destination, entities
-pnpm run sync
-
-# Direct mode
-pnpm run sync -- -s <source_id> -d <dest_id>
-
 # Run database migrations
 pnpm run migrate
 ```
+
+Data sync is configured through [flows](/data-sync/), not a CLI — either in
+the console UI or as `flows/<slug>.yml` files in a workspace repo. The old
+interactive sync CLI (`pnpm run sync`) was removed.
 
 ## Next Steps
 


### PR DESCRIPTION
Daily docs-maintenance run.

**P0 — dead CLI references (fixed):**
- `README.md` and `getting-started.md` told developers to run `pnpm run sync`. That CLI was deleted in 0b38786 ("chore(sync): delete legacy sync CLI") along with `api/src/sync/cli.ts`. Removed the dead rows/sections.
- `data-sync.md`'s CLI section referenced the same deleted commands (`pnpm run sync --connector ...`).

**P1 — new flows-as-code system had zero user-facing docs:**
RFC #904 ("flows as code") shipped 2026-09-01 (~20 commits over the last day, culminating in #946 adding the system skill). It lets an agent define/edit/delete sync flows via `flows/<slug>.yml` in a workspace's git repo instead of the UI — a materially different, git-native workflow from what `data-sync.md` describes. Added a section covering:
- file = authoritative, push-to-main semantics, slug immutability
- credentials/webhook secrets never live in the file
- connector must pre-exist (created in UI only)
- `check_flow_files` validation tool
- pointer to the `flows-as-code` system skill for the full workflow

Scope kept tight per the one-PR-per-run rule — didn't touch CLAUDE.md (already corrected in 0b38786) or add a dedicated flows-as-code doc page; the data-sync.md addition covers the user-facing gap.