### PR TITLE
feat(app): phone shell with a fixed Browse · View · Ask nav

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,7 +13,6 @@ import {
   Box,
   CircularProgress,
   styled,
-  Drawer,
   BottomNavigation,
   BottomNavigationAction,
   Paper,
@@ -22,9 +21,9 @@ import {
 } from "@mui/material";
 import {
   MessageCircleMore as AskTabIcon,
-  SquareTerminal as EditorTabIcon,
-  Table as ResultsTabIcon,
-  X as CloseDrawerIcon,
+  Eye as ViewTabIcon,
+  Compass as BrowseTabIcon,
+  Settings as SettingsTabIcon,
 } from "lucide-react";
 import {
   Routes,
@@ -152,11 +151,11 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
- * User identity + active workspace shown in the mobile explorer drawer header.
+ * User identity + active workspace shown at the top of the mobile Browse pane.
  * Rendered inside `WorkspaceProvider` (unlike `MainApp`'s body), so it can read
  * the current workspace via `useWorkspace()`.
  */
-function MobileDrawerIdentity() {
+function MobileBrowseIdentity() {
   const { user } = useAuth();
   const { currentWorkspace } = useWorkspace();
 
@@ -212,22 +211,19 @@ function MainApp() {
   // Mobile (< md) shell state. Desktop ignores these entirely.
   const isMobile = useIsMobile();
   const mobileTab = useUIStore(state => state.mobileTab);
-  const mobileDrawer = useUIStore(state => state.mobileDrawer);
   const setMobileTab = useUIStore(state => state.setMobileTab);
-  const closeMobileDrawer = useUIStore(state => state.closeMobileDrawer);
+  const setLeftPane = useUIStore(state => state.setLeftPane);
 
-  // On mobile, selecting a tree node in the explorer Drawer opens/focuses a
-  // console tab. Surface the editor and close the drawer so the result of the
-  // tap is visible. Gated on the drawer being open so chat-driven tab opens
-  // (e.g. the agent creating a console) don't yank the user out of the Ask
-  // view mid-conversation.
+  // On mobile, tapping a tree node in Browse opens/focuses a tab. Surface it
+  // in View so the result of the tap is visible. Gated on Browse being the
+  // active tab so chat-driven tab opens (e.g. the agent creating a console)
+  // don't yank the user out of Ask mid-conversation.
   useEffect(() => {
     if (!isMobile) return;
     if (!activeTabId) return;
-    if (useUIStore.getState().mobileDrawer !== "explorer") return;
-    setMobileTab("editor");
-    closeMobileDrawer();
-  }, [activeTabId, isMobile, setMobileTab, closeMobileDrawer]);
+    if (useUIStore.getState().mobileTab !== "browse") return;
+    setMobileTab("view");
+  }, [activeTabId, isMobile, setMobileTab]);
 
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
   const groupRef = useRef<ImperativePanelGroupHandle | null>(null);
@@ -638,16 +634,11 @@ function MainApp() {
   }, []);
 
   // ── Mobile shell (< md) ───────────────────────────────────────────────
-  // A chat-first, single-pane experience: one full-screen pane at a time
-  // (Ask / Editor / Results) switched by the BottomNavigation, plus an
-  // explorer Drawer. Chat and Editor stay mounted (visibility toggled) so
-  // their state survives tab switches, mirroring the desktop dual-pane mount.
+  // One full-screen pane at a time behind a FIXED bottom nav — Browse ·
+  // View · Ask, the desktop pane order. All three stay mounted (visibility
+  // toggled) so their state survives tab switches, mirroring the desktop
+  // multi-pane mount. Per-kind switches live inside View (see Editor).
   if (isMobile) {
-    const drawerOpen = mobileDrawer === "explorer";
-    // Bottom nav only drives the content panes now; the explorer Drawer is
-    // opened from the hamburger in each pane header (top-left).
-    const bottomValue = mobileTab;
-
     return (
       <AuthWrapper>
         <UrlSync />
@@ -662,47 +653,21 @@ function MainApp() {
             width: "100vw",
             maxWidth: "100vw",
             overflow: "hidden",
-            // No top app bar on mobile — navigation lives in the bottom nav and
-            // the explorer Drawer (which carries the user/workspace menu). Keep
+            // No top app bar on mobile — navigation is the bottom nav. Keep
             // content clear of the status bar / notch on standalone installs.
             pt: "env(safe-area-inset-top)",
           }}
         >
-          {/* Content — one pane at a time, both kept mounted for state */}
+          {/* Content — one pane at a time, all kept mounted for state */}
           <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+            {/* Browse: the explorers, as a pane rather than a drawer. */}
             <Box
               sx={{
                 position: "absolute",
                 inset: 0,
-                display: mobileTab === "ask" ? "block" : "none",
+                display: mobileTab === "browse" ? "flex" : "none",
+                flexDirection: "column",
               }}
-            >
-              {chatElement}
-            </Box>
-            <Box
-              sx={{
-                position: "absolute",
-                inset: 0,
-                display:
-                  mobileTab === "editor" || mobileTab === "results"
-                    ? "block"
-                    : "none",
-              }}
-            >
-              {editorElement}
-            </Box>
-          </Box>
-
-          {/* Explorer drawer — reuses the same explorer panels as desktop */}
-          <Drawer
-            anchor="left"
-            open={drawerOpen}
-            onClose={closeMobileDrawer}
-            ModalProps={{ keepMounted: true }}
-            PaperProps={{ sx: { width: "85vw", maxWidth: 340 } }}
-          >
-            <Box
-              sx={{ height: "100%", display: "flex", flexDirection: "column" }}
             >
               <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
                 <Box
@@ -715,13 +680,16 @@ function MainApp() {
                   }}
                 >
                   <SidebarUserMenu tooltipPlacement="bottom" />
-                  <MobileDrawerIdentity />
+                  <MobileBrowseIdentity />
                   <IconButton
                     size="small"
-                    aria-label="Close explorer"
-                    onClick={closeMobileDrawer}
+                    aria-label="Settings"
+                    onClick={() => {
+                      setLeftPane("settings");
+                      openLeftPane();
+                    }}
                   >
-                    <CloseDrawerIcon size={20} />
+                    <SettingsTabIcon size={20} strokeWidth={1.5} />
                   </IconButton>
                 </Box>
                 <SidebarMobileExplorerNav />
@@ -745,10 +713,29 @@ function MainApp() {
                 </Suspense>
               </Box>
             </Box>
-          </Drawer>
+            {/* View: the active tab (console, app, dashboard, ...). */}
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                display: mobileTab === "view" ? "block" : "none",
+              }}
+            >
+              {editorElement}
+            </Box>
+            {/* Ask: chat. */}
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                display: mobileTab === "ask" ? "block" : "none",
+              }}
+            >
+              {chatElement}
+            </Box>
+          </Box>
 
-          {/* Bottom navigation — Ask / Editor / Results.
-              Explore lives in the top-left hamburger of each pane header. */}
+          {/* Bottom navigation — fixed: Browse · View · Ask. */}
           <Paper
             square
             elevation={3}
@@ -760,25 +747,25 @@ function MainApp() {
           >
             <BottomNavigation
               showLabels
-              value={bottomValue}
+              value={mobileTab}
               onChange={(_event, value) =>
-                setMobileTab(value as "ask" | "editor" | "results")
+                setMobileTab(value as "browse" | "view" | "ask")
               }
             >
+              <BottomNavigationAction
+                label="Browse"
+                value="browse"
+                icon={<BrowseTabIcon size={22} strokeWidth={1.5} />}
+              />
+              <BottomNavigationAction
+                label="View"
+                value="view"
+                icon={<ViewTabIcon size={22} strokeWidth={1.5} />}
+              />
               <BottomNavigationAction
                 label="Ask"
                 value="ask"
                 icon={<AskTabIcon size={22} strokeWidth={1.5} />}
-              />
-              <BottomNavigationAction
-                label="Editor"
-                value="editor"
-                icon={<EditorTabIcon size={22} strokeWidth={1.5} />}
-              />
-              <BottomNavigationAction
-                label="Results"
-                value="results"
-                icon={<ResultsTabIcon size={22} strokeWidth={1.5} />}
               />
             </BottomNavigation>
           </Paper>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,14 +16,11 @@ import {
   BottomNavigation,
   BottomNavigationAction,
   Paper,
-  IconButton,
-  Typography,
 } from "@mui/material";
 import {
   MessageCircleMore as AskTabIcon,
   Eye as ViewTabIcon,
   Compass as BrowseTabIcon,
-  Settings as SettingsTabIcon,
 } from "lucide-react";
 import {
   Routes,
@@ -41,10 +38,9 @@ import {
 } from "react-resizable-panels";
 import { trackEvent, trackPageView } from "./lib/analytics";
 import { setIframeDragGuard } from "./lib/iframe-drag-guard";
-import Sidebar, {
-  SidebarUserMenu,
-  SidebarMobileExplorerNav,
-} from "./components/Sidebar";
+import Sidebar from "./components/Sidebar";
+import MobileBrowse from "./components/MobileBrowse";
+import { useRecentsStore } from "./store/recentsStore";
 import { useIsMobile } from "./hooks/useIsMobile";
 import {
   CENTER_PANE_MIN_WIDTH_PX,
@@ -82,7 +78,7 @@ const loadDbtExplorer = () => import("./components/DbtExplorer");
 const DbtExplorer = lazy(loadDbtExplorer);
 import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
-import { WorkspaceProvider, useWorkspace } from "./contexts/workspace-context";
+import { WorkspaceProvider } from "./contexts/workspace-context";
 import { OnboardingProvider } from "./contexts/onboarding-context";
 import type { DbFlowFormRef } from "./components/DbFlowForm";
 import { generateObjectId } from "./utils/objectId";
@@ -150,50 +146,6 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-/**
- * User identity + active workspace shown at the top of the mobile Browse pane.
- * Rendered inside `WorkspaceProvider` (unlike `MainApp`'s body), so it can read
- * the current workspace via `useWorkspace()`.
- */
-function MobileBrowseIdentity() {
-  const { user } = useAuth();
-  const { currentWorkspace } = useWorkspace();
-
-  return (
-    <Box sx={{ flex: 1, minWidth: 0 }}>
-      {user?.email && (
-        <Typography
-          variant="subtitle2"
-          sx={{
-            fontWeight: 600,
-            lineHeight: 1.2,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {user.email}
-        </Typography>
-      )}
-      {currentWorkspace?.name && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{
-            display: "block",
-            lineHeight: 1.2,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {currentWorkspace.name}
-        </Typography>
-      )}
-    </Box>
-  );
-}
-
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
@@ -212,7 +164,6 @@ function MainApp() {
   const isMobile = useIsMobile();
   const mobileTab = useUIStore(state => state.mobileTab);
   const setMobileTab = useUIStore(state => state.setMobileTab);
-  const setLeftPane = useUIStore(state => state.setLeftPane);
 
   // On mobile, tapping a tree node in Browse opens/focuses a tab. Surface it
   // in View so the result of the tap is visible. Gated on Browse being the
@@ -224,6 +175,39 @@ function MainApp() {
     if (useUIStore.getState().mobileTab !== "browse") return;
     setMobileTab("view");
   }, [activeTabId, isMobile, setMobileTab]);
+
+  // Recents (the Browse tab's list): every activation of a durable, reopenable
+  // tab is recorded locally. Recorded on every device, read on phones.
+  useEffect(() => {
+    if (!activeTabId) return;
+    const tab = useConsoleStore.getState().tabs[activeTabId];
+    const workspaceId = useUIStore.getState().currentWorkspaceId;
+    if (!tab || !workspaceId) return;
+    const kind = tab.kind ?? "console";
+    const record = useRecentsStore.getState().record;
+    if (kind === "console") {
+      record(workspaceId, { kind, id: tab.id, title: tab.title });
+    } else if (kind === "dashboard" && tab.metadata?.dashboardId) {
+      record(workspaceId, {
+        kind,
+        id: tab.metadata.dashboardId as string,
+        title: tab.title,
+      });
+    } else if (kind === "notebook" && tab.metadata?.notebookId) {
+      record(workspaceId, {
+        kind,
+        id: tab.metadata.notebookId as string,
+        title: tab.title,
+      });
+    } else if (kind === "app" && tab.metadata?.appId) {
+      record(workspaceId, {
+        kind,
+        id: tab.metadata.appId as string,
+        title: tab.title,
+        slug: tab.metadata.appSlug as string | undefined,
+      });
+    }
+  }, [activeTabId]);
 
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
   const groupRef = useRef<ImperativePanelGroupHandle | null>(null);
@@ -660,58 +644,34 @@ function MainApp() {
         >
           {/* Content — one pane at a time, all kept mounted for state */}
           <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
-            {/* Browse: the explorers, as a pane rather than a drawer. */}
+            {/* Browse: search, recents and the explorers, as a pane. */}
             <Box
               sx={{
                 position: "absolute",
                 inset: 0,
-                display: mobileTab === "browse" ? "flex" : "none",
-                flexDirection: "column",
+                display: mobileTab === "browse" ? "block" : "none",
               }}
             >
-              <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1,
-                    px: 1,
-                    pt: 1,
-                  }}
-                >
-                  <SidebarUserMenu tooltipPlacement="bottom" />
-                  <MobileBrowseIdentity />
-                  <IconButton
-                    size="small"
-                    aria-label="Settings"
-                    onClick={() => {
-                      setLeftPane("settings");
-                      openLeftPane();
-                    }}
+              <MobileBrowse
+                explorer={
+                  <Suspense
+                    fallback={
+                      <Box
+                        sx={{
+                          height: "100%",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        <CircularProgress size={20} />
+                      </Box>
+                    }
                   >
-                    <SettingsTabIcon size={20} strokeWidth={1.5} />
-                  </IconButton>
-                </Box>
-                <SidebarMobileExplorerNav />
-              </Box>
-              <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
-                <Suspense
-                  fallback={
-                    <Box
-                      sx={{
-                        height: "100%",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <CircularProgress size={20} />
-                    </Box>
-                  }
-                >
-                  {leftPaneContent}
-                </Suspense>
-              </Box>
+                    {leftPaneContent}
+                  </Suspense>
+                }
+              />
             </Box>
             {/* View: the active tab (console, app, dashboard, ...). */}
             <Box

--- a/app/src/components/AppWorkspace.tsx
+++ b/app/src/components/AppWorkspace.tsx
@@ -14,7 +14,13 @@
  * Every read resolves from git through the durable worktree API, so the view
  * renders identically whether the sandbox is hot, paused, or dead.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
 import {
   Alert,
   Box,
@@ -46,6 +52,8 @@ import AppHistoryPopover from "./AppHistoryPopover";
 import { useConsoleStore } from "../store/consoleStore";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { setIframeDragGuard } from "../lib/iframe-drag-guard";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { useUIStore } from "../store/uiStore";
 import { TerminalTypeAhead } from "../lib/terminal-type-ahead";
 
 // ---------------------------------------------------------------------------
@@ -97,6 +105,18 @@ const HIDDEN_PAUSE_MS = 10 * 60 * 1000;
  * is how a dev box billed hours of idle time. Pausing unmounts the dev
  * preview and terminals (dtach keeps the sessions; they replay on return).
  */
+/** Keys a phone keyboard does not have, as the bytes a pty expects. */
+const MOBILE_TERMINAL_KEYS: ReadonlyArray<readonly [string, string]> = [
+  ["Esc", "\x1b"],
+  ["Tab", "\t"],
+  ["^C", "\x03"],
+  ["↑", "\x1b[A"],
+  ["↓", "\x1b[B"],
+  ["←", "\x1b[D"],
+  ["→", "\x1b[C"],
+  ["Ret", "\r"],
+];
+
 function useHiddenPause(): boolean {
   const [paused, setPaused] = useState(false);
   useEffect(() => {
@@ -129,6 +149,7 @@ function TerminalPanel({
   label,
   fresh = false,
   onSessionEnd,
+  inputRef,
 }: {
   appId: string;
   workspaceId: string;
@@ -140,6 +161,12 @@ function TerminalPanel({
   fresh?: boolean;
   /** The session ended for good (`exit`, kill): close the tab, do not respawn. */
   onSessionEnd?: () => void;
+  /**
+   * Receives the "write to the pty" function while the socket is up, so a
+   * parent can inject keystrokes a phone keyboard has no key for (Esc,
+   * arrows, ^C) — see the mobile key bar in TerminalTabs.
+   */
+  inputRef?: MutableRefObject<((data: string) => void) | null>;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [status, setStatus] = useState<
@@ -197,6 +224,7 @@ function TerminalPanel({
     const send = (data: string) => {
       if (ws && ws.readyState === WebSocket.OPEN) ws.send(data);
     };
+    if (inputRef) inputRef.current = send;
 
     // macOS line editing. xterm sends a bare backspace for these, so
     // ⌘⌫ and ⌥⌫ silently deleted one character — the shell already
@@ -352,6 +380,7 @@ function TerminalPanel({
       typeAhead?.dispose();
       ws?.close();
       term.dispose();
+      if (inputRef) inputRef.current = null;
     };
     // onSessionEnd deliberately not a dependency: it is stable in practice
     // and reconnecting the pty because a parent re-rendered would be worse.
@@ -580,6 +609,247 @@ function TerminalTabs({
   // dev server]" attach with nothing behind it (apps.md §13.11).
   const runningDevApps = useAppsStore(st => st.runningDevApps);
   const devRunning = slug ? runningDevApps.includes(slug) : false;
+  const isMobile = useIsMobile();
+  // One writer ref per terminal id, handed to its TerminalPanel; the mobile
+  // key bar writes through the active one. Refs, not state: a socket coming
+  // up must not re-render the tab bar.
+  const inputRefs = useRef<
+    Record<string, MutableRefObject<((data: string) => void) | null>>
+  >({});
+  const inputRefFor = (id: string) =>
+    (inputRefs.current[id] ??= { current: null });
+
+  const addShell = () => {
+    // Never mint an id the BOX already has a session for: with a detached
+    // ghost "1" on screen, + used to create id 1 — silently adopting the old
+    // shell (cwd, state) while presenting it as fresh. Skip every id in use,
+    // client-side or box-side.
+    const used = new Set([
+      ...shells,
+      ...boxTerminals.filter(t => /^[0-9]+$/.test(t)),
+    ]);
+    let n = nextId.current;
+    while (used.has(String(n))) n += 1;
+    nextId.current = n + 1;
+    const id = String(n);
+    freshIds.current.add(id);
+    setShells(prev => [...prev, id]);
+    setActive(id);
+  };
+
+  // ONE session list for both layouts: the desktop column and the mobile chip
+  // row. Dev server first (server-side it is a tmux session like any other),
+  // then this pageview's shells, then GHOST sessions — shells that exist in
+  // the box (pushed truth) but have no tab here: opened by the agent, another
+  // browser, or a previous pageview. One tap attaches, history and all;
+  // invisible sessions were how people collided with them.
+  const devTermId = `dev-${slug ?? ""}`;
+  const sessionItems: {
+    key: string;
+    termId: string;
+    label: string;
+    selected: boolean;
+    onSelect: () => void;
+    onClose?: () => void;
+  }[] = [
+    {
+      key: "dev",
+      termId: devTermId,
+      label: slug
+        ? `dev: ${slug}${devRunning ? "" : " · stopped"}`
+        : "dev server",
+      selected: active === "dev",
+      onSelect: () => setActive("dev"),
+      // Closing the dev session IS stopping dev mode — one mental model,
+      // same as the toolbar's Stop dev.
+      onClose: devRunning ? () => void stopDev(workspaceId, appId) : undefined,
+    },
+    ...shells.map((id, index) => ({
+      key: id,
+      termId: id,
+      label: `bash ${index + 1}`,
+      selected: active === id,
+      onSelect: () => setActive(id),
+      onClose: () => closeShell(id, { killRemote: true }),
+    })),
+    ...boxTerminals
+      .filter(id => /^[0-9]+$/.test(id) && !shells.includes(id))
+      .map(id => ({
+        key: `ghost-${id}`,
+        termId: id,
+        label: `bash · detached (${id})`,
+        selected: false,
+        onSelect: () => {
+          setShells(prev => (prev.includes(id) ? prev : [...prev, id]));
+          setActive(id);
+        },
+      })),
+  ];
+
+  // Every pane STAYS MOUNTED — an unmounted xterm is a dropped session and a
+  // re-scroll; hiding keeps the socket, the scrollback and the dev-log offset
+  // alive across switches.
+  const terminalPanes = (
+    <Box
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          display: active === "dev" ? "block" : "none",
+        }}
+      >
+        {!hiddenPaused && slug && (devRunning || active === "dev") ? (
+          // The dev server runs in a dtach session named like any other
+          // (mako-term-dev-<slug>) — this is a normal terminal attached
+          // to it: colors, native scrollback, prefit history, and Ctrl-C
+          // reaches vite. Mounted only when a server is actually running
+          // (box truth) or the user selected this tab — never on mount for
+          // a stopped app, which would attach a waiter to nothing.
+          <TerminalPanel
+            appId={appId}
+            workspaceId={workspaceId}
+            termId={devTermId}
+            label={`dev: ${slug}`}
+            inputRef={inputRefFor(devTermId)}
+          />
+        ) : null}
+      </Box>
+      {!hiddenPaused &&
+        shells.map((id, index) => (
+          <Box
+            key={id}
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              display: active === id ? "block" : "none",
+            }}
+          >
+            <TerminalPanel
+              appId={appId}
+              workspaceId={workspaceId}
+              termId={id}
+              label={`bash ${index + 1}`}
+              fresh={freshIds.current.has(id)}
+              onSessionEnd={() => closeShell(id, { killRemote: false })}
+              inputRef={inputRefFor(id)}
+            />
+          </Box>
+        ))}
+    </Box>
+  );
+
+  if (isMobile) {
+    // Phone anatomy: sessions as a chip row on top (the column would eat a
+    // third of the width), the shell filling the pane, and a key bar above
+    // the soft keyboard for the keys it does not have.
+    const activeTermId = active === "dev" ? devTermId : active;
+    const sendKey = (seq: string) => inputRefFor(activeTermId).current?.(seq);
+    return (
+      <Box
+        sx={{
+          height: "100%",
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.75,
+            px: 1,
+            py: 0.75,
+            borderBottom: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              gap: 0.75,
+              overflowX: "auto",
+              scrollbarWidth: "none",
+              "&::-webkit-scrollbar": { display: "none" },
+            }}
+          >
+            {sessionItems.map(item => (
+              <Chip
+                key={item.key}
+                icon={<TerminalIcon size={14} strokeWidth={1.75} />}
+                label={item.label}
+                variant={item.selected ? "filled" : "outlined"}
+                onClick={item.onSelect}
+                onDelete={item.onClose}
+                sx={{
+                  flexShrink: 0,
+                  fontFamily:
+                    'ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace',
+                  fontSize: 12,
+                }}
+              />
+            ))}
+          </Box>
+          <Tooltip title="New terminal — another real shell in the same sandbox">
+            <IconButton
+              size="small"
+              aria-label="New terminal"
+              onClick={addShell}
+            >
+              <PlusIcon size={16} strokeWidth={2} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        {terminalPanes}
+        <Box
+          sx={{
+            display: "flex",
+            gap: 0.75,
+            px: 1,
+            py: 0.75,
+            borderTop: 1,
+            borderColor: "divider",
+            bgcolor: "background.default",
+          }}
+        >
+          {MOBILE_TERMINAL_KEYS.map(([label, seq]) => (
+            <Button
+              key={label}
+              size="small"
+              variant="outlined"
+              color="inherit"
+              aria-label={`Send ${label}`}
+              // Keep focus (and the soft keyboard) on the terminal: a button
+              // that takes focus on tap hides the keyboard on iOS.
+              onPointerDown={e => e.preventDefault()}
+              onClick={() => sendKey(seq)}
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                px: 0,
+                minHeight: 36,
+                textTransform: "none",
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace',
+              }}
+            >
+              {label}
+            </Button>
+          ))}
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     // VS Code's panel anatomy: the active session fills the area, and the
@@ -593,61 +863,7 @@ function TerminalTabs({
       style={{ height: "100%" }}
     >
       <Panel minSize={40}>
-        <Box
-          sx={{
-            height: "100%",
-            minWidth: 0,
-            minHeight: 0,
-            display: "flex",
-            flexDirection: "column",
-          }}
-        >
-          {/* Every pane STAYS MOUNTED — an unmounted xterm is a dropped
-            session and a re-scroll; hiding keeps the socket, the scrollback
-            and the dev-log offset alive across switches. */}
-          <Box
-            sx={{
-              flex: 1,
-              minHeight: 0,
-              display: active === "dev" ? "block" : "none",
-            }}
-          >
-            {!hiddenPaused && slug && (devRunning || active === "dev") ? (
-              // The dev server runs in a dtach session named like any other
-              // (mako-term-dev-<slug>) — this is a normal terminal attached
-              // to it: colors, native scrollback, prefit history, and Ctrl-C
-              // reaches vite. Mounted only when a server is actually running
-              // (box truth) or the user selected this tab — never on mount for
-              // a stopped app, which would attach a waiter to nothing.
-              <TerminalPanel
-                appId={appId}
-                workspaceId={workspaceId}
-                termId={`dev-${slug}`}
-                label={`dev: ${slug}`}
-              />
-            ) : null}
-          </Box>
-          {!hiddenPaused &&
-            shells.map((id, index) => (
-              <Box
-                key={id}
-                sx={{
-                  flex: 1,
-                  minHeight: 0,
-                  display: active === id ? "block" : "none",
-                }}
-              >
-                <TerminalPanel
-                  appId={appId}
-                  workspaceId={workspaceId}
-                  termId={id}
-                  label={`bash ${index + 1}`}
-                  fresh={freshIds.current.has(id)}
-                  onSessionEnd={() => closeShell(id, { killRemote: false })}
-                />
-              </Box>
-            ))}
-        </Box>
+        <Box sx={{ height: "100%", display: "flex" }}>{terminalPanes}</Box>
       </Panel>
       <SessionsResizeHandle />
       <Panel defaultSize={14} minSize={7} maxSize={40}>
@@ -681,71 +897,20 @@ function TerminalTabs({
               SESSIONS
             </Typography>
             <Tooltip title="New terminal — another real shell in the same sandbox">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  // Never mint an id the BOX already has a session for:
-                  // with a detached ghost "1" on screen, + used to create
-                  // id 1 — silently adopting the old shell (cwd, state)
-                  // while presenting it as fresh. Skip every id in use,
-                  // client-side or box-side.
-                  const used = new Set([
-                    ...shells,
-                    ...boxTerminals.filter(t => /^[0-9]+$/.test(t)),
-                  ]);
-                  let n = nextId.current;
-                  while (used.has(String(n))) n += 1;
-                  nextId.current = n + 1;
-                  const id = String(n);
-                  freshIds.current.add(id);
-                  setShells(prev => [...prev, id]);
-                  setActive(id);
-                }}
-              >
+              <IconButton size="small" onClick={addShell}>
                 <PlusIcon size={13} strokeWidth={2} />
               </IconButton>
             </Tooltip>
           </Box>
-          <SessionRow
-            label={
-              slug
-                ? `dev: ${slug}${devRunning ? "" : " · stopped"}`
-                : "dev server"
-            }
-            selected={active === "dev"}
-            onSelect={() => setActive("dev")}
-            // Closing the dev session IS stopping dev mode — one mental
-            // model, same as the toolbar's Stop dev.
-            onClose={
-              devRunning ? () => void stopDev(workspaceId, appId) : undefined
-            }
-          />
-          {shells.map((id, index) => (
+          {sessionItems.map(item => (
             <SessionRow
-              key={id}
-              label={`bash ${index + 1}`}
-              selected={active === id}
-              onSelect={() => setActive(id)}
-              onClose={() => closeShell(id, { killRemote: true })}
+              key={item.key}
+              label={item.label}
+              selected={item.selected}
+              onSelect={item.onSelect}
+              onClose={item.onClose}
             />
           ))}
-          {/* GHOST sessions: shells that exist in the box (pushed truth)
-              but have no tab here — opened by the agent, another browser,
-              or a previous pageview. One click attaches, history and all;
-              invisible sessions were how people collided with them. */}
-          {boxTerminals
-            .filter(id => /^[0-9]+$/.test(id) && !shells.includes(id))
-            .map(id => (
-              <SessionRow
-                key={`ghost-${id}`}
-                label={`bash · detached (${id})`}
-                selected={false}
-                onSelect={() => {
-                  setShells(prev => (prev.includes(id) ? prev : [...prev, id]));
-                  setActive(id);
-                }}
-              />
-            ))}
         </Box>
       </Panel>
     </PanelGroup>
@@ -967,6 +1132,10 @@ export default function AppWorkspace({
       ? `/api/workspaces/${workspaceId}/apps/${appId}/live/`
       : undefined;
   const fetchViewUrl = useAppsStore(s => s.fetchViewUrl);
+  // Phone: the workbench is one pane at a time (preview OR terminal),
+  // switched by the toggle beside the window pill in the Editor header.
+  const isMobile = useIsMobile();
+  const mobileAppPane = useUIStore(s => s.mobileAppPane);
 
   // Derive the workbench view from BOX TRUTH, never localStorage. Auto-open
   // the workbench ONLY when a dev server is actually serving this app — a
@@ -1081,6 +1250,75 @@ export default function AppWorkspace({
 
   if (!workspaceId) return null;
 
+  // The dev-mode preview: build log while booting, the live iframe, or the
+  // getting-started copy. Shared by the desktop split and the phone layout.
+  const previewPane =
+    preview?.building && preview.publishing ? (
+      <BuildLogPanel text={preview.buildOutput ?? ""} />
+    ) : preview?.building ? (
+      // A 60-second cold boot behind a bare spinner reads as frozen.
+      // The boot writes a real log (npm install → vite); stream its
+      // tail here so starting reads as PROGRESS.
+      <DevBootLog workspaceId={workspaceId} appId={appId} />
+    ) : preview?.mode === "dev" && preview.reachable === false ? (
+      <Alert severity="warning" sx={{ m: 2 }}>
+        A dev server for this app is running in the sandbox but rejects the
+        preview host — it was started outside Mako without{" "}
+        <code>server.allowedHosts</code> including{" "}
+        <code>&quot;.e2b.app&quot;</code>. Use{" "}
+        <strong>Restart dev session</strong> to let Mako run it, or add that
+        host to the app&apos;s <code>vite.config</code>.
+      </Alert>
+    ) : hiddenPaused ? (
+      <Alert severity="info" sx={{ m: 2 }}>
+        Preview paused after 10 minutes in the background — its sockets are
+        released so the sandbox can sleep. It resumes when you come back.
+      </Alert>
+    ) : preview?.url ? (
+      <iframe
+        key={`dev-${previewNonce}`}
+        title="App preview"
+        src={preview.url}
+        // The two preview tiers need DIFFERENT sandboxes.
+        //
+        // Static builds are served by Mako from Mako's own origin, so
+        // `allow-same-origin` would hand app code our origin and let
+        // it escape the sandbox entirely — it stays off, and the
+        // opaque origin is why those assets are served with
+        // `Access-Control-Allow-Origin: *`.
+        //
+        // The live dev server (§12.4) is a genuinely foreign origin
+        // (`<port>-<sandbox>.e2b.app`), so `allow-same-origin` grants
+        // it only ITS OWN origin, never ours. It is required there:
+        // with an opaque origin, Vite's HMR socket and its
+        // cross-origin module scripts do not work.
+        sandbox={
+          preview.mode === "dev"
+            ? "allow-scripts allow-forms allow-same-origin"
+            : "allow-scripts allow-forms"
+        }
+        style={{ border: 0, width: "100%", height: "100%" }}
+      />
+    ) : (
+      <Box sx={{ p: 3, maxWidth: 560 }}>
+        <Typography variant="subtitle1" gutterBottom>
+          {app?.title ?? "App"}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          Browse and edit this app&apos;s files from the Apps explorer on the
+          left — every file opens in its own tab. Ask the agent in chat to build
+          features (it works on your branch and commits every turn), or use the
+          terminal below — it is a real machine with a real git checkout.
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          <strong>Start dev session</strong> runs the app live, so edits show up
+          as you make them. <strong>Publish</strong> builds it and deploys —
+          that is the version everyone else sees. A failed build publishes
+          nothing and leaves the current version untouched.
+        </Typography>
+      </Box>
+    );
+
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {/* Toolbar */}
@@ -1096,9 +1334,12 @@ export default function AppWorkspace({
           flexWrap: "wrap",
         }}
       >
-        <Typography variant="subtitle2" noWrap sx={{ maxWidth: 240 }}>
-          {app?.title ?? "App"}
-        </Typography>
+        {/* The window pill already carries the title on a phone. */}
+        {!isMobile && (
+          <Typography variant="subtitle2" noWrap sx={{ maxWidth: 240 }}>
+            {app?.title ?? "App"}
+          </Typography>
+        )}
         {devRunning && (
           <Chip
             label="live · HMR"
@@ -1198,17 +1439,19 @@ export default function AppWorkspace({
             </Button>
           </span>
         </Tooltip>
-        <Tooltip title={`History (${status?.branch ?? "main"})`}>
-          <IconButton
-            size="small"
-            onClick={e => {
-              setHistoryAnchor(e.currentTarget);
-              void fetchHistory(workspaceId, appId);
-            }}
-          >
-            <HistoryIcon size={16} />
-          </IconButton>
-        </Tooltip>
+        {!isMobile && (
+          <Tooltip title={`History (${status?.branch ?? "main"})`}>
+            <IconButton
+              size="small"
+              onClick={e => {
+                setHistoryAnchor(e.currentTarget);
+                void fetchHistory(workspaceId, appId);
+              }}
+            >
+              <HistoryIcon size={16} />
+            </IconButton>
+          </Tooltip>
+        )}
         <Tooltip title="Open the preview in a new tab">
           <span>
             <IconButton
@@ -1324,6 +1567,30 @@ export default function AppWorkspace({
             </Box>
           )}
         </Box>
+      ) : isMobile ? (
+        // Phone: preview and terminal are the two halves of the toggle in
+        // the Editor header; both stay mounted so switching costs nothing.
+        <>
+          <Box
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              display: mobileAppPane === "preview" ? "flex" : "none",
+              flexDirection: "column",
+            }}
+          >
+            {previewPane}
+          </Box>
+          <Box
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              display: mobileAppPane === "terminal" ? "block" : "none",
+            }}
+          >
+            <TerminalTabs appId={appId} workspaceId={workspaceId} />
+          </Box>
+        </>
       ) : (
         <PanelGroup
           direction="vertical"
@@ -1334,74 +1601,7 @@ export default function AppWorkspace({
           style={{ flex: 1, minHeight: 0 }}
         >
           <Panel defaultSize={70} minSize={20}>
-            {preview?.building && preview.publishing ? (
-              <BuildLogPanel text={preview.buildOutput ?? ""} />
-            ) : preview?.building ? (
-              // A 60-second cold boot behind a bare spinner reads as frozen.
-              // The boot writes a real log (npm install → vite); stream its
-              // tail here so starting reads as PROGRESS.
-              <DevBootLog workspaceId={workspaceId} appId={appId} />
-            ) : preview?.mode === "dev" && preview.reachable === false ? (
-              <Alert severity="warning" sx={{ m: 2 }}>
-                A dev server for this app is running in the sandbox but rejects
-                the preview host — it was started outside Mako without{" "}
-                <code>server.allowedHosts</code> including{" "}
-                <code>&quot;.e2b.app&quot;</code>. Use{" "}
-                <strong>Restart dev session</strong> to let Mako run it, or add
-                that host to the app&apos;s <code>vite.config</code>.
-              </Alert>
-            ) : hiddenPaused ? (
-              <Alert severity="info" sx={{ m: 2 }}>
-                Preview paused after 10 minutes in the background — its sockets
-                are released so the sandbox can sleep. It resumes when you come
-                back.
-              </Alert>
-            ) : preview?.url ? (
-              <iframe
-                key={`dev-${previewNonce}`}
-                title="App preview"
-                src={preview.url}
-                // The two preview tiers need DIFFERENT sandboxes.
-                //
-                // Static builds are served by Mako from Mako's own origin, so
-                // `allow-same-origin` would hand app code our origin and let
-                // it escape the sandbox entirely — it stays off, and the
-                // opaque origin is why those assets are served with
-                // `Access-Control-Allow-Origin: *`.
-                //
-                // The live dev server (§12.4) is a genuinely foreign origin
-                // (`<port>-<sandbox>.e2b.app`), so `allow-same-origin` grants
-                // it only ITS OWN origin, never ours. It is required there:
-                // with an opaque origin, Vite's HMR socket and its
-                // cross-origin module scripts do not work.
-                sandbox={
-                  preview.mode === "dev"
-                    ? "allow-scripts allow-forms allow-same-origin"
-                    : "allow-scripts allow-forms"
-                }
-                style={{ border: 0, width: "100%", height: "100%" }}
-              />
-            ) : (
-              <Box sx={{ p: 3, maxWidth: 560 }}>
-                <Typography variant="subtitle1" gutterBottom>
-                  {app?.title ?? "App"}
-                </Typography>
-                <Typography variant="body2" color="text.secondary" paragraph>
-                  Browse and edit this app&apos;s files from the Apps explorer
-                  on the left — every file opens in its own tab. Ask the agent
-                  in chat to build features (it works on your branch and commits
-                  every turn), or use the terminal below — it is a real machine
-                  with a real git checkout.
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  <strong>Start dev session</strong> runs the app live, so edits
-                  show up as you make them. <strong>Publish</strong> builds it
-                  and deploys — that is the version everyone else sees. A failed
-                  build publishes nothing and leaves the current version
-                  untouched.
-                </Typography>
-              </Box>
-            )}
+            {previewPane}
           </Panel>
 
           <TerminalResizeHandle onDragging={setTerminalDragging} />

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -18,15 +18,7 @@ import {
   Collapse,
   Tooltip,
 } from "@mui/material";
-import {
-  ChevronDown,
-  Copy,
-  Check,
-  History,
-  Menu as MenuIcon,
-  Plus,
-  X,
-} from "lucide-react";
+import { ChevronDown, Copy, Check, History, Plus, X } from "lucide-react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import { useChat } from "@ai-sdk/react";
 import { Virtuoso, type VirtuosoHandle, type Components } from "react-virtuoso";
@@ -1116,10 +1108,11 @@ const Chat: React.FC<ChatProps> = ({
 
   const handleConsoleTitleClick = useCallback(async (consoleId: string) => {
     const store = useConsoleStore.getState();
-    // On mobile the editor lives behind the "Editor" tab — surface it so
+    // On mobile the console lives behind the View tab — surface it so
     // tapping a console reference in chat ("view SQL") shows the query.
     if (isMobileRef.current) {
-      useUIStore.getState().setMobileTab("editor");
+      useUIStore.getState().setMobileConsolePane("query");
+      useUIStore.getState().setMobileTab("view");
     }
     const existingTab = store.tabs[consoleId];
     if (existingTab) {
@@ -1277,17 +1270,9 @@ const Chat: React.FC<ChatProps> = ({
               gap: 1,
             }}
           >
-            {isMobile ? (
-              <Tooltip title="Open explorer">
-                <IconButton
-                  aria-label="Open explorer"
-                  onClick={() => useUIStore.getState().openMobileDrawer()}
-                  sx={MOBILE_FLOAT_BTN_SX}
-                >
-                  <MenuIcon size={20} />
-                </IconButton>
-              </Tooltip>
-            ) : (
+            {/* On mobile the explorer is the Browse tab, so the header's
+                left side is empty: floating actions on the right only. */}
+            {!isMobile && (
               <Typography
                 variant="h6"
                 sx={{

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -36,6 +36,7 @@ import { useDashboardTreeStore } from "../store/dashboardTreeStore";
 import { useDbtStore } from "../store/dbtStore";
 import { useFlowStore } from "../store/flowStore";
 import { useUIStore } from "../store/uiStore";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 const SEARCH_DEBOUNCE_MS = 200;
 
@@ -58,6 +59,9 @@ function groupIntoRows(items: PaletteItem[]): Row[] {
 
 export default function CommandPalette() {
   const open = useCommandPaletteStore(state => state.open);
+  // On a phone the palette IS the search screen (Browse's search field opens
+  // it), so it takes the whole viewport instead of floating as a dialog.
+  const isMobile = useIsMobile();
   const consoleResults = useCommandPaletteStore(state => state.consoleResults);
   const searching = useCommandPaletteStore(state => state.searching);
   const workspaceId = useUIStore(state => state.currentWorkspaceId);
@@ -216,6 +220,7 @@ export default function CommandPalette() {
       open={open}
       onClose={() => useCommandPaletteStore.getState().closePalette()}
       fullWidth
+      fullScreen={isMobile}
       maxWidth="sm"
       // Without this, MUI restores focus to the previously focused element
       // (e.g. Monaco) when the dialog opens, defeating the input autofocus.

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -40,6 +40,7 @@ import {
   FolderInput as MoveIcon,
   Clock3 as ScheduleIcon,
   Share2 as Share2Icon,
+  MoreHorizontal as MoreIcon,
 } from "lucide-react";
 import Editor, { DiffEditor } from "@monaco-editor/react";
 import { EDITOR_OPTIONS, useMonacoTheme } from "../lib/monaco-presets";
@@ -234,6 +235,10 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     null,
   );
   const saveMenuOpen = Boolean(saveMenuAnchor);
+  // Mobile overflow menu: everything the one-row phone toolbar cannot show.
+  const [mobileMenuAnchor, setMobileMenuAnchor] = useState<null | HTMLElement>(
+    null,
+  );
 
   // Compute dirty state by comparing current state hash vs saved state hash
   const hasUnsavedChanges = useMemo(() => {
@@ -1169,6 +1174,56 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     ],
   );
 
+  // Undo/redo go through Monaco's own stack so the toolbar (desktop) and the
+  // overflow menu (mobile) behave identically to the keyboard shortcuts.
+  const runUndo = useCallback(() => {
+    if (!editorRef.current) return;
+    editorRef.current.trigger("keyboard", "undo", null);
+    setTimeout(() => {
+      const model = editorRef.current?.getModel();
+      if (model) {
+        setMonacoCanUndo(model.canUndo());
+        setMonacoCanRedo(model.canRedo());
+      }
+    }, 0);
+  }, []);
+  const runRedo = useCallback(() => {
+    if (!editorRef.current) return;
+    editorRef.current.trigger("keyboard", "redo", null);
+    setTimeout(() => {
+      const model = editorRef.current?.getModel();
+      if (model) {
+        setMonacoCanUndo(model.canUndo());
+        setMonacoCanRedo(model.canRedo());
+      }
+    }, 0);
+  }, []);
+
+  const handleConnectionChange = useCallback(
+    (newConnectionId: string) => {
+      const newConnection = databases.find(db => db.id === newConnectionId);
+      if (onDatabaseChange) {
+        onDatabaseChange(newConnectionId);
+      }
+      // For non-cluster mode: set databaseName from the connection's database
+      // For cluster mode: clear and let user select from dropdown
+      if (onDatabaseNameChange) {
+        if (
+          newConnection &&
+          !newConnection.isClusterMode &&
+          newConnection.databaseName
+        ) {
+          onDatabaseNameChange(undefined, newConnection.databaseName);
+        } else {
+          onDatabaseNameChange(undefined, undefined);
+        }
+      }
+    },
+    [databases, onDatabaseChange, onDatabaseNameChange],
+  );
+
+  const closeMobileMenu = () => setMobileMenuAnchor(null);
+
   return (
     <Box
       sx={{
@@ -1178,9 +1233,240 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
         position: "relative",
       }}
     >
+      {/* Mobile toolbar — ONE row: connection, save, overflow. Everything
+          else (undo, redo, history, share, schedule, info, save-as) lives in
+          the overflow menu; the run affordance is the FAB. This is what gets
+          the first line of SQL back above the fold on a phone. */}
+      {isMobile && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            px: 1,
+            pb: 1,
+            backgroundColor: "background.paper",
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <ConnectionSelector
+              value={connectionId || ""}
+              onChange={handleConnectionChange}
+              size="compact"
+              showLabel={false}
+              placeholder="Select connection"
+              fullWidth
+            />
+          </Box>
+          {selectedConnection?.isClusterMode && (
+            <FormControl size="small" variant="outlined" sx={{ minWidth: 96 }}>
+              <Select
+                value={databaseId || ""}
+                onChange={e => {
+                  const dbId = e.target.value || undefined;
+                  const db = availableDatabases.find(d => d.id === dbId);
+                  if (onDatabaseNameChange) {
+                    onDatabaseNameChange(dbId, db?.label);
+                  }
+                }}
+                disabled={isLoadingDatabases || availableDatabases.length === 0}
+                displayEmpty
+                aria-label="Database"
+              >
+                {availableDatabases.map(db => (
+                  <MenuItem key={db.id} value={db.id}>
+                    {db.label || db.id}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {onSave && !isReadOnly && (
+            <Tooltip title={!hasUnsavedChanges ? "No changes to save" : "Save"}>
+              <span>
+                <IconButton
+                  aria-label="Save"
+                  onClick={handleSave}
+                  disabled={isSaving || isExecuting || !hasUnsavedChanges}
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    border: 1,
+                    borderColor: "divider",
+                    borderRadius: 1,
+                  }}
+                >
+                  <SaveIcon strokeWidth={1.75} size={20} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+          <IconButton
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={mobileMenuAnchor ? "true" : undefined}
+            onClick={e => setMobileMenuAnchor(e.currentTarget)}
+            sx={{
+              width: 40,
+              height: 40,
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 1,
+            }}
+          >
+            <MoreIcon strokeWidth={1.75} size={20} />
+          </IconButton>
+          <Menu
+            anchorEl={mobileMenuAnchor}
+            open={Boolean(mobileMenuAnchor)}
+            onClose={closeMobileMenu}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            transformOrigin={{ vertical: "top", horizontal: "right" }}
+          >
+            {enableVersionControl && (
+              <MenuItem
+                disabled={isDiffMode || !monacoCanUndo}
+                onClick={() => {
+                  closeMobileMenu();
+                  runUndo();
+                }}
+              >
+                <ListItemIcon>
+                  <UndoIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText primary="Undo" />
+              </MenuItem>
+            )}
+            {enableVersionControl && (
+              <MenuItem
+                disabled={isDiffMode || !monacoCanRedo}
+                onClick={() => {
+                  closeMobileMenu();
+                  runRedo();
+                }}
+              >
+                <ListItemIcon>
+                  <RedoIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText primary="Redo" />
+              </MenuItem>
+            )}
+            {enableVersionControl && onHistoryClick && (
+              <MenuItem
+                disabled={isDiffMode || !historyAvailable}
+                onClick={() => {
+                  const anchor = mobileMenuAnchor;
+                  closeMobileMenu();
+                  if (anchor) onHistoryClick(anchor);
+                }}
+              >
+                <ListItemIcon>
+                  <HistoryIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText
+                  primary="Version history"
+                  secondary={
+                    historyAvailable ? undefined : "Save the console first"
+                  }
+                />
+              </MenuItem>
+            )}
+            {enableVersionControl && onShareClick && (
+              <MenuItem
+                disabled={isDiffMode || !shareAvailable}
+                onClick={() => {
+                  closeMobileMenu();
+                  onShareClick();
+                }}
+              >
+                <ListItemIcon>
+                  <Share2Icon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText
+                  primary="Share"
+                  secondary={
+                    shareAvailable ? undefined : "Save the console first"
+                  }
+                />
+              </MenuItem>
+            )}
+            {!isReadOnly && (onCreateSchedule || onUpdateSchedule) && (
+              <MenuItem
+                disabled={!isSaved}
+                onClick={() => {
+                  closeMobileMenu();
+                  if (hasSchedule) onUpdateSchedule?.();
+                  else onCreateSchedule?.();
+                }}
+              >
+                <ListItemIcon>
+                  <ScheduleIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText
+                  primary={hasSchedule ? "Update schedule" : "Schedule"}
+                  secondary={isSaved ? undefined : "Save the console first"}
+                />
+              </MenuItem>
+            )}
+            {onSave && !isReadOnly && <Divider />}
+            {onSave && !isReadOnly && (
+              <MenuItem
+                disabled={isSaving || isExecuting || !onSaveAsCopy}
+                onClick={() => {
+                  closeMobileMenu();
+                  handleSaveAsCopy();
+                }}
+              >
+                <ListItemIcon>
+                  <CopyIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText primary="Save a copy…" />
+              </MenuItem>
+            )}
+            {onSave && !isReadOnly && (
+              <MenuItem
+                disabled={
+                  isSaving ||
+                  isExecuting ||
+                  !onRenameMove ||
+                  !filePathRef.current
+                }
+                onClick={() => {
+                  closeMobileMenu();
+                  handleRenameMove();
+                }}
+              >
+                <ListItemIcon>
+                  <MoveIcon size={18} strokeWidth={2} />
+                </ListItemIcon>
+                <ListItemText primary="Rename / Move…" />
+              </MenuItem>
+            )}
+            <Divider />
+            <MenuItem
+              onClick={() => {
+                closeMobileMenu();
+                handleInfoClick();
+              }}
+            >
+              <ListItemIcon>
+                <InfoOutlineIcon size={18} strokeWidth={2} />
+              </ListItemIcon>
+              <ListItemText primary="Console info" />
+            </MenuItem>
+          </Menu>
+        </Box>
+      )}
+      {isMobile && headerExtras && (
+        <Box sx={{ px: 1, pb: 1, backgroundColor: "background.paper" }}>
+          {headerExtras}
+        </Box>
+      )}
+      {/* Desktop toolbar. Hidden (not unmounted) on phones, where the one-row
+          toolbar above replaces it. */}
       <Box
         sx={{
-          display: "flex",
+          display: isMobile ? "none" : "flex",
           justifyContent: "space-between",
           alignItems: "center",
           backgroundColor: "background.paper",
@@ -1201,7 +1487,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           }}
         >
           {/* On mobile the run/cancel affordance is the floating FAB, so the
-              inline toolbar button is desktop-only to save horizontal space. */}
+            inline toolbar button is desktop-only to save horizontal space. */}
           {!isMobile &&
             (isExecuting ? (
               <Button
@@ -1418,18 +1704,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 <span>
                   <IconButton
                     size="small"
-                    onClick={() => {
-                      if (editorRef.current) {
-                        editorRef.current.trigger("keyboard", "undo", null);
-                        setTimeout(() => {
-                          const model = editorRef.current?.getModel();
-                          if (model) {
-                            setMonacoCanUndo(model.canUndo());
-                            setMonacoCanRedo(model.canRedo());
-                          }
-                        }, 0);
-                      }
-                    }}
+                    onClick={runUndo}
                     disabled={isDiffMode || !monacoCanUndo}
                   >
                     <UndoIcon strokeWidth={2} size={22} />
@@ -1441,18 +1716,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 <span>
                   <IconButton
                     size="small"
-                    onClick={() => {
-                      if (editorRef.current) {
-                        editorRef.current.trigger("keyboard", "redo", null);
-                        setTimeout(() => {
-                          const model = editorRef.current?.getModel();
-                          if (model) {
-                            setMonacoCanUndo(model.canUndo());
-                            setMonacoCanRedo(model.canRedo());
-                          }
-                        }, 0);
-                      }
-                    }}
+                    onClick={runRedo}
                     disabled={isDiffMode || !monacoCanRedo}
                   >
                     <RedoIcon strokeWidth={2} size={22} />
@@ -1511,27 +1775,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           {/* Connection selector */}
           <ConnectionSelector
             value={connectionId || ""}
-            onChange={newConnectionId => {
-              const newConnection = databases.find(
-                db => db.id === newConnectionId,
-              );
-              if (onDatabaseChange) {
-                onDatabaseChange(newConnectionId);
-              }
-              // For non-cluster mode: set databaseName from the connection's database
-              // For cluster mode: clear and let user select from dropdown
-              if (onDatabaseNameChange) {
-                if (
-                  newConnection &&
-                  !newConnection.isClusterMode &&
-                  newConnection.databaseName
-                ) {
-                  onDatabaseNameChange(undefined, newConnection.databaseName);
-                } else {
-                  onDatabaseNameChange(undefined, undefined);
-                }
-              }
-            }}
+            onChange={handleConnectionChange}
             size="compact"
             showLabel={false}
             placeholder="Select connection"

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -55,6 +55,7 @@ import EntityLoadErrorState, {
   EntityLoadingState,
 } from "./EntityLoadErrorState";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
+import { useIsMobile } from "../hooks/useIsMobile";
 import WidgetInspector from "./dashboard/WidgetInspector";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
@@ -114,6 +115,14 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   } = useDashboardEditSession({ dashboardId, workspaceId });
 
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
+
+  // Phones are for reading dashboards, not laying them out: the grid is
+  // responsive but the widget inspector, drag handles and code editor are
+  // not. Force view mode and hide the edit toggle below the breakpoint.
+  const isMobile = useIsMobile();
+  useEffect(() => {
+    if (isMobile && isEditMode) handleEditModeToggle("view");
+  }, [isMobile, isEditMode, handleEditModeToggle]);
 
   const dashboardLoadError = useDashboardStore(state =>
     dashboardId ? state.openDashboardErrors[dashboardId] : undefined,
@@ -319,7 +328,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           minHeight: 44,
         }}
       >
-        {!isReadOnly && (
+        {!isReadOnly && !isMobile && (
           <ToggleButtonGroup
             value={isEditMode ? "edit" : "view"}
             exclusive

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -39,14 +39,19 @@ import {
   ListItemIcon,
   ListItemText,
   Divider,
+  ToggleButton,
+  ToggleButtonGroup,
 } from "@mui/material";
 import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Clock as ScheduleIcon,
   Webhook as WebhookIcon,
   CirclePause as PauseIcon,
-  Menu as MenuIcon,
   ChevronDown as ChevronDownIcon,
+  SquareTerminal as QueryPaneIcon,
+  Table as ResultsPaneIcon,
+  AppWindow as PreviewPaneIcon,
+  TerminalSquare as TerminalPaneIcon,
   Plus as PlusIcon,
   X as CloseTabIcon,
 } from "lucide-react";
@@ -70,6 +75,7 @@ import { FlowEditor } from "./FlowEditor";
 import DashboardCanvas from "./DashboardCanvas";
 import NotebookRenderer from "./NotebookRenderer";
 import AppWorkspace from "./AppWorkspace";
+import { useAppsStore } from "../store/appsStore";
 import AppFileEditor from "./AppFileEditor";
 import AppDiffTab from "./AppDiffTab";
 import ConsoleDiffTab from "./ConsoleDiffTab";
@@ -335,7 +341,7 @@ const MOBILE_FLOAT_BTN_SX = {
 const MOBILE_WINDOW_PILL_SX = {
   flex: 1,
   minWidth: 0,
-  maxWidth: 260,
+  maxWidth: 320,
   height: 38,
   px: 1.5,
   textTransform: "none",
@@ -347,6 +353,28 @@ const MOBILE_WINDOW_PILL_SX = {
   boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
   backdropFilter: "blur(8px)",
   "&:hover": { bgcolor: "action.hover" },
+} as const;
+
+// Icon-only pane switch that sits beside the window pill on mobile (query /
+// results for a console, preview / terminal for an app in dev mode). Same
+// height and pill shape as its neighbours so the header stays one row.
+const MOBILE_PANE_TOGGLE_SX = {
+  height: 38,
+  flexShrink: 0,
+  borderRadius: 999,
+  overflow: "hidden",
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+  "& .MuiToggleButtonGroup-grouped": {
+    border: 0,
+    borderRadius: 0,
+    minWidth: 40,
+    px: 0,
+    color: "text.secondary",
+    "&.Mui-selected": { color: "text.primary" },
+  },
 } as const;
 
 function Editor({
@@ -691,13 +719,29 @@ function Editor({
     state => state.setActiveEditorContent,
   );
 
-  // Mobile (< md): the editor and results live behind separate bottom-nav tabs
-  // instead of the desktop vertical split. `mobileResultsView` decides which of
-  // the two a console tab shows.
+  // Mobile (< md): a console tab shows EITHER its editor or its results, and
+  // an app tab in dev mode EITHER its preview or its terminal — switched by
+  // the icon toggle beside the window pill, never by the (fixed) bottom nav.
   const isMobile = useIsMobile();
-  const mobileTab = useUIStore(state => state.mobileTab);
-  const setMobileTab = useUIStore(state => state.setMobileTab);
-  const mobileResultsView = isMobile && mobileTab === "results";
+  const mobileConsolePane = useUIStore(state => state.mobileConsolePane);
+  const setMobileConsolePane = useUIStore(state => state.setMobileConsolePane);
+  const mobileAppPane = useUIStore(state => state.mobileAppPane);
+  const setMobileAppPane = useUIStore(state => state.setMobileAppPane);
+  const mobileResultsView = isMobile && mobileConsolePane === "results";
+  // Which toggle (if any) the active tab gets. Apps only have two panes while
+  // a dev session is open; a merely viewed app is just its published build.
+  const activeMobileKind = activeConsoleId
+    ? (tabs[activeConsoleId]?.kind ?? "console")
+    : null;
+  const activeMobileAppId =
+    activeMobileKind === "app" && activeConsoleId
+      ? (tabs[activeConsoleId]?.metadata?.appId as string | undefined)
+      : undefined;
+  const activeMobileAppEditing = useAppsStore(state =>
+    activeMobileAppId
+      ? (state.editingByApp[activeMobileAppId] ?? false)
+      : false,
+  );
 
   // Tabs whose editing surfaces are not usable on a phone; we show a dismissible
   // notice instead of the cramped desktop UI.
@@ -1183,10 +1227,10 @@ function Editor({
             capApplied: result.pageInfo?.capApplied ?? false,
           },
         }));
-        // On mobile, jump to the Results pane so the answer is visible without
-        // the user having to switch tabs manually.
+        // On mobile, flip the console to its results pane so the answer is
+        // visible without the user having to switch manually.
         if (isMobile) {
-          setMobileTab("results");
+          setMobileConsolePane("results");
         }
         // Keep the Runs panel fresh when it's open (fire-and-forget).
         if (currentWorkspace && tabBottomPanel[tabId] === "runs") {
@@ -2186,7 +2230,8 @@ function Editor({
           }}
         >
           {/* Tab bar (desktop) / Claude-style floating window switcher
-              (mobile): round hamburger + center window pill + new-console. */}
+              (mobile): window pill + per-kind pane toggle + new-console. The
+              explorer is the Browse tab, so there is no hamburger here. */}
           {isMobile ? (
             <Box
               sx={{
@@ -2199,15 +2244,6 @@ function Editor({
                 minHeight: 52,
               }}
             >
-              <Tooltip title="Open explorer">
-                <IconButton
-                  aria-label="Open explorer"
-                  onClick={() => useUIStore.getState().openMobileDrawer()}
-                  sx={MOBILE_FLOAT_BTN_SX}
-                >
-                  <MenuIcon size={20} />
-                </IconButton>
-              </Tooltip>
               <Button
                 aria-label="Switch window"
                 onClick={e => setWindowMenuAnchor(e.currentTarget)}
@@ -2226,6 +2262,43 @@ function Editor({
                     "Console"}
                 </Box>
               </Button>
+              {activeMobileKind === "console" ? (
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={mobileConsolePane}
+                  onChange={(_event, value) => {
+                    if (value) setMobileConsolePane(value);
+                  }}
+                  aria-label="Console pane"
+                  sx={MOBILE_PANE_TOGGLE_SX}
+                >
+                  <ToggleButton value="query" aria-label="Query">
+                    <QueryPaneIcon size={19} strokeWidth={1.5} />
+                  </ToggleButton>
+                  <ToggleButton value="results" aria-label="Results">
+                    <ResultsPaneIcon size={19} strokeWidth={1.5} />
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              ) : activeMobileKind === "app" && activeMobileAppEditing ? (
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={mobileAppPane}
+                  onChange={(_event, value) => {
+                    if (value) setMobileAppPane(value);
+                  }}
+                  aria-label="App pane"
+                  sx={MOBILE_PANE_TOGGLE_SX}
+                >
+                  <ToggleButton value="preview" aria-label="Preview">
+                    <PreviewPaneIcon size={19} strokeWidth={1.5} />
+                  </ToggleButton>
+                  <ToggleButton value="terminal" aria-label="Terminal">
+                    <TerminalPaneIcon size={19} strokeWidth={1.5} />
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              ) : null}
               <Tooltip title="New console">
                 <IconButton
                   aria-label="New console"
@@ -2470,6 +2543,9 @@ function Editor({
           {(() => {
             const activeTab = activeConsoleId ? tabs[activeConsoleId] : null;
             if (!activeTab) return null;
+            // On a phone the window pill already carries the title; a second
+            // row repeating it is the space the editor needs.
+            if (isMobile) return null;
             const rendersOwnBreadcrumbs =
               activeTab.kind === "table-data" ||
               activeTab.kind === "dashboard-data-source" ||
@@ -3013,27 +3089,6 @@ function Editor({
             flexDirection: "column",
           }}
         >
-          {isMobile && (
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                minHeight: 52,
-                px: 1,
-                py: 0.75,
-              }}
-            >
-              <Tooltip title="Open explorer">
-                <IconButton
-                  aria-label="Open explorer"
-                  onClick={() => useUIStore.getState().openMobileDrawer()}
-                  sx={MOBILE_FLOAT_BTN_SX}
-                >
-                  <MenuIcon size={20} />
-                </IconButton>
-              </Tooltip>
-            </Box>
-          )}
           <Box
             sx={{
               flexGrow: 1,

--- a/app/src/components/MobileBrowse.tsx
+++ b/app/src/components/MobileBrowse.tsx
@@ -1,0 +1,374 @@
+/**
+ * The phone's Browse tab.
+ *
+ * Two levels. HOME is what the desktop rail never had: search (the command
+ * palette), a Recent list across every kind, and a grid of the explorers.
+ * EXPLORER is one explorer's panel — the same component the desktop left
+ * pane renders — under a back button. Tapping a node there opens a tab,
+ * and App.tsx switches to View.
+ */
+import { startTransition, useCallback } from "react";
+import {
+  Box,
+  ButtonBase,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ChevronLeft as BackIcon,
+  ChevronRight as OpenIcon,
+  Search as SearchIcon,
+  Settings as SettingsIcon,
+} from "lucide-react";
+import { SidebarUserMenu } from "./Sidebar";
+import { topNavigationItems, type NavigationView } from "../lib/explorer-nav";
+import { useAuth } from "../contexts/auth-context";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useUIStore, selectActiveExplorer } from "../store/uiStore";
+import { useConsoleStore } from "../store/consoleStore";
+import { useCommandPaletteStore } from "../store/commandPaletteStore";
+import {
+  useRecentsStore,
+  selectRecents,
+  type RecentEntry,
+} from "../store/recentsStore";
+import { tabKindIcon } from "../lib/entity-icons";
+import { relativeTime } from "../lib/relative-time";
+import { tabKindEntityLabel } from "../lib/entity-labels";
+import { focusDashboardTab } from "../dashboard-runtime/shell";
+import { focusNotebookTab } from "../notebook-runtime/shell";
+import { focusAppsTab } from "../apps-runtime/shell";
+
+const EXPLORER_LABELS: Partial<Record<NavigationView, string>> =
+  Object.fromEntries(topNavigationItems.map(i => [i.view, i.label]));
+
+function Identity() {
+  const { user } = useAuth();
+  const { currentWorkspace } = useWorkspace();
+  return (
+    <Box sx={{ flex: 1, minWidth: 0 }}>
+      {currentWorkspace?.name && (
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 600,
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {currentWorkspace.name}
+        </Typography>
+      )}
+      {user?.email && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            display: "block",
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {user.email}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Typography
+      variant="caption"
+      sx={{
+        display: "block",
+        px: 1,
+        pb: 0.5,
+        fontWeight: 600,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        color: "text.secondary",
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+function RecentRow({
+  entry,
+  onOpen,
+}: {
+  entry: RecentEntry;
+  onOpen: (entry: RecentEntry) => void;
+}) {
+  const Icon = tabKindIcon(entry.kind);
+  return (
+    <ButtonBase
+      onClick={() => onOpen(entry)}
+      sx={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        minHeight: 48,
+        px: 1,
+        py: 0.75,
+        borderRadius: 1,
+        textAlign: "left",
+        "&:hover": { bgcolor: "action.hover" },
+      }}
+    >
+      <Box
+        sx={{
+          width: 32,
+          height: 32,
+          borderRadius: 1,
+          border: 1,
+          borderColor: "divider",
+          bgcolor: "background.paper",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "text.secondary",
+          flexShrink: 0,
+        }}
+      >
+        <Icon size={18} strokeWidth={1.5} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+          {entry.title}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {tabKindEntityLabel(entry.kind)} · {relativeTime(entry.at)}
+        </Typography>
+      </Box>
+      <OpenIcon size={18} strokeWidth={1.5} style={{ opacity: 0.6 }} />
+    </ButtonBase>
+  );
+}
+
+export default function MobileBrowse({
+  explorer,
+}: {
+  /** The active explorer's panel — the same element the desktop pane shows. */
+  explorer: React.ReactNode;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const browseView = useUIStore(state => state.mobileBrowseView);
+  const setBrowseView = useUIStore(state => state.setMobileBrowseView);
+  const activeExplorer = useUIStore(selectActiveExplorer);
+  const setLeftPane = useUIStore(state => state.setLeftPane);
+  const openLeftPane = useUIStore(state => state.openLeftPane);
+  const setMobileConsolePane = useUIStore(state => state.setMobileConsolePane);
+  const openPalette = useCommandPaletteStore(state => state.openPalette);
+  const recents = useRecentsStore(selectRecents(workspaceId));
+  const removeRecent = useRecentsStore(state => state.remove);
+
+  const enterExplorer = useCallback(
+    (view: NavigationView) => {
+      startTransition(() => {
+        setLeftPane(view as Exclude<NavigationView, "views">);
+        openLeftPane();
+        setBrowseView("explorer");
+      });
+    },
+    [setLeftPane, openLeftPane, setBrowseView],
+  );
+
+  // Reopen by kind. Consoles are fetched from the server (their content is
+  // not in the entry); the others are focus-or-open with what the entry
+  // carries. App.tsx switches to View once a tab becomes active.
+  const openRecent = useCallback(
+    (entry: RecentEntry) => {
+      if (!workspaceId) return;
+      switch (entry.kind) {
+        case "console": {
+          setMobileConsolePane("query");
+          void useConsoleStore
+            .getState()
+            .openConsoleFromServer(workspaceId, entry.id)
+            .then(() => {
+              // The server no longer has it: the entry is stale, drop it.
+              if (!useConsoleStore.getState().tabs[entry.id]) {
+                removeRecent(workspaceId, "console", entry.id);
+              }
+            });
+          break;
+        }
+        case "dashboard":
+          focusDashboardTab(entry.id, entry.title);
+          break;
+        case "notebook":
+          focusNotebookTab(entry.id, entry.title);
+          break;
+        case "app":
+          focusAppsTab(entry.id, entry.title, entry.slug);
+          break;
+      }
+    },
+    [workspaceId, setMobileConsolePane, removeRecent],
+  );
+
+  if (browseView === "explorer") {
+    const label =
+      (activeExplorer && EXPLORER_LABELS[activeExplorer as NavigationView]) ??
+      (activeExplorer === "settings" ? "Settings" : "Explore");
+    return (
+      <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.5,
+            px: 0.5,
+            minHeight: 52,
+            borderBottom: 1,
+            borderColor: "divider",
+          }}
+        >
+          <IconButton
+            aria-label="Back to Browse"
+            onClick={() => setBrowseView("home")}
+            sx={{ width: 44, height: 44 }}
+          >
+            <BackIcon size={22} strokeWidth={1.5} />
+          </IconButton>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }} noWrap>
+            {label}
+          </Typography>
+        </Box>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>{explorer}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        overflowY: "auto",
+      }}
+    >
+      {/* Workspace + user, and the way into Settings. */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.5,
+          pt: 1.25,
+          pb: 0.75,
+        }}
+      >
+        <SidebarUserMenu tooltipPlacement="bottom" />
+        <Identity />
+        <Tooltip title="Settings">
+          <IconButton
+            aria-label="Settings"
+            onClick={() => enterExplorer("settings")}
+            sx={{ width: 40, height: 40 }}
+          >
+            <SettingsIcon size={20} strokeWidth={1.5} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {/* Search = the command palette: consoles (server search), dashboards,
+          flows, projects and open tabs, one field. */}
+      <Box sx={{ px: 1.5, pb: 1 }}>
+        <ButtonBase
+          onClick={openPalette}
+          aria-label="Search"
+          sx={{
+            width: "100%",
+            height: 40,
+            borderRadius: 20,
+            bgcolor: "action.hover",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            gap: 1,
+            px: 1.75,
+            color: "text.secondary",
+          }}
+        >
+          <SearchIcon size={18} strokeWidth={1.5} />
+          <Typography variant="body2" color="text.secondary" noWrap>
+            Search consoles, dashboards, apps…
+          </Typography>
+        </ButtonBase>
+      </Box>
+
+      {recents.length > 0 && (
+        <Box sx={{ px: 1, pt: 1 }}>
+          <SectionLabel>Recent</SectionLabel>
+          {recents.map(entry => (
+            <RecentRow
+              key={`${entry.kind}:${entry.id}`}
+              entry={entry}
+              onOpen={openRecent}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Box sx={{ px: 1, pt: recents.length > 0 ? 2 : 1, pb: 2 }}>
+        <SectionLabel>Explore</SectionLabel>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            gap: 1,
+            px: 0.5,
+          }}
+        >
+          {topNavigationItems.map(item => {
+            const Icon = item.icon;
+            return (
+              <ButtonBase
+                key={item.view}
+                onClick={() => enterExplorer(item.view)}
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 0.75,
+                  minHeight: 64,
+                  px: 0.5,
+                  py: 1,
+                  borderRadius: 1,
+                  border: 1,
+                  borderColor: "divider",
+                  bgcolor: "background.paper",
+                  color: "text.primary",
+                }}
+              >
+                <Box sx={{ color: "text.secondary", display: "flex" }}>
+                  <Icon size={20} strokeWidth={1.5} />
+                </Box>
+                <Typography
+                  variant="caption"
+                  noWrap
+                  sx={{ maxWidth: "100%", fontSize: "0.72rem" }}
+                >
+                  {item.label}
+                </Typography>
+              </ButtonBase>
+            );
+          })}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -142,7 +142,7 @@ const preloadDashboardsExplorer = () => {
 
 /**
  * Avatar button + dropdown (workspace switcher + sign out). Shared between the
- * desktop rail and the mobile AppBar / explorer drawer so logout and workspace
+ * desktop rail and the mobile Browse pane header so logout and workspace
  * switching behave identically everywhere.
  */
 export function SidebarUserMenu({
@@ -363,7 +363,7 @@ function Sidebar() {
   };
 
   // On mobile the 52px rail is hidden; navigation moves to the BottomNavigation
-  // and explorer Drawer rendered by App.tsx (which reuse the helpers above).
+  // and Browse pane rendered by App.tsx (which reuse the helpers above).
   if (isMobile) return null;
 
   return (

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import { Logout as LogoutIcon } from "@mui/icons-material";
 import { CircleUserRound as UserIcon } from "lucide-react";
-import { CHAT_ICON as ChatIcon, EXPLORER_ICONS } from "../lib/entity-icons";
+import { CHAT_ICON as ChatIcon } from "../lib/entity-icons";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useConsoleStore } from "../store/consoleStore";
 import { useAuth } from "../contexts/auth-context";
@@ -25,6 +25,11 @@ import { useRepoStore } from "../store/repoStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { trackEvent, resetIdentity } from "../lib/analytics";
 import { useIsMobile } from "../hooks/useIsMobile";
+import {
+  topNavigationItems,
+  bottomNavigationItems,
+  type NavigationView,
+} from "../lib/explorer-nav";
 import { tabRevealTarget } from "../lib/explorer-reveal";
 
 /**
@@ -68,40 +73,6 @@ const NavButton = styled(Button, {
 // Views that can appear in the sidebar navigation. Extends the core AppView
 // union with additional sidebar-specific entries that don't directly map to
 // a left-pane view managed by the app store.
-type NavigationView =
-  | "databases"
-  | "consoles"
-  | "connectors"
-  | "flows"
-  | "dashboards"
-  | "notebooks"
-  | "apps"
-  | "dbt"
-  | "source-control"
-  | "settings"
-  | "views";
-
-const topNavigationItems: {
-  view: NavigationView;
-  icon: any;
-  label: string;
-}[] = [
-  { view: "databases", icon: EXPLORER_ICONS.databases, label: "Databases" },
-  // The workspace repository, VS Code style — second in the rail, the same
-  // neighbourhood VS Code keeps its SCM icon in.
-  {
-    view: "source-control",
-    icon: EXPLORER_ICONS["source-control"],
-    label: "Source Control",
-  },
-  { view: "consoles", icon: EXPLORER_ICONS.consoles, label: "Consoles" },
-  { view: "flows", icon: EXPLORER_ICONS.flows, label: "Flows" },
-  { view: "dbt", icon: EXPLORER_ICONS.dbt, label: "Transforms" },
-  { view: "connectors", icon: EXPLORER_ICONS.connectors, label: "Connectors" },
-  { view: "dashboards", icon: EXPLORER_ICONS.dashboards, label: "Dashboards" },
-  { view: "notebooks", icon: EXPLORER_ICONS.notebooks, label: "Notebooks" },
-  { view: "apps", icon: EXPLORER_ICONS["apps"], label: "Apps" },
-];
 
 /**
  * Is the workspace checkout dirty? VS Code's SCM badge, reduced to a dot.
@@ -129,12 +100,6 @@ function useRepoDirty(): boolean {
   }, [workspaceId, fetchStatus]);
   return dirty;
 }
-
-const bottomNavigationItems: {
-  view: NavigationView;
-  icon: any;
-  label: string;
-}[] = [{ view: "settings", icon: EXPLORER_ICONS.settings, label: "Settings" }];
 
 const preloadDashboardsExplorer = () => {
   void import("./DashboardsExplorer");
@@ -247,80 +212,6 @@ export function SidebarUserMenu({
         </MenuItem>
       </Menu>
     </>
-  );
-}
-
-/**
- * Horizontal explorer switcher for the mobile drawer header. Reuses the same
- * nav item definitions as the desktop rail and switches which explorer the
- * drawer body (App.tsx `renderLeftPane`) shows. The drawer stays open so the
- * user can browse explorers; selecting a tree node closes it (handled in
- * App.tsx).
- */
-export function SidebarMobileExplorerNav() {
-  const activeExplorer = useUIStore(selectActiveExplorer);
-  const setLeftPane = useUIStore(state => state.setLeftPane);
-  const openLeftPane = useUIStore(state => state.openLeftPane);
-  const items = [...topNavigationItems, ...bottomNavigationItems];
-
-  return (
-    <Box
-      sx={{
-        display: "grid",
-        // Wrap every destination into an even grid so nothing scrolls off
-        // the right edge or gets clipped mid-label on a phone.
-        gridTemplateColumns: "repeat(auto-fill, minmax(64px, 1fr))",
-        gap: 0.25,
-        px: 0.5,
-        py: 0.25,
-      }}
-    >
-      {items.map(item => {
-        const Icon = item.icon;
-        const isActive = activeExplorer === item.view;
-        return (
-          <Button
-            key={item.view}
-            onClick={() => {
-              startTransition(() => {
-                setLeftPane(item.view as Exclude<NavigationView, "views">);
-                openLeftPane();
-              });
-            }}
-            onTouchStart={
-              item.view === "dashboards" ? preloadDashboardsExplorer : undefined
-            }
-            sx={{
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 0.25,
-              minWidth: 0,
-              width: "100%",
-              px: 0.5,
-              py: 0.5,
-              borderRadius: 1.5,
-              color: isActive ? "primary.main" : "text.secondary",
-              backgroundColor: isActive ? "action.selected" : "transparent",
-            }}
-          >
-            <Icon size={18} strokeWidth={1.5} />
-            <Typography
-              variant="caption"
-              sx={{
-                fontSize: "0.6rem",
-                lineHeight: 1.1,
-                maxWidth: "100%",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {item.label}
-            </Typography>
-          </Button>
-        );
-      })}
-    </Box>
   );
 }
 

--- a/app/src/lib/explorer-nav.ts
+++ b/app/src/lib/explorer-nav.ts
@@ -1,0 +1,48 @@
+/**
+ * The explorer rail, as data: which explorers exist, in what order, with
+ * which icon and label. Shared by the desktop rail (Sidebar) and the
+ * phone's Browse grid (MobileBrowse), so the two can never disagree.
+ */
+import { EXPLORER_ICONS } from "./entity-icons";
+
+export type NavigationView =
+  | "databases"
+  | "consoles"
+  | "connectors"
+  | "flows"
+  | "dashboards"
+  | "notebooks"
+  | "apps"
+  | "dbt"
+  | "source-control"
+  | "settings"
+  | "views";
+
+/** The explorers, in rail order. Shared with the phone's Browse grid. */
+export const topNavigationItems: {
+  view: NavigationView;
+  icon: any;
+  label: string;
+}[] = [
+  { view: "databases", icon: EXPLORER_ICONS.databases, label: "Databases" },
+  // The workspace repository, VS Code style — second in the rail, the same
+  // neighbourhood VS Code keeps its SCM icon in.
+  {
+    view: "source-control",
+    icon: EXPLORER_ICONS["source-control"],
+    label: "Source Control",
+  },
+  { view: "consoles", icon: EXPLORER_ICONS.consoles, label: "Consoles" },
+  { view: "flows", icon: EXPLORER_ICONS.flows, label: "Flows" },
+  { view: "dbt", icon: EXPLORER_ICONS.dbt, label: "Transforms" },
+  { view: "connectors", icon: EXPLORER_ICONS.connectors, label: "Connectors" },
+  { view: "dashboards", icon: EXPLORER_ICONS.dashboards, label: "Dashboards" },
+  { view: "notebooks", icon: EXPLORER_ICONS.notebooks, label: "Notebooks" },
+  { view: "apps", icon: EXPLORER_ICONS["apps"], label: "Apps" },
+];
+
+export const bottomNavigationItems: {
+  view: NavigationView;
+  icon: any;
+  label: string;
+}[] = [{ view: "settings", icon: EXPLORER_ICONS.settings, label: "Settings" }];

--- a/app/src/lib/relative-time.test.ts
+++ b/app/src/lib/relative-time.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { relativeTime } from "./relative-time";
+
+const NOW = Date.UTC(2026, 8, 2, 12, 0, 0);
+const ago = (ms: number) => NOW - ms;
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("relativeTime", () => {
+  it("rounds to the nearest sensible unit", () => {
+    expect(relativeTime(ago(10_000), NOW)).toBe("just now");
+    expect(relativeTime(ago(5 * MIN), NOW)).toBe("5 min ago");
+    expect(relativeTime(ago(2 * HOUR), NOW)).toBe("2 h ago");
+    expect(relativeTime(ago(DAY), NOW)).toBe("yesterday");
+    expect(relativeTime(ago(3 * DAY), NOW)).toBe("3 days ago");
+    expect(relativeTime(ago(31 * DAY), NOW)).toBe("a month ago");
+    expect(relativeTime(ago(95 * DAY), NOW)).toBe("3 months ago");
+  });
+
+  it("never reports the future", () => {
+    expect(relativeTime(NOW + 5 * MIN, NOW)).toBe("just now");
+  });
+});

--- a/app/src/lib/relative-time.ts
+++ b/app/src/lib/relative-time.ts
@@ -1,0 +1,14 @@
+/** "just now", "5 min ago", "2 h ago", "yesterday", "3 days ago". */
+export function relativeTime(at: number, now = Date.now()): string {
+  const sec = Math.max(0, Math.round((now - at) / 1000));
+  if (sec < 60) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min} min ago`;
+  const hours = Math.round(min / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.round(hours / 24);
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days} days ago`;
+  const months = Math.round(days / 30);
+  return months === 1 ? "a month ago" : `${months} months ago`;
+}

--- a/app/src/store/recentsStore.test.ts
+++ b/app/src/store/recentsStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_RECENTS_PER_WORKSPACE,
+  selectRecents,
+  useRecentsStore,
+} from "./recentsStore";
+
+describe("recentsStore", () => {
+  beforeEach(() => {
+    useRecentsStore.getState().reset();
+  });
+
+  it("puts the latest activation first and dedupes by kind + id", () => {
+    const s = useRecentsStore.getState();
+    s.record("w1", { kind: "console", id: "c1", title: "First" });
+    s.record("w1", { kind: "dashboard", id: "d1", title: "Board" });
+    s.record("w1", { kind: "console", id: "c1", title: "First (renamed)" });
+    const list = selectRecents("w1")(useRecentsStore.getState());
+    expect(list.map(e => `${e.kind}:${e.id}`)).toEqual([
+      "console:c1",
+      "dashboard:d1",
+    ]);
+    expect(list[0].title).toBe("First (renamed)");
+  });
+
+  it("is scoped per workspace", () => {
+    const s = useRecentsStore.getState();
+    s.record("w1", { kind: "app", id: "a1", title: "App", slug: "app" });
+    s.record("w2", { kind: "notebook", id: "n1", title: "Notes" });
+    expect(selectRecents("w1")(useRecentsStore.getState())).toHaveLength(1);
+    expect(selectRecents("w2")(useRecentsStore.getState())).toHaveLength(1);
+    expect(selectRecents(undefined)(useRecentsStore.getState())).toEqual([]);
+  });
+
+  it("caps the list and drops the oldest", () => {
+    const s = useRecentsStore.getState();
+    for (let i = 0; i < MAX_RECENTS_PER_WORKSPACE + 3; i += 1) {
+      s.record("w1", { kind: "console", id: `c${i}`, title: `C${i}` });
+    }
+    const list = selectRecents("w1")(useRecentsStore.getState());
+    expect(list).toHaveLength(MAX_RECENTS_PER_WORKSPACE);
+    expect(list[0].id).toBe(`c${MAX_RECENTS_PER_WORKSPACE + 2}`);
+    expect(list.some(e => e.id === "c0")).toBe(false);
+  });
+
+  it("removes an entry", () => {
+    const s = useRecentsStore.getState();
+    s.record("w1", { kind: "console", id: "c1", title: "First" });
+    s.remove("w1", "console", "c1");
+    expect(selectRecents("w1")(useRecentsStore.getState())).toEqual([]);
+  });
+});

--- a/app/src/store/recentsStore.ts
+++ b/app/src/store/recentsStore.ts
@@ -1,0 +1,84 @@
+/**
+ * Recently opened entities, per workspace — the "Recent" list on the phone's
+ * Browse tab. Nothing server-side knows "what this person looked at last",
+ * so the shell records it locally every time a tab becomes active: a phone
+ * that opened the app after a desktop session shows nothing, but anything
+ * touched on this device is one tap away.
+ *
+ * Only durable, reopenable kinds are recorded — the entry must carry enough
+ * to reopen the entity on a fresh page (id + title, plus the app slug), and
+ * transient tabs (settings, diffs, plans) would only be noise.
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+
+export type RecentKind = "console" | "dashboard" | "notebook" | "app";
+
+export interface RecentEntry {
+  kind: RecentKind;
+  /** The entity id (console id, dashboard id, ...). */
+  id: string;
+  title: string;
+  /** Apps: the slug rides along so the URL upgrades on reopen. */
+  slug?: string;
+  /** Last activation, epoch ms. */
+  at: number;
+}
+
+/** Newest first; older entries fall off the end. */
+export const MAX_RECENTS_PER_WORKSPACE = 12;
+
+interface RecentsState {
+  byWorkspace: Record<string, RecentEntry[]>;
+}
+
+interface RecentsActions {
+  /** Move-or-insert to the front of the workspace's list, refreshing title. */
+  record: (workspaceId: string, entry: Omit<RecentEntry, "at">) => void;
+  /** Drop an entry (the entity no longer exists). */
+  remove: (workspaceId: string, kind: RecentKind, id: string) => void;
+  reset: () => void;
+}
+
+type RecentsStore = RecentsState & RecentsActions;
+
+export const useRecentsStore = create<RecentsStore>()(
+  persist(
+    immer(set => ({
+      byWorkspace: {},
+
+      record: (workspaceId, entry) =>
+        set(state => {
+          const list = state.byWorkspace[workspaceId] ?? [];
+          const rest = list.filter(
+            e => !(e.kind === entry.kind && e.id === entry.id),
+          );
+          state.byWorkspace[workspaceId] = [
+            { ...entry, at: Date.now() },
+            ...rest,
+          ].slice(0, MAX_RECENTS_PER_WORKSPACE);
+        }),
+
+      remove: (workspaceId, kind, id) =>
+        set(state => {
+          const list = state.byWorkspace[workspaceId];
+          if (!list) return;
+          state.byWorkspace[workspaceId] = list.filter(
+            e => !(e.kind === kind && e.id === id),
+          );
+        }),
+
+      reset: () => set({ byWorkspace: {} }),
+    })),
+    { name: "recents-store" },
+  ),
+);
+
+/** Empty-array constant so selectors return a stable reference. */
+const NO_RECENTS: RecentEntry[] = [];
+
+export const selectRecents =
+  (workspaceId: string | undefined) =>
+  (state: RecentsStore): RecentEntry[] =>
+    workspaceId ? (state.byWorkspace[workspaceId] ?? NO_RECENTS) : NO_RECENTS;

--- a/app/src/store/uiStore.mobile.test.ts
+++ b/app/src/store/uiStore.mobile.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUIStore } from "./uiStore";
+
+/**
+ * The phone shell's navigation contract: a FIXED bottom nav (Browse · View ·
+ * Ask) plus per-kind panes inside View. Nothing here may leak into the
+ * persisted slice — a reload lands on Ask with the console on its query.
+ */
+describe("uiStore mobile navigation", () => {
+  beforeEach(() => {
+    useUIStore.getState().reset();
+  });
+
+  it("starts on Ask with the console on query and the app on preview", () => {
+    const s = useUIStore.getState();
+    expect(s.mobileTab).toBe("ask");
+    expect(s.mobileConsolePane).toBe("query");
+    expect(s.mobileAppPane).toBe("preview");
+  });
+
+  it("switches tabs without touching the per-kind panes", () => {
+    const s = useUIStore.getState();
+    s.setMobileConsolePane("results");
+    s.setMobileAppPane("terminal");
+    s.setMobileTab("browse");
+    expect(useUIStore.getState().mobileTab).toBe("browse");
+    expect(useUIStore.getState().mobileConsolePane).toBe("results");
+    expect(useUIStore.getState().mobileAppPane).toBe("terminal");
+    s.setMobileTab("view");
+    expect(useUIStore.getState().mobileTab).toBe("view");
+  });
+
+  it("does not persist any mobile navigation state", () => {
+    const s = useUIStore.getState();
+    s.setMobileTab("view");
+    s.setMobileConsolePane("results");
+    s.setMobileAppPane("terminal");
+    // The store persists under this key; the desktop layout fields are in
+    // there, the phone navigation must not be.
+    const raw = localStorage.getItem("ui-store");
+    expect(raw).not.toBeNull();
+    expect(raw).toContain("leftPaneOpen");
+    expect(raw).not.toContain("mobileTab");
+    expect(raw).not.toContain("mobileConsolePane");
+    expect(raw).not.toContain("mobileAppPane");
+  });
+});

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -34,13 +34,19 @@ interface ActiveEditorContent {
 
 /**
  * Which full-screen pane is shown on mobile (< md). Desktop ignores this and
- * keeps its 4-column flex shell. "explore" is surfaced via the explorer Drawer
- * rather than a dedicated content pane (see `setMobileTab`).
+ * keeps its 4-column flex shell. The bottom nav is FIXED — Browse · View ·
+ * Ask, the same left-to-right order as the desktop panes (explorer, editor,
+ * chat) — so what a tab means never depends on what is open. Per-kind
+ * switches (a console's query/results, an app's preview/terminal) live inside
+ * the View pane, beside the window pill, not in the nav.
  */
-export type MobileTab = "ask" | "editor" | "results" | "explore";
+export type MobileTab = "browse" | "view" | "ask";
 
-/** Mobile overlay drawer state. Only the explorer drawer exists today. */
-export type MobileDrawer = "none" | "explorer";
+/** Which half of a console tab the mobile View pane shows. */
+export type MobileConsolePane = "query" | "results";
+
+/** Which half of an app tab in dev mode the mobile View pane shows. */
+export type MobileAppPane = "preview" | "terminal";
 
 interface UIState {
   // Navigation
@@ -54,7 +60,8 @@ interface UIState {
   // Mobile (< md) navigation — ephemeral, never persisted. Desktop layout is
   // driven by leftPaneOpen/rightPaneOpen; mobile is driven by mobileTab.
   mobileTab: MobileTab;
-  mobileDrawer: MobileDrawer;
+  mobileConsolePane: MobileConsolePane;
+  mobileAppPane: MobileAppPane;
 
   // Loading indicators (keyed by operation name)
   loading: Record<string, boolean>;
@@ -83,8 +90,8 @@ interface UIActions {
 
   // Mobile navigation
   setMobileTab: (tab: MobileTab) => void;
-  openMobileDrawer: () => void;
-  closeMobileDrawer: () => void;
+  setMobileConsolePane: (pane: MobileConsolePane) => void;
+  setMobileAppPane: (pane: MobileAppPane) => void;
 
   // Loading state
   setLoading: (key: string, value: boolean) => void;
@@ -110,7 +117,8 @@ const initialState: UIState = {
   leftPaneWidthPx: null,
   rightPaneWidthPx: null,
   mobileTab: "ask",
-  mobileDrawer: "none",
+  mobileConsolePane: "query",
+  mobileAppPane: "preview",
   loading: {},
   activeEditorContent: undefined,
   currentWorkspaceId: null,
@@ -174,27 +182,21 @@ export const useUIStore = create<UIStore>()(
           }
         }),
 
-      // Mobile navigation. Selecting "explore" opens the explorer Drawer as an
-      // overlay rather than swapping the underlying content pane, so closing
-      // the drawer returns to the previous ask/editor/results view.
+      // Mobile navigation — plain setters; the nav is fixed and nothing here
+      // is persisted (see partialize), so a reload lands on Ask.
       setMobileTab: tab =>
         set(state => {
-          if (tab === "explore") {
-            state.mobileDrawer = "explorer";
-          } else {
-            state.mobileTab = tab;
-            state.mobileDrawer = "none";
-          }
+          state.mobileTab = tab;
         }),
 
-      openMobileDrawer: () =>
+      setMobileConsolePane: pane =>
         set(state => {
-          state.mobileDrawer = "explorer";
+          state.mobileConsolePane = pane;
         }),
 
-      closeMobileDrawer: () =>
+      setMobileAppPane: pane =>
         set(state => {
-          state.mobileDrawer = "none";
+          state.mobileAppPane = pane;
         }),
 
       // Loading state

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -42,6 +42,12 @@ interface ActiveEditorContent {
  */
 export type MobileTab = "browse" | "view" | "ask";
 
+/**
+ * The Browse tab has two levels: its home (search, recents, the explorer
+ * grid) and one explorer's tree, entered from a tile and left via back.
+ */
+export type MobileBrowseView = "home" | "explorer";
+
 /** Which half of a console tab the mobile View pane shows. */
 export type MobileConsolePane = "query" | "results";
 
@@ -60,6 +66,7 @@ interface UIState {
   // Mobile (< md) navigation — ephemeral, never persisted. Desktop layout is
   // driven by leftPaneOpen/rightPaneOpen; mobile is driven by mobileTab.
   mobileTab: MobileTab;
+  mobileBrowseView: MobileBrowseView;
   mobileConsolePane: MobileConsolePane;
   mobileAppPane: MobileAppPane;
 
@@ -90,6 +97,7 @@ interface UIActions {
 
   // Mobile navigation
   setMobileTab: (tab: MobileTab) => void;
+  setMobileBrowseView: (view: MobileBrowseView) => void;
   setMobileConsolePane: (pane: MobileConsolePane) => void;
   setMobileAppPane: (pane: MobileAppPane) => void;
 
@@ -117,6 +125,7 @@ const initialState: UIState = {
   leftPaneWidthPx: null,
   rightPaneWidthPx: null,
   mobileTab: "ask",
+  mobileBrowseView: "home",
   mobileConsolePane: "query",
   mobileAppPane: "preview",
   loading: {},
@@ -187,6 +196,11 @@ export const useUIStore = create<UIStore>()(
       setMobileTab: tab =>
         set(state => {
           state.mobileTab = tab;
+        }),
+
+      setMobileBrowseView: view =>
+        set(state => {
+          state.mobileBrowseView = view;
         }),
 
       setMobileConsolePane: pane =>


### PR DESCRIPTION
## Why

The phone layout (< md) shipped as a console-only shell: a bottom nav of Ask / Editor / Results whose tabs only meant something for a console tab, an explorer hidden behind a hamburger drawer, and a console toolbar that wrapped into three rows before the first line of SQL. Apps, dashboards and terminals had no place in it.

Mockups the change was validated against: https://claude.ai/code/artifact/894ced29-d0e9-43c5-82fa-923c7ed31963

## What

The bottom nav is now **fixed** — Browse · View · Ask, the desktop pane order (explorer, editor, chat) — so what a tab means never depends on what is open.

- **Browse** is a home screen, not a drawer: workspace/user header with the Settings gear, a search field that opens the command palette (full-screen on phones), a **Recent** list of the last twelve consoles, dashboards, notebooks and apps activated on this device (new `recentsStore`, persisted locally, recorded on every tab activation, a tap reopens by kind), and an **Explore** grid of the explorers in rail order. A tile opens that explorer's panel under a back button; tapping a node lands in View. The hamburger is gone from every pane header. The rail's item list moves to `lib/explorer-nav` so desktop and phone share one definition.
- **View** shows the active tab. The per-kind switch is an icon toggle beside the window pill, on the same row: Query / Results for a console, Preview / Terminal for an app in dev mode, nothing for kinds with one view. The breadcrumb row is dropped on phones (the pill carries the title).
- **Ask** is chat; console references in chat open View on the query pane.
- **Console**: one-row phone toolbar — connection selector across the width, save, and an overflow menu holding undo, redo, version history, share, schedule, save-as, rename and info. Run stays the FAB. The desktop toolbar is hidden by CSS rather than unmounted so desktop behaviour is untouched.
- **Apps**: on a phone the workbench is preview OR terminal (both mounted, display toggled). The terminal's session column becomes a chip row (dev server, shells, detached ghosts, +) and a key bar above the soft keyboard sends Esc, Tab, ^C, arrows and Return through a pty writer each `TerminalPanel` now exposes via an input ref. The session list is built once and shared by both layouts.
- **Dashboards** are forced into view mode below the breakpoint; the edit toggle is hidden there.
- **uiStore**: `mobileTab` is `browse | view | ask`, `mobileBrowseView` is `home | explorer`; the drawer state is gone; `mobileConsolePane` and `mobileAppPane` carry the per-kind switch. None of it is persisted (test added).

## Not in this PR

- The breakpoint is unchanged (900px), so an iPad in portrait still gets the phone shell.
- Recents are device-local: a phone shows nothing from a desktop session until something is opened on the phone.

## Verification

- `tsc --noEmit`, `eslint` (only the five pre-existing warnings in untouched files) and `vitest run` (454 tests, including new tests for `recentsStore`, `relativeTime` and the mobile nav state) pass in `app/`.
- Not yet exercised on a real phone: this was built in a cloud session without an `.env`. Please open the branch on a phone and check Browse (search, recents, a tile and back), the console pill toggle and the terminal key bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8CeYVb9voFUTMgH6E1Xa