### PR TITLE
feat(apps): previews read the connected repo, never write it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,6 +227,9 @@ APPS_SESSIONS_ROOT=
 # prod-cloned DBs that carry REAL customer bindings, so they treat bindings as
 # inert metadata (local-only bare repos) unless this explicit opt-in is set
 # (never sync it; use only with repos you own): APPS_CONNECTED_REPO_PUSH=allow
+# READ-ONLY middle ground (what PR previews run, apps.md §26): clone and fetch
+# the connected repo so apps/consoles/skills/dbt/flows/notebooks show as in
+# production, but never push to it: APPS_CONNECTED_REPO_READ=allow
 
 # Local development login shortcut (OFF unless set; NEVER set this in a
 # deployed environment — the API refuses to boot if it is set alongside

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -192,9 +192,16 @@ jobs:
       E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
       APPS_SANDBOX_PROVIDER: e2b
       APPS_E2B_TEMPLATE: mako-apps
-      # Apps cloud repos (Mako-hosted GitHub storage under mako-ai-cloud).
-      # All previews share the staging DB, so they share the "staging" prefix:
-      # same workspace -> same repo regardless of which PR created it.
+      # Apps connected repos, READ-ONLY (apps.md §26). The preview DB is a
+      # copy of production, so it carries every workspace's real GitHub repo
+      # binding. Reading that repo (clone on a cache miss, fetch before reads
+      # and writes) is what makes apps, consoles, skills, dbt, flows and
+      # notebooks show up on a preview exactly as in production — the API
+      # derives all of them from the repo, not from Mongo. Pushing is left
+      # OFF (no APPS_CONNECTED_REPO_PUSH, no APPS_REQUIRE_CONNECTED_REPO):
+      # a commit made on a preview stays in that instance's local repo and
+      # must never land in a customer's repository.
+      APPS_CONNECTED_REPO_READ: allow
       TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
       LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
@@ -614,6 +621,7 @@ jobs:
             --set-env-vars E2B_API_KEY=${E2B_API_KEY} \
             --set-env-vars APPS_SANDBOX_PROVIDER=${APPS_SANDBOX_PROVIDER} \
             --set-env-vars APPS_E2B_TEMPLATE=${APPS_E2B_TEMPLATE} \
+            --set-env-vars APPS_CONNECTED_REPO_READ=${APPS_CONNECTED_REPO_READ} \
             --set-env-vars TAVILY_API_KEY=${TAVILY_API_KEY} \
             --set-env-vars LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY} \
             --set-env-vars LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY} \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ The cloud environment starts with no `.env`. Bootstrap:
    Secret Manager, but `APPS_CONNECTED_REPO_PUSH` is opt-in per machine —
    without it, mirror pushes to customer repos are refused (safe default for
    a fresh environment); set it deliberately where pushes belong.
+   `APPS_CONNECTED_REPO_READ=allow` is the read-only middle: workspace repos
+   are cloned and fetched from the connected GitHub repo (so apps, consoles,
+   skills, dbt, flows and notebooks appear as in production) but never
+   pushed — what PR previews run (`apps.md` §26).
 3. Sandboxes cannot reach the environment's localhost:8080, so `pnpm dev`
    needs the cloudflared tunnel (`scripts/sandbox-tunnel.sh`); without a named
    tunnel it supervises an ephemeral trycloudflare URL. Terminals work without

--- a/api/src/apps/cloud-repo.service.test.ts
+++ b/api/src/apps/cloud-repo.service.test.ts
@@ -63,8 +63,10 @@ import {
 import {
   adoptConnectedRepo,
   ensureCommitLocally,
+  ensureLocalRepo,
   fetchFromCloud,
   mirrorPushNow,
+  queueMirrorPush,
   resolveMirrorTarget,
   freshenForServe,
 } from "./cloud-repo.service";
@@ -94,6 +96,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.APPS_CONNECTED_REPO_PUSH;
+  delete process.env.APPS_CONNECTED_REPO_READ;
 });
 
 async function makeBareRemote(owner: string, repo: string): Promise<string> {
@@ -470,5 +473,97 @@ describe("freshenForServe", () => {
     state.binding = null; // no connected repo — nothing to freshen from
     await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
     await expect(freshenForServe(workspaceId, 0)).resolves.toBeUndefined();
+  });
+});
+
+describe("read-only connected tier (APPS_CONNECTED_REPO_READ=allow, previews §26)", () => {
+  beforeEach(() => {
+    delete process.env.APPS_CONNECTED_REPO_PUSH;
+    process.env.APPS_CONNECTED_REPO_READ = "allow";
+  });
+
+  it("resolves the binding as the mirror", async () => {
+    state.binding = { owner: "acme", repo: "site" };
+    const target = await resolveMirrorTarget(workspaceId);
+    expect(target).toMatchObject({ kind: "connected", owner: "acme" });
+  });
+
+  it("restores a missing local repo by cloning the connected repo", async () => {
+    const remoteDir = path.join(remotesRoot, "acme", "restore-ro.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await initRepo(remoteDir, { "apps/prod-app/mako.json": "{}" });
+    state.binding = { owner: "acme", repo: "restore-ro" };
+    expect(await repoExists(repoDirFor(workspaceId))).toBe(false);
+
+    await ensureLocalRepo(workspaceId);
+
+    expect(await repoExists(repoDirFor(workspaceId))).toBe(true);
+    const entries = await listTree(repoDirFor(workspaceId), DEFAULT_BRANCH);
+    expect(entries.map(e => e.path)).toContain("apps/prod-app/mako.json");
+    expect(await headOf(repoDirFor(workspaceId))).toBe(await headOf(remoteDir));
+  });
+
+  it("follows the connected repo on fetch but never pushes local commits", async () => {
+    const remoteDir = path.join(remotesRoot, "acme", "follow-ro.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await initRepo(remoteDir, { "README.md": "prod" });
+    state.binding = { owner: "acme", repo: "follow-ro" };
+    await ensureLocalRepo(workspaceId);
+    const remoteHead = await headOf(remoteDir);
+
+    // A preview commit: stays local, both push entry points are no-ops.
+    const local = await commitFiles(
+      repoDirFor(workspaceId),
+      { "apps/preview-only/mako.json": "{}" },
+      "made on a preview",
+    );
+    await mirrorPushNow(workspaceId);
+    queueMirrorPush(workspaceId);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(await headOf(remoteDir)).toBe(remoteHead);
+    expect(await headOf(repoDirFor(workspaceId))).toBe(local);
+
+    // A merely-ahead local branch is left alone by a fetch…
+    await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
+    expect(await headOf(repoDirFor(workspaceId))).toBe(local);
+
+    // …and the remote moving ahead of a clean local branch fast-forwards it.
+    await updateRefCas(
+      repoDirFor(workspaceId),
+      `refs/heads/${DEFAULT_BRANCH}`,
+      remoteHead as string,
+      local,
+    );
+    const theirs = await commitFiles(
+      remoteDir,
+      { "apps/from-github/mako.json": "{}" },
+      "pushed to GitHub",
+    );
+    await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
+    expect(await headOf(repoDirFor(workspaceId))).toBe(theirs);
+  });
+
+  it("adoption imports (a clone) but defers seeding (a push)", async () => {
+    const remoteDir = path.join(remotesRoot, "acme", "import-ro.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await initRepo(remoteDir, { "apps/imported/mako.json": "{}" });
+    state.binding = { owner: "acme", repo: "import-ro" };
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe(
+      "imported",
+    );
+    expect(
+      (await listTree(repoDirFor(workspaceId), DEFAULT_BRANCH)).map(
+        e => e.path,
+      ),
+    ).toContain("apps/imported/mako.json");
+
+    const seedWorkspace = freshWorkspaceId();
+    const emptyRemote = await makeBareRemote("acme", "seed-ro");
+    state.binding = { owner: "acme", repo: "seed-ro" };
+    await initRepo(repoDirFor(seedWorkspace), { "apps/a/mako.json": "{}" });
+    expect(await adoptConnectedRepo(seedWorkspace, state.binding)).toBe(
+      "deferred",
+    );
+    expect(await headOf(emptyRemote)).toBeNull();
   });
 });

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -12,11 +12,16 @@
  * mirror is reset to it with its commits parked under `refs/mako/diverged/*`
  * (`fetchFromCloud`).
  *
- * The connected tier only engages on production (APPS_REQUIRE_CONNECTED_REPO)
- * or under the explicit APPS_CONNECTED_REPO_PUSH=allow opt-in. Previews and
- * dev run on prod-cloned databases that carry REAL customer bindings, and a
- * test commit must never land in a customer repo — gated environments treat
- * the binding as inert metadata and keep local-only bare repos.
+ * The connected tier engages on production (APPS_REQUIRE_CONNECTED_REPO) or
+ * under the explicit APPS_CONNECTED_REPO_PUSH=allow opt-in. Previews and dev
+ * run on prod-cloned databases that carry REAL customer bindings, and a test
+ * commit must never land in a customer repo — gated environments treat the
+ * binding as inert metadata and keep local-only bare repos. In between sits
+ * the READ-ONLY tier (APPS_CONNECTED_REPO_READ=allow, what PR previews run):
+ * the connected repo is cloned on a cache miss and fetched before reads and
+ * writes, so the preview shows the workspace exactly as production does, but
+ * `pushMirror` never runs — commits made there stay in the instance's local
+ * repo and die with it (§26).
  *
  * The local bare repo remains the working store the API reads from; the
  * mirror is the durable replica. Mirror pushes run after commits/merges
@@ -28,7 +33,11 @@ import { getWorkspaceRepo } from "../services/workspace-repos.service";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runGit } from "./git";
-import { appsConnectedRepoPushEnv, appsRequireConnectedRepo } from "./config";
+import {
+  appsConnectedRepoPushEnv,
+  appsConnectedRepoReadEnv,
+  appsRequireConnectedRepo,
+} from "./config";
 import {
   DEFAULT_BRANCH,
   initRepo,
@@ -51,12 +60,34 @@ function remoteUrl(owner: string, repo: string): string {
 }
 
 /**
- * Whether connected customer repos participate as mirrors in THIS
- * environment. Prod (APPS_REQUIRE_CONNECTED_REPO=true), plus an explicit
- * dev opt-in — see the module doc for why previews must stay out.
+ * Whether connected customer repos are READ in THIS environment: cloned on a
+ * cache miss (`ensureLocalRepo`) and fetched before reads and writes
+ * (`fetchFromCloud`). True wherever pushes are enabled, and under the
+ * read-only opt-in previews run with — see the module doc.
  */
 export function connectedTierEnabled(): boolean {
+  return connectedRepoPushEnabled() || appsConnectedRepoReadEnv() === "allow";
+}
+
+/**
+ * Whether commits made here are PUSHED to the connected repo. Prod
+ * (APPS_REQUIRE_CONNECTED_REPO=true), plus the explicit dev opt-in. A
+ * read-only environment restores and follows the repo but never writes to
+ * it: a preview commit must not land in a customer's GitHub repository.
+ */
+export function connectedRepoPushEnabled(): boolean {
   return appsRequireConnectedRepo() || appsConnectedRepoPushEnv() === "allow";
+}
+
+/** True in the read-only tier: reads engage, pushes are refused. */
+function mirrorPushesRefusedHere(workspaceId: string): boolean {
+  if (connectedRepoPushEnabled()) return false;
+  if (connectedTierEnabled()) {
+    logger.debug("Apps mirror push skipped: connected repo is read-only here", {
+      workspaceId,
+    });
+  }
+  return true;
 }
 
 export type MirrorTarget = {
@@ -251,7 +282,7 @@ async function pushMirror(
  * seen.
  */
 export function queueMirrorPush(workspaceId: string): void {
-  if (!connectedTierEnabled()) return;
+  if (mirrorPushesRefusedHere(workspaceId)) return;
   void schedulePush(workspaceId).catch(error => {
     logger.warn("Apps mirror push failed", {
       workspaceId,
@@ -267,7 +298,7 @@ export function queueMirrorPush(workspaceId: string): void {
  * guaranteed to start after the caller's commit.
  */
 export async function mirrorPushNow(workspaceId: string): Promise<void> {
-  if (!connectedTierEnabled()) return;
+  if (mirrorPushesRefusedHere(workspaceId)) return;
   await schedulePush(workspaceId);
 }
 
@@ -607,8 +638,9 @@ export type ConnectedRepoAdoption =
  *  - both have content → refuse. Choosing whose history wins is not ours to
  *    guess; the caller rolls the binding back.
  *
- * Where the connected tier is gated off (previews/dev on prod-cloned DBs) the
- * binding is stored as inert metadata: "deferred".
+ * Where the connected tier is gated off (dev on prod-cloned DBs) the binding
+ * is stored as inert metadata: "deferred". The read-only tier (previews) can
+ * IMPORT — that is a clone — but never SEED, which is a push: "deferred" too.
  */
 export async function adoptConnectedRepo(
   workspaceId: string,
@@ -653,6 +685,13 @@ export async function adoptConnectedRepo(
     return "imported";
   }
   if (hasHistory) {
+    if (!connectedRepoPushEnabled()) {
+      logger.info(
+        "Apps workspace history NOT seeded into its connected repo: pushes are refused here",
+        { workspaceId, repo: label },
+      );
+      return "deferred";
+    }
     await mirrorPushNow(workspaceId);
     logger.info("Apps workspace history seeded into its connected repo", {
       workspaceId,

--- a/api/src/apps/config.ts
+++ b/api/src/apps/config.ts
@@ -53,6 +53,19 @@ export function appsConnectedRepoPushEnv(): string | undefined {
 }
 
 /**
+ * Opt-in for READING customer-connected repos without ever pushing to them:
+ * the local bare repo is restored from the connected repo on a cache miss and
+ * fetched from it before reads and writes, so apps, consoles, skills, dbt,
+ * flows and notebooks show exactly as in production — but every commit made
+ * here stays local. PR previews run this way (apps.md §26): they hold the
+ * production bindings, and a preview commit must never land in a customer's
+ * repository. Implied by the push opt-in and by production.
+ */
+export function appsConnectedRepoReadEnv(): string | undefined {
+  return appsEnv("CONNECTED_REPO_READ");
+}
+
+/**
  * Production: a workspace must connect its own GitHub repository before
  * anything is saved to git — there is no Mako-hosted tier (apps.md §17).
  * Unset (dev, previews, tests) = local bare repos, nothing durable.

--- a/api/src/apps/worktree.service.ts
+++ b/api/src/apps/worktree.service.ts
@@ -817,7 +817,9 @@ export async function createProject(input: {
   }
   // Durable tier (§13.17): the connected repo. When one is bound, the
   // durable push is REQUIRED — on serverless hosts the local repo is an
-  // ephemeral cache. Hosts without a binding (dev, previews) stay local-only.
+  // ephemeral cache. Hosts without a binding (dev) stay local-only, and the
+  // read-only tier (previews, §26) resolves the mirror but `mirrorPushNow`
+  // is a no-op there: the app exists on that instance and nowhere else.
   try {
     if (mirror) {
       await mirrorPushNow(input.workspaceId);

--- a/api/src/services/flow-config.service.ts
+++ b/api/src/services/flow-config.service.ts
@@ -21,7 +21,7 @@
 import { loggers } from "../logging";
 import { authorForUser } from "../apps/workspace-consoles.service";
 import {
-  connectedTierEnabled,
+  connectedRepoPushEnabled,
   ensureLocalRepo,
   freshenBeforeMainWrite,
   resolveMirrorTarget,
@@ -177,11 +177,11 @@ export async function deleteFlowFile(
 export async function assertMirrorReachable(
   workspaceId: string,
 ): Promise<{ ok: true; mainOid: string } | { ok: false; reason: string }> {
-  if (!connectedTierEnabled()) {
+  if (!connectedRepoPushEnabled()) {
     return {
       ok: false,
       reason:
-        "connected-repo tier is disabled here (set APPS_CONNECTED_REPO_PUSH=allow); " +
+        "connected-repo pushes are disabled here (set APPS_CONNECTED_REPO_PUSH=allow); " +
         "an export would commit locally and push nothing",
     };
   }

--- a/apps.md
+++ b/apps.md
@@ -3017,3 +3017,43 @@ on.
   pins because they only fail on old code for the trivial reason that the
   route did not exist yet. #912 now enforces the first half of this
   mechanically.
+
+## 26. Previews read the connected repo, never write it (2026-09-02)
+
+The pr-950 preview showed every console and dashboard of the RealAdvisor
+workspace and an Apps rail that said "No apps yet". Nothing was broken; the
+asymmetry was §17 doing exactly what it said. Dashboards are Mongo documents
+and the preview DB is a copy of production. Consoles are a hybrid — git is
+the file, `SavedConsole` is the derived index, and the index still carries
+the query text, so the list and the body both serve from the copied rows
+(the repo→index sync never touches a repo without the `consoles/README.md`
+marker, and the preview's starter repo had none). Apps have no such index:
+the list IS `apps/<slug>/mako.json` on main, `AppProject` is only an overlay
+joined by slug, and a preview never cloned the connected repo because §17
+gated the whole connected tier behind `APPS_REQUIRE_CONNECTED_REPO` (prod)
+or `APPS_CONNECTED_REPO_PUSH=allow` (a per-machine dev opt-in). One gate for
+two different things: cloning a customer's repo, and pushing into it.
+
+Now there are two gates. `connectedTierEnabled()` answers "may this
+environment READ the connected repo" — `ensureLocalRepo` clones on a cache
+miss, `fetchFromCloud` fast-forwards before reads and writes, adoption may
+IMPORT. `connectedRepoPushEnabled()` answers "may commits made here be
+PUSHED there" — `queueMirrorPush`, `mirrorPushNow`, and adoption's SEED. Prod
+and the push opt-in enable both. The new `APPS_CONNECTED_REPO_READ=allow`
+enables reads alone, and that is what the preview deploy sets: the preview
+restores every workspace repo from GitHub (the GitHub App credentials it
+already carries mint the installation token), so apps, consoles, skills,
+`PROMPT.md`, dbt, flows and `.deepnote` notebooks all appear as in
+production, and every path that would push logs a debug line and returns.
+
+What a preview commit means under this tier: it lands on the instance's
+local main, `fetchFromCloud` leaves a merely-ahead local branch alone, and it
+dies with the tmpfs — the same "throwaway by design" §17 promised, now on
+top of real content instead of an empty starter repo. Should GitHub move
+while a preview holds local commits, the diverged-branch rule applies
+unchanged: the mirror wins, the local tip is parked under
+`refs/mako/diverged/*` (which, with pushes refused, is where it stays).
+`assertMirrorReachable` (the flows export) checks the push gate, since an
+export that cannot push is the silent no-op it exists to catch. The variable
+is on the never-sync list next to its push sibling: whether a machine clones
+customer repositories is that machine's decision.

--- a/scripts/secrets.ts
+++ b/scripts/secrets.ts
@@ -55,6 +55,9 @@ const LOCAL_ONLY = new Set([
   // dev DBs are prod clones carrying real customer bindings, so a synced
   // "allow" would arm mirror pushes on every machine that pulls .env.
   "APPS_CONNECTED_REPO_PUSH",
+  // Same reasoning for the read-only variant: whether a machine clones
+  // customer repos at all is that machine's decision, not a shared value.
+  "APPS_CONNECTED_REPO_READ",
   // A named tunnel is one machine's identity; its credentials live in that
   // machine's ~/.cloudflared and the hostname is useless anywhere else.
   "APPS_TUNNEL_NAME",


### PR DESCRIPTION
## Why

The pr-950 preview showed every console and dashboard of the RealAdvisor workspace and an Apps rail that said "No apps yet". Nothing was broken in that PR: dashboards are Mongo documents and the preview DB is a copy of production; consoles serve their list and body from the copied `SavedConsole` index (git is the file, Mongo the derived index that still carries the query text); apps have no such index — the list **is** `apps/<slug>/mako.json` on the workspace repo's main, and a preview never cloned that repo.

It never cloned it because one gate covered two different things. `APPS_REQUIRE_CONNECTED_REPO` (prod) or `APPS_CONNECTED_REPO_PUSH=allow` (per-machine dev opt-in) switched on the whole connected tier: cloning a customer's repo **and** pushing into it. Previews deliberately set neither (a preview commit must never land in a customer repo), so they got neither, and initialised an empty starter repo instead.

## What

Two gates instead of one, in `api/src/apps/cloud-repo.service.ts`:

- `connectedTierEnabled()` — may this environment **read** the connected repo: `ensureLocalRepo` clones on a cache miss, `fetchFromCloud` fast-forwards before reads and writes, adoption may *import*.
- `connectedRepoPushEnabled()` (new) — may commits made here be **pushed** there: `queueMirrorPush`, `mirrorPushNow`, adoption's *seed*, and the flows-export `assertMirrorReachable` check.

Prod and the push opt-in enable both. The new **`APPS_CONNECTED_REPO_READ=allow`** enables reads alone. Every push path in the read-only tier logs a debug line and returns.

The preview deploy job sets it. A preview now restores every workspace repo from GitHub (the GitHub App credentials it already carries mint the installation token), so **apps, consoles, skills, `PROMPT.md`, dbt, flows and `.deepnote` notebooks all show as in production** — everything the API derives from the repo, not just apps. Commits made on a preview land on that instance's local main and die with it, exactly what §17 promised, now on top of real content.

Also: the stale "mako-ai-cloud" comment in the preview job is replaced; `.env.example`, `CLAUDE.md` and `scripts/secrets.ts` (never-sync list, next to the push sibling) document the variable; `apps.md` §26 records the reasoning.

## Verification

- `api` vitest apps suite: 19 files, 195 tests pass — including five new tests for the read-only tier (resolves the binding; restores a missing repo by cloning; follows the remote on fetch and never pushes a local commit; adoption imports but defers seeding, remote left untouched).
- `flows-repo-required`, `flows-writethrough`, `flow-config-mongoose`, `console-save-guards` tsx tests pass.
- `tsc -p tsconfig.build.json` clean; eslint and prettier clean on changed files. No route or schema change, so no OpenAPI sync.
- Not exercised on a live preview from this cloud session. The preview built from **this** PR is the real check: its Apps rail should list the workspace's production apps, and the Cloud Run logs should show "Apps local repo restored from its mirror" and no "Apps mirror push" lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qAvMJtnRkQ46r6Z2hK3DX

---
_Generated by [Claude Code](https://claude.ai/code/session_013qAvMJtnRkQ46r6Z2hK3DX)_