### PR TITLE
fix(connectors): render workspace-provided icons

### DIFF
--- a/api/src/routes/connector-catalog-tenancy.test.ts
+++ b/api/src/routes/connector-catalog-tenancy.test.ts
@@ -33,6 +33,17 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 const ctx = vi.hoisted(() => ({
   signedIn: true,
   memberOf: [] as string[],
+  workspaceIcon: `<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 1h1z"/></svg>`,
+}));
+
+vi.mock("../connectors/workspace/resolver", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../connectors/workspace/resolver")
+  >()),
+  readConnectorFolder: vi.fn(
+    async () =>
+      new Map([["icon.svg", new TextEncoder().encode(ctx.workspaceIcon)]]),
+  ),
 }));
 
 vi.mock("../auth/unified-auth.middleware", () => ({
@@ -164,5 +175,32 @@ describe("GET /api/connectors/{type}/schema", () => {
         encrypted: true,
       },
     ]);
+  });
+});
+
+describe("GET /api/connectors/{type}/icon.svg", () => {
+  it("returns the repo icon only to a workspace member", async () => {
+    ctx.memberOf = [WS_THEIRS];
+    const response = await app.request(
+      `/api/connectors/ws:acme-crm/icon.svg?workspaceId=${WS_THEIRS}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "default-src 'none'",
+    );
+    expect(await response.text()).toBe(ctx.workspaceIcon);
+  });
+
+  it("does not reveal the repo icon to a non-member", async () => {
+    ctx.memberOf = [];
+    const response = await app.request(
+      `/api/connectors/ws:acme-crm/icon.svg?workspaceId=${WS_THEIRS}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(await response.text()).not.toBe(ctx.workspaceIcon);
   });
 });

--- a/api/src/routes/connectors.ts
+++ b/api/src/routes/connectors.ts
@@ -13,6 +13,10 @@ import {
   workspaceConnectorForm,
 } from "../connectors/workspace/catalog";
 import {
+  loadConnectorDefinition,
+  readConnectorFolder,
+} from "../connectors/workspace/resolver";
+import {
   createRouter,
   errorJson,
   jsonContent,
@@ -41,8 +45,10 @@ export const connectorRoutes = createRouter();
  * either gets the built-in catalog — the routes stay genuinely public — but
  * never another tenant's connectors.
  */
-async function memberWorkspaceId(c: Context): Promise<string | null> {
-  const requested = c.req.header("x-workspace-id");
+async function memberWorkspaceId(
+  c: Context,
+  requested = c.req.header("x-workspace-id"),
+): Promise<string | null> {
   if (!requested || !Types.ObjectId.isValid(requested)) return null;
 
   // The middleware answers with a 401/redirect for an anonymous caller. That
@@ -325,15 +331,43 @@ connectorRoutes.openapi(
       404: errorJson("Icon not found"),
     },
   }),
-  c => {
+  async c => {
     const { type } = c.req.valid("param");
 
-    // An `<img>` carries no workspace header, so a workspace connector's own
-    // icon cannot be fetched from its repo here without putting a tenant id
-    // in a public URL. It gets a generated monogram instead: derived purely
-    // from the slug, so it exposes nothing and still gives the picker a
-    // stable, distinguishable mark per connector.
+    // `<img>` cannot send the workspace header used by catalog requests. The
+    // UI therefore includes the active workspace as a query parameter; it is
+    // only a selector, never authorization. Authenticate the same-origin
+    // session and prove membership before reading the tenant's repo. Callers
+    // without that proof retain the non-sensitive generated monogram.
     if (isWorkspaceConnectorType(type)) {
+      const requested = c.req.query("workspaceId");
+      const workspaceId = requested
+        ? await memberWorkspaceId(c, requested)
+        : null;
+      if (workspaceId) {
+        try {
+          const slug = type.slice(3);
+          const definition = await loadConnectorDefinition(workspaceId, slug);
+          const files = await readConnectorFolder(
+            workspaceId,
+            slug,
+            definition.sha,
+          );
+          const icon = files.get("icon.svg");
+          if (icon) {
+            return c.body(icon, 200, {
+              "Content-Type": "image/svg+xml",
+              "Cache-Control": "private, no-store",
+              "Content-Security-Policy":
+                "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+            });
+          }
+        } catch {
+          // A missing/stale icon must not break every place that renders a
+          // connector. Reconciliation will surface connector failures; the
+          // image endpoint keeps the stable fallback.
+        }
+      }
       return c.body(monogramSvg(type.slice(3)), 200, {
         "Content-Type": "image/svg+xml",
         "Cache-Control": "public, max-age=3600",

--- a/app/src/components/ConnectorExplorer.tsx
+++ b/app/src/components/ConnectorExplorer.tsx
@@ -26,6 +26,7 @@ import ResourceTree, {
 } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { connectorIconUrl } from "../lib/connector-icon";
 
 interface Connector {
   _id: string;
@@ -94,7 +95,7 @@ function ConnectorExplorer() {
         title: source.name,
         content: contentKey,
         kind: "connectors",
-        icon: `/api/connectors/${source.type}/icon.svg`,
+        icon: connectorIconUrl(source.type, currentWorkspace?.id),
       });
       setActiveTab(id);
     } else {
@@ -147,7 +148,7 @@ function ConnectorExplorer() {
     return (
       <Box
         component="img"
-        src={`/api/connectors/${src.type}/icon.svg`}
+        src={connectorIconUrl(src.type, currentWorkspace?.id)}
         alt={`${src.type} icon`}
         sx={{ width: 20, height: 20, display: "block", flexShrink: 0 }}
       />

--- a/app/src/components/ConnectorForm.tsx
+++ b/app/src/components/ConnectorForm.tsx
@@ -33,6 +33,7 @@ import {
 // Zustand stores
 import { useConnectorStore } from "../store/connectorStore";
 import { useConnectorCatalogStore } from "../store/connectorCatalogStore";
+import { connectorIconUrl } from "../lib/connector-icon";
 
 export interface ConnectorFieldSchema {
   name: string;
@@ -903,7 +904,7 @@ function ConnectorForm({
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Box
                     component="img"
-                    src={`/api/connectors/${connector.type}/icon.svg`}
+                    src={connectorIconUrl(connector.type, currentWorkspace?.id)}
                     alt={`${connector.type} icon`}
                     sx={{ width: 20, height: 20 }}
                   />
@@ -1100,7 +1101,7 @@ function ConnectorForm({
           >
             <Box
               component="img"
-              src={`/api/connectors/${selectedType}/icon.svg`}
+              src={connectorIconUrl(selectedType, currentWorkspace?.id)}
               alt={`${selectedType} icon`}
               sx={{ width: 32, height: 32 }}
             />

--- a/app/src/components/ConnectorTab.tsx
+++ b/app/src/components/ConnectorTab.tsx
@@ -7,6 +7,7 @@ import { useConnectorCatalogStore } from "../store/connectorCatalogStore";
 import { useConnectorEntitiesStore } from "../store/connectorEntitiesStore";
 import { useConnectorStore } from "../store/connectorStore";
 import { trackEvent } from "../lib/analytics";
+import { connectorIconUrl } from "../lib/connector-icon";
 
 interface ConnectorTabProps {
   /**
@@ -72,9 +73,9 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
   // Helper to update the tab icon based on connector type
   const updateTabIcon = useCallback(
     (type: string) => {
-      updateIcon(tabId, `/api/connectors/${type}/icon.svg`);
+      updateIcon(tabId, connectorIconUrl(type, currentWorkspace?.id));
     },
-    [updateIcon, tabId],
+    [updateIcon, tabId, currentWorkspace?.id],
   );
 
   /* ------------------ effects ------------------ */

--- a/app/src/lib/connector-icon.test.ts
+++ b/app/src/lib/connector-icon.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { connectorIconUrl } from "./connector-icon";
+
+describe("connectorIconUrl", () => {
+  it("scopes workspace connector icons to the active workspace", () => {
+    expect(connectorIconUrl("ws:acme/crm", "workspace 1")).toBe(
+      "/api/connectors/ws%3Aacme%2Fcrm/icon.svg?workspaceId=workspace%201",
+    );
+  });
+
+  it("keeps built-in connector icons public", () => {
+    expect(connectorIconUrl("stripe", "workspace 1")).toBe(
+      "/api/connectors/stripe/icon.svg",
+    );
+  });
+});

--- a/app/src/lib/connector-icon.ts
+++ b/app/src/lib/connector-icon.ts
@@ -1,0 +1,9 @@
+export function connectorIconUrl(
+  type: string,
+  workspaceId?: string | null,
+): string {
+  const base = `/api/connectors/${encodeURIComponent(type)}/icon.svg`;
+  return type.startsWith("ws:") && workspaceId
+    ? `${base}?workspaceId=${encodeURIComponent(workspaceId)}`
+    : base;
+}


### PR DESCRIPTION
## Summary
- serve a workspace connector’s repo-provided `icon.svg` only after session authentication and membership verification
- keep the generated monogram fallback for anonymous and unauthorized callers
- scope workspace icon URLs in the connector UI and protect SVG responses with private caching and a restrictive CSP

## Verification
- `pnpm --filter api run build`
- `pnpm --filter app run build`
- `pnpm --filter api exec vitest run src/routes/connector-catalog-tenancy.test.ts`
- `pnpm --filter app exec vitest run src/lib/connector-icon.test.ts`