### PR TITLE
fix(skills): adoption writes declared entities to SKILL.md, never the derived index

### DIFF
--- a/api/src/apps/workspace-skills.service.test.ts
+++ b/api/src/apps/workspace-skills.service.test.ts
@@ -222,4 +222,58 @@ describe("adoption (migration path)", () => {
       "Adopt workspace skills",
     );
   });
+
+  it("writes the DECLARED entities to the file, never the derived index", async () => {
+    // A row as the extractor leaves it: the author declared one entity, the
+    // index holds that plus every tokenised body word.
+    await Skill.create({
+      workspaceId: new Types.ObjectId(WS),
+      name: "mrr_rules",
+      loadWhen: "MRR questions",
+      body: "MRR is working already; null months are pending.",
+      declaredEntities: ["mrr"],
+      entities: ["mrr", "working", "already", "null", "months", "pending"],
+      scopeType: "workspace",
+      createdBy: "agent",
+      suppressed: false,
+      useCount: 0,
+    });
+    // A row from before `declaredEntities` existed: nothing was declared.
+    await Skill.create({
+      workspaceId: new Types.ObjectId(WS),
+      name: "legacy_rules",
+      loadWhen: "legacy questions",
+      body: "Legacy body with several tokenised words.",
+      entities: ["legacy", "body", "several", "tokenised", "words"],
+      scopeType: "workspace",
+      createdBy: "agent",
+      suppressed: false,
+      useCount: 0,
+    });
+    await adoptWorkspaceSkills(WS);
+
+    const declared = parseSkillFile(
+      "mrr_rules",
+      (await fileAt(skillFilePath("mrr_rules"))) ?? "",
+    );
+    expect(declared?.entities).toEqual(["mrr"]);
+    const legacy = await fileAt(skillFilePath("legacy_rules"));
+    expect(legacy).not.toContain("entities:");
+  });
+});
+
+describe("index sync keeps declared and derived apart", () => {
+  it("stores the file's list as declaredEntities and the union as entities", async () => {
+    await commitSkillSave(WS, {
+      ...skill("feed_rules", "Offers come from lead_agents rows."),
+      entities: ["feed"],
+    });
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    const row = await Skill.findOne({ name: "feed_rules" });
+    expect(row?.declaredEntities).toEqual(["feed"]);
+    expect(row?.entities).toEqual(
+      expect.arrayContaining(["feed", "lead_agents"]),
+    );
+    expect(row?.entities.length ?? 0).toBeGreaterThan(1);
+  });
 });

--- a/api/src/apps/workspace-skills.service.ts
+++ b/api/src/apps/workspace-skills.service.ts
@@ -312,6 +312,7 @@ export async function syncSkillsIndexFromRepo(
         loadWhen: file.loadWhen,
         body: file.body,
         entities,
+        declaredEntities: file.entities,
         loadWhenEmbedding: embedding,
         embeddingModel: model,
         scopeType: "workspace",
@@ -325,7 +326,8 @@ export async function syncSkillsIndexFromRepo(
       row.loadWhen === file.loadWhen &&
       row.body === file.body &&
       row.suppressed === file.suppressed &&
-      sameEntities(row.entities ?? [], entities);
+      sameEntities(row.entities ?? [], entities) &&
+      sameEntities(row.declaredEntities ?? [], file.entities);
     if (unchanged) continue;
     if (row.body !== file.body) {
       row.previousBody = row.body;
@@ -341,6 +343,7 @@ export async function syncSkillsIndexFromRepo(
     row.loadWhen = file.loadWhen;
     row.body = file.body;
     row.entities = entities;
+    row.declaredEntities = file.entities;
     row.suppressed = file.suppressed;
     await row.save();
   }
@@ -369,9 +372,12 @@ export async function adoptWorkspaceSkills(workspaceId: string): Promise<{
   const rows = (await Skill.find({
     workspaceId: new Types.ObjectId(workspaceId),
   })
-    .select("name loadWhen body entities suppressed")
+    .select("name loadWhen body declaredEntities suppressed")
     .lean()) as Array<
-    Pick<ISkill, "name" | "loadWhen" | "body" | "entities" | "suppressed">
+    Pick<
+      ISkill,
+      "name" | "loadWhen" | "body" | "declaredEntities" | "suppressed"
+    >
   >;
   const repoDir = await ensureWorkspaceRepo(workspaceId);
   const alreadyAdopted = await skillsAdopted(repoDir);
@@ -386,10 +392,12 @@ export async function adoptWorkspaceSkills(workspaceId: string): Promise<{
     }
     const path = skillFilePath(row.name);
     if ((await readRepoFile(repoDir, path)) !== null) continue;
+    // The file carries what the author declared, never the derived
+    // retrieval index (`entities` = declared ∪ extracted body tokens).
     writes[path] = serializeSkillFile({
       name: row.name,
       loadWhen: row.loadWhen,
-      entities: row.entities ?? [],
+      entities: row.declaredEntities ?? [],
       suppressed: !!row.suppressed,
       body: row.body,
     });

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4259,6 +4259,10 @@ export const Dashboard = mongoose.model<IDashboard>(
  *   - loadWhen: short trigger description (what query/task it applies to)
  *   - body:     schema facts + procedural hints (SQL shapes, gotchas, etc.)
  *   - entities: tokens used for retrieval (authored + extracted)
+ *   - declaredEntities: only the authored ones — what the SKILL.md file
+ *     carries. `entities` is derived from it and must never be written
+ *     back to git (that is how the 2026-08-31 adoption put ~200 tokenised
+ *     body words into every skill's frontmatter).
  *
  * Retrieval combines entity overlap with semantic similarity on `loadWhen`.
  * The full index (name + loadWhen) is injected into the agent's system prompt
@@ -4274,6 +4278,8 @@ export interface ISkill extends Document {
   loadWhen: string;
   body: string;
   entities: string[];
+  /** Author-declared entities as written in SKILL.md; absent on rows that predate the field. */
+  declaredEntities?: string[];
   /** Embedding over `loadWhen` only. Bodies are too long to embed usefully. */
   loadWhenEmbedding?: number[];
   embeddingModel?: string;
@@ -4308,6 +4314,7 @@ const SkillSchema = new Schema<ISkill>(
     loadWhen: { type: String, required: true, trim: true, maxlength: 500 },
     body: { type: String, required: true, maxlength: 20000 },
     entities: { type: [String], default: [] },
+    declaredEntities: { type: [String], default: [] },
     loadWhenEmbedding: { type: [Number], select: false },
     embeddingModel: { type: String },
     scopeType: {

--- a/api/src/services/skills.service.test.ts
+++ b/api/src/services/skills.service.test.ts
@@ -97,6 +97,34 @@ describe("agent saves are proposals", () => {
   });
 });
 
+describe("declared vs derived entities", () => {
+  it("the file carries only what was declared; Mongo carries the union", async () => {
+    const result = await saveSkill(
+      WS,
+      {
+        ...input("feed_rules"),
+        body: "Offers are lead_agents rows; claims set claimed_at.",
+        entities: ["feed"],
+      },
+      "u1",
+      { origin: "user" },
+    );
+    expect(result.success).toBe(true);
+    const row = await Skill.findOne({ name: "feed_rules" });
+    expect(row?.declaredEntities).toEqual(["feed"]);
+    expect(row?.entities).toEqual(
+      expect.arrayContaining(["feed", "lead_agents", "claimed_at"]),
+    );
+    const blob = await readBlob(
+      repoDirFor(WS),
+      `refs/heads/${DEFAULT_BRANCH}`,
+      "skills/feed_rules/SKILL.md",
+    );
+    expect(blob.contents).toContain("entities:\n  - feed\n");
+    expect(blob.contents).not.toContain("lead_agents\n");
+  });
+});
+
 describe("index cap + honest counters", () => {
   it("shows at most 30 workspace entries and reports the omission count", async () => {
     for (let i = 0; i < 35; i++) {

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -204,7 +204,8 @@ export async function saveSkill(
   const body = input.body.trim();
 
   const extracted = extractEntities(`${loadWhen}\n${body}`);
-  const entities = unionEntities(input.entities, extracted);
+  const declaredEntities = unionEntities(input.entities, []);
+  const entities = unionEntities(declaredEntities, extracted);
 
   // Compute embedding over loadWhen ONLY. Body content is too long and noisy
   // for the embedding to represent usefully; entity overlap carries body-
@@ -237,14 +238,18 @@ export async function saveSkill(
     const loadAdoptable = async () =>
       (
         (await Skill.find({ workspaceId: new Types.ObjectId(workspaceId) })
-          .select("name loadWhen body entities suppressed")
+          .select("name loadWhen body declaredEntities suppressed")
           .lean()) as Array<
-          Pick<ISkill, "name" | "loadWhen" | "body" | "entities" | "suppressed">
+          Pick<
+            ISkill,
+            "name" | "loadWhen" | "body" | "declaredEntities" | "suppressed"
+          >
         >
       ).map(s => ({
         name: s.name,
         loadWhen: s.loadWhen,
-        entities: s.entities ?? [],
+        // Adoption writes the declared list, never the derived index.
+        entities: s.declaredEntities ?? [],
         suppressed: !!s.suppressed,
         body: s.body,
       }));
@@ -255,7 +260,7 @@ export async function saveSkill(
         loadWhen,
         // The file carries the author-DECLARED entities; the Mongo row below
         // carries the declared ∪ extracted union the retrieval uses.
-        entities: unionEntities(input.entities, []),
+        entities: declaredEntities,
         suppressed: pendingApproval || !!existing?.suppressed,
         body,
       },
@@ -276,6 +281,7 @@ export async function saveSkill(
       loadWhen,
       body,
       entities,
+      declaredEntities,
       loadWhenEmbedding: embedding ?? undefined,
       embeddingModel: model ?? undefined,
       scopeType: "workspace",
@@ -300,6 +306,7 @@ export async function saveSkill(
   existing.loadWhen = loadWhen;
   existing.body = body;
   existing.entities = entities;
+  existing.declaredEntities = declaredEntities;
   if (embedding) {
     existing.loadWhenEmbedding = embedding;
     existing.embeddingModel = model ?? undefined;


### PR DESCRIPTION
## Bug

`adoptWorkspaceSkills` (called by the `2026-08-31-190000_workspace_skills_to_git` migration) and `saveSkill`'s lazy-adoption `loadAdoptable` both serialised **`row.entities`** into the file's `entities:` frontmatter. But `entities` on the Mongo row is the *retrieval index* — author-declared ∪ `extractEntities(loadWhen + body)`, where the extractor keeps every alphanumeric run ≥3 chars minus a 106-word stoplist. `saveSkill`'s own write path already emitted only the declared list (`unionEntities(input.entities, [])`, with the comment explaining why); the two adoption paths didn't get the same split.

Observed on the RealAdvisor workspace after the migration: 88 of 110 skills carry a median of **184 entities** (max 587) — `working`, `already`, `instead`, `during`, `'null'`, `pending` — 17,625 lines of frontmatter over 3,425 lines of body. Files written by `save_skill` afterwards are clean (4–8), which is what pointed at adoption rather than the tool.

The lazy path is still live: any workspace that connects a repo from now on adopts the same way.

## Fix

Keep the declared list as its own field, `declaredEntities`, next to the derived `entities`:

- `workspace-schema.ts` — `declaredEntities: string[]` on `ISkill` + schema (default `[]`).
- `workspace-skills.service.ts` — `syncSkillsIndexFromRepo` stores the file's list as `declaredEntities` and the union as `entities` (and treats a declared-list change as a change); `adoptWorkspaceSkills` serialises `declaredEntities`.
- `skills.service.ts` — `saveSkill` computes `declaredEntities` once, writes it to the file, stores it on create/update; `loadAdoptable` serialises it.

Rows that predate the field adopt with no `entities:` line — nothing was ever declared on them, so that is the honest output. The ranker is untouched: `entities` still carries the union.

## Tests

- `workspace-skills.service.test.ts` — adoption emits only declared entities and omits the key for a pre-field row; sync stores the file list as `declaredEntities` and `lead_agents` (extracted from the body) lands in `entities` only.
- `skills.service.test.ts` — `saveSkill` file carries only the declared list; Mongo carries the union.

`vitest run --config vitest.apps.config.ts` on both files: 13/13 pass. `tsc --noEmit` reports no errors in touched files (the remaining errors are pre-existing in `agent-thread.service.test.ts`, `message-sanitizer.test.ts`, `mongoose-dirty-paths.test.ts`).

## Not in this PR

The extractor itself. It is a tokenizer (`entity-extraction.ts` header: "LLM-based extraction is a future upgrade"), so the derived index will keep containing body words — this PR only stops them leaking into git. A better stoplist, or keeping only identifiers and multi-word phrases, is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAqUddVYbyx29sPbFULL4q
