### PR TITLE
fix(apps): reconnecting a repo that shares the workspace's history; dbt config written to git from the first commit

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -63,6 +63,7 @@ import {
 } from "../../dbt/dbt-working-tree.service";
 import { resolveDbtRules } from "../../dbt/dbt-rules.service";
 import {
+  commitDbtEnvironmentsFile,
   commitDbtJobFile,
   deleteDbtJobFile,
   reserveJobSlug,
@@ -647,6 +648,9 @@ export const createDbtServerTools = (
             defaultEnvironment: environmentName,
             createdBy: "agent",
           });
+          // Environments/settings live in dbt/environments.yml (apps.md §23)
+          // from the first commit — not only after the first edit.
+          await commitDbtEnvironmentsFile(project, actingUserId);
 
           const scaffold = buildStarterScaffold(name);
           await commitDbtFiles(

--- a/api/src/apps/cloud-repo.service.test.ts
+++ b/api/src/apps/cloud-repo.service.test.ts
@@ -8,7 +8,9 @@
  *    connected tier is enabled (prod / explicit opt-in) — previews and dev on
  *    prod-cloned DBs must treat customer bindings as inert
  *  - connect-time adoption: seed an empty repo, import a non-empty repo into
- *    an empty workspace, refuse when both sides have content
+ *    an empty workspace, reconnect a repo that shares the workspace's
+ *    history (unlink never touches the local repo, so a re-link finds both
+ *    sides populated), refuse only when both sides have UNRELATED content
  *  - a customer remote is NEVER force-pushed: a diverged remote branch
  *    survives our push attempt; only refs/mako/* may move non-fast-forward
  *  - webhook fetch fast-forwards the local branch, leaves a merely-ahead
@@ -194,7 +196,90 @@ describe("adoptConnectedRepo", () => {
     expect(entries.map(e => e.path)).toContain("apps/imported/mako.json");
   });
 
-  it("refuses when both the repo and the workspace have content", async () => {
+  it("reconnects a repo that already holds the workspace's history", async () => {
+    // Connect, disconnect (the local repo stays), connect again.
+    const remoteDir = await makeBareRemote("acme", "relink-same");
+    state.binding = { owner: "acme", repo: "relink-same" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe("seeded");
+    const head = await headOf(repoDirFor(workspaceId));
+
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe(
+      "reconnected",
+    );
+    expect(await headOf(repoDirFor(workspaceId))).toBe(head);
+    expect(await headOf(remoteDir)).toBe(head);
+  });
+
+  it("reconnect pushes commits made while the repo was disconnected", async () => {
+    const remoteDir = await makeBareRemote("acme", "relink-behind");
+    state.binding = { owner: "acme", repo: "relink-behind" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await adoptConnectedRepo(workspaceId, state.binding);
+    const local = await commitFiles(
+      repoDirFor(workspaceId),
+      { "apps/b/mako.json": "{}" },
+      "made while unlinked",
+    );
+
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe(
+      "reconnected",
+    );
+    expect(await headOf(remoteDir)).toBe(local);
+  });
+
+  it("reconnect fast-forwards to a repo that moved on GitHub meanwhile", async () => {
+    const remoteDir = await makeBareRemote("acme", "relink-ahead");
+    state.binding = { owner: "acme", repo: "relink-ahead" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await adoptConnectedRepo(workspaceId, state.binding);
+    const theirs = await commitFiles(
+      remoteDir,
+      { "apps/c/mako.json": "{}" },
+      "pushed to GitHub while unlinked",
+    );
+
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe(
+      "reconnected",
+    );
+    expect(await headOf(repoDirFor(workspaceId))).toBe(theirs);
+    const entries = await listTree(repoDirFor(workspaceId), DEFAULT_BRANCH);
+    expect(entries.map(e => e.path)).toContain("apps/c/mako.json");
+  });
+
+  it("reconnect on a diverged shared history lets the mirror win and parks the local tip", async () => {
+    const remoteDir = await makeBareRemote("acme", "relink-split");
+    state.binding = { owner: "acme", repo: "relink-split" };
+    await initRepo(repoDirFor(workspaceId), { "apps/a/mako.json": "{}" });
+    await adoptConnectedRepo(workspaceId, state.binding);
+    const theirs = await commitFiles(
+      remoteDir,
+      { "theirs.txt": "x" },
+      "theirs",
+    );
+    const ours = await commitFiles(
+      repoDirFor(workspaceId),
+      { "ours.txt": "y" },
+      "ours",
+    );
+
+    expect(await adoptConnectedRepo(workspaceId, state.binding)).toBe(
+      "reconnected",
+    );
+    expect(await headOf(repoDirFor(workspaceId))).toBe(theirs);
+    expect(await headOf(remoteDir)).toBe(theirs);
+    const parked = (
+      await runGit([
+        "-C",
+        remoteDir,
+        "rev-parse",
+        `refs/mako/diverged/${DEFAULT_BRANCH}/${ours.slice(0, 12)}`,
+      ])
+    ).stdout.trim();
+    expect(parked).toBe(ours);
+  });
+
+  it("refuses when both the repo and the workspace have unrelated content", async () => {
     const remoteDir = path.join(remotesRoot, "acme", "busy.git");
     await fs.mkdir(path.dirname(remoteDir), { recursive: true });
     await initRepo(remoteDir, { "README.md": "not mako" });

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -587,9 +587,45 @@ export async function assertTreeAtMirrorMain(
   }
 }
 
+/**
+ * Whether the remote's default branch and the local one descend from a common
+ * commit. Fetching the remote tip into the local object store is harmless (a
+ * fetch never moves a local ref) and is what the reconcile step needs anyway.
+ * A remote with content but no default branch, or an unreachable remote,
+ * answers "no": the caller then refuses, which is the safe side.
+ */
+async function sharesHistoryWith(
+  repoDir: string,
+  url: string,
+  token: string | undefined,
+): Promise<boolean> {
+  try {
+    await runGit([
+      "-C",
+      repoDir,
+      ...authArgs(token),
+      "fetch",
+      "--quiet",
+      url,
+      `refs/heads/${DEFAULT_BRANCH}`,
+    ]);
+    await runGit([
+      "-C",
+      repoDir,
+      "merge-base",
+      "FETCH_HEAD",
+      `refs/heads/${DEFAULT_BRANCH}`,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export type ConnectedRepoAdoption =
   | "imported"
   | "seeded"
+  | "reconnected"
   | "fresh"
   | "deferred";
 
@@ -604,8 +640,15 @@ export type ConnectedRepoAdoption =
  *  - workspace has content, repo is empty → SEED: the workspace history is
  *    pushed into the repo; it is the mirror from here on.
  *  - both empty → nothing to reconcile; the first commit seeds the repo.
- *  - both have content → refuse. Choosing whose history wins is not ours to
- *    guess; the caller rolls the binding back.
+ *  - both have content and share history → RECONNECT: this is the
+ *    disconnect-then-connect-again case (the repo WAS this workspace's
+ *    mirror; unlinking never touches the local repo, so both sides hold the
+ *    same commits). The two tips are reconciled the way every later fetch
+ *    reconciles them (`fetchFromCloud`: remote ahead → fast-forward, local
+ *    ahead → push, diverged → the mirror wins with the local tip parked
+ *    under refs/mako/diverged/*, nothing dropped), then pushed.
+ *  - both have content and NO common ancestor → refuse. Choosing whose
+ *    history wins is not ours to guess; the caller rolls the binding back.
  *
  * Where the connected tier is gated off (previews/dev on prod-cloned DBs) the
  * binding is stored as inert metadata: "deferred".
@@ -636,11 +679,25 @@ export async function adoptConnectedRepo(
   const remoteEmpty = lsRemote.stdout.trim() === "";
 
   if (!remoteEmpty && hasHistory) {
-    throw new Error(
-      `${label} already has content and this workspace already has apps. ` +
-        "Connect an empty repository (the workspace's history will be pushed into it), " +
-        "or import a non-empty repository into a workspace that has no apps yet.",
-    );
+    if (!(await sharesHistoryWith(repoDir, url, token))) {
+      throw new Error(
+        `${label} already has content unrelated to this workspace's history, and this workspace already has apps. ` +
+          "Reconnect the repository this workspace was previously connected to, " +
+          "connect an empty repository (the workspace's history will be pushed into it), " +
+          "or import a non-empty repository into a workspace that has no apps yet.",
+      );
+    }
+    // RECONNECT: same lineage on both sides. Reconcile main exactly as a
+    // webhook fetch would, then push so the mirror carries whatever the
+    // local side has that it lacks (local-ahead commits, refs/mako/*, a
+    // parked diverged tip).
+    await fetchFromCloud(workspaceId, DEFAULT_BRANCH);
+    await mirrorPushNow(workspaceId);
+    logger.info("Apps workspace reconnected to a repo sharing its history", {
+      workspaceId,
+      repo: label,
+    });
+    return "reconnected";
   }
   if (!remoteEmpty) {
     // IMPORT: drop the (history-less) local slot and adopt the repo's history.

--- a/api/src/dbt/dbt-config.service.test.ts
+++ b/api/src/dbt/dbt-config.service.test.ts
@@ -136,6 +136,17 @@ describe("write-through", () => {
     await deleteDbtJobFile(project, job.slug);
     expect(await fileAt(jobFilePath(job.slug!))).toBeNull();
   });
+
+  it("commitDbtJobFile leaves the row unstamped when nothing was written", async () => {
+    // No repo → no file → the row must not claim a sha the push-sync would
+    // then treat as "already level".
+    await fs.rm(repoDirFor(WS.toString()), { recursive: true, force: true });
+    const project = await seedProject();
+    const job = await seedJob(project, "Nightly");
+    await commitDbtJobFile(project, job);
+    const fresh = await DbtJob.findById(job._id);
+    expect(fresh?.sourceBlobSha).toBeFalsy();
+  });
 });
 
 describe("sync from repo", () => {

--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -118,7 +118,7 @@ async function commitConfig(
   mutation: { writes?: Record<string, string>; deletes?: string[] },
   message: string,
   author?: GitAuthor,
-): Promise<void> {
+): Promise<boolean> {
   // Freshened by repoDirIfExists: config-as-code commits land on main, so
   // they are judged against the mirror's main rather than this instance's
   // cache (#916, moved up to the choke point so the reads get it too —
@@ -126,13 +126,15 @@ async function commitConfig(
   // cost two sequential fetches per write).
   const repoDir = await repoDirIfExists(workspaceId);
   // No repo (pre-§17 workspace): Mongo remains the only home — nothing to
-  // write through. RealAdvisor and every §17-era workspace has one.
-  if (!repoDir) return;
+  // write through. RealAdvisor and every §17-era workspace has one. Callers
+  // get `false` so they never record a file that was not written.
+  if (!repoDir) return false;
   const result = await commitBlobsOnBranch(repoDir, DEFAULT_BRANCH, mutation, {
     message,
     author,
   });
   if (!result.unchanged) queueMirrorPush(workspaceId);
+  return true;
 }
 
 /** Reserve a unique slug for a new job and stamp it on the row fields. */
@@ -160,15 +162,19 @@ export async function commitDbtJobFile(
   if (!job.slug) return; // pre-adoption row; the migration stamps slugs
   const contents = serializeJobFile(jobToFile(job));
   const sha = blobOid(contents);
-  if (job.sourceBlobSha !== sha) {
-    await DbtJob.updateOne({ _id: job._id }, { $set: { sourceBlobSha: sha } });
-  }
-  await commitConfig(
+  const written = await commitConfig(
     project.workspaceId.toString(),
     { writes: { [jobFilePath(job.slug)]: contents } },
     messageOverride ?? `dbt: job "${job.name}" (${job.slug})`,
     actorUserId ? await authorForUser(actorUserId) : undefined,
   );
+  // Stamp the row AFTER the file exists. Stamping first meant a failed or
+  // skipped commit (no repo) left the row claiming a sha for a file that was
+  // never written, and the push-sync short-circuits on a matching sha — so
+  // the row could never be repaired from the file.
+  if (written && job.sourceBlobSha !== sha) {
+    await DbtJob.updateOne({ _id: job._id }, { $set: { sourceBlobSha: sha } });
+  }
 }
 
 export async function deleteDbtJobFile(

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -384,6 +384,9 @@ dbtRoutes.post("/projects", async (c: AuthenticatedContext) => {
       defaultEnvironment: body.defaultEnvironment,
       createdBy: userId,
     });
+    // Environments/settings live in dbt/environments.yml (apps.md §23) from
+    // the first commit — not only after the first edit.
+    await commitDbtEnvironmentsFile(project, userId);
 
     // Scaffold straight into the workspace repo: dbt/ appears as one commit
     // on the creator's session branch. A pre-existing dbt/dbt_project.yml

--- a/app/src/components/GitHubConnectionSection.tsx
+++ b/app/src/components/GitHubConnectionSection.tsx
@@ -175,9 +175,11 @@ export default function GitHubConnectionSection() {
           ? "Repository imported — its apps/ folders now appear as apps."
           : result.adoption === "seeded"
             ? "Repository connected — the workspace's existing apps were pushed into it."
-            : result.adoption === "deferred"
-              ? "Repository linked, but mirroring is INACTIVE in this environment — preview and dev deployments never push to customer repos. It engages in production."
-              : "Repository connected — it is now where this workspace's apps are stored.",
+            : result.adoption === "reconnected"
+              ? "Repository reconnected — it shares this workspace's history, so both sides were brought back in sync."
+              : result.adoption === "deferred"
+                ? "Repository linked, but mirroring is INACTIVE in this environment — preview and dev deployments never push to customer repos. It engages in production."
+                : "Repository connected — it is now where this workspace's apps are stored.",
       );
     } else {
       setError(result.error ?? "Failed to connect");

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -292,7 +292,7 @@ interface AppsStore {
     ok: boolean;
     error?: string;
     /** §13.17 connect-time reconciliation outcome. */
-    adoption?: "imported" | "seeded" | "fresh" | "deferred";
+    adoption?: "imported" | "seeded" | "reconnected" | "fresh" | "deferred";
   }>;
   disconnectRepo: (
     workspaceId: string,
@@ -689,7 +689,12 @@ export const useAppsStore = create<AppsStore>()(
             }),
           ) as {
             repo?: AppRepoBinding;
-            adoption?: "imported" | "seeded" | "fresh" | "deferred";
+            adoption?:
+              | "imported"
+              | "seeded"
+              | "reconnected"
+              | "fresh"
+              | "deferred";
           };
           set(s => {
             s.canCreate = true;

--- a/apps.md
+++ b/apps.md
@@ -1284,7 +1284,8 @@ refusal the binding is rolled back):
 | empty | none | `fresh` — first commit seeds the repo |
 | empty | exists | `seeded` — history pushed into the repo |
 | has content | none | `imported` — the repo's history becomes the workspace repo; its `apps/<slug>/mako.json` folders appear as apps with no registration step (§13 doctrine, now applied to customer repos) |
-| has content | exists | refused — whose history wins is not ours to guess |
+| has content (shares history) | exists | `reconnected` — the disconnect-then-connect-again case: unlinking never touches the local repo, so both sides hold the same lineage. `main` is reconciled like a webhook fetch (remote ahead → fast-forward; local ahead → push; diverged → mirror wins, local tip parked under `refs/mako/diverged/*`), then pushed |
+| has content (unrelated) | exists | refused — whose history wins is not ours to guess |
 
 **A customer remote is never force-pushed.** mako-cloud repos are OUR remotes
 and keep `git push --mirror` (all refs, pruned). Connected repos get explicit
@@ -2045,8 +2046,8 @@ echoes the active session's name instead of a generic caption.
 moment a workspace binds a repo (RealAdvisor → `realadvisor/mako-workspace`),
 `resolveMirrorTarget` prefers the binding over `appsV2CloudRepo`, and every
 mirror push lands in the customer's own repo. Adoption on connect follows a
-matrix (fresh repo → seed; matching history → import; unrelated history →
-refuse), and pushes to a customer remote are NEVER forced: `refs/heads/*` and
+matrix (fresh repo → seed; empty workspace → import; shared history → reconnect;
+unrelated history → refuse), and pushes to a customer remote are NEVER forced: `refs/heads/*` and
 `refs/tags/*` go unforced, only `+refs/mako/*` may move. Divergence therefore
 stalls by design and is reconciled with a merge commit, not `--force`. Inbound,
 the GitHub webhook matches pushes by repo binding


### PR DESCRIPTION
## Summary

**Reconnecting a GitHub repo no longer fails with "already has content and this workspace already has apps".**

Unlinking a repo never touches the workspace's local bare repo, so linking the same repo again found content on both sides and hit the refusal in `adoptConnectedRepo`. The §13.17 matrix only knew empty/empty, empty/content, content/empty and treated every content/content pair as unrelated histories.

- `adoptConnectedRepo` now fetches the remote's `main` and checks for a common ancestor. Shared lineage is reconciled the way every later fetch reconciles it (`fetchFromCloud`: remote ahead → fast-forward, local ahead → push, diverged → the mirror wins with the local tip parked under `refs/mako/diverged/*`, nothing dropped), then pushed. The link reports a new adoption outcome, `reconnected`.
- Only histories with **no** common ancestor are still refused, and the message now says "unrelated".
- Frontend: `reconnected` added to the adoption union and the settings notice; apps.md matrix updated.

**dbt orchestration config: git is the record from the first commit** (first two items of the audit behind #956).

- `commitDbtJobFile` stamped the row's `sourceBlobSha` *before* committing the file. A failed or skipped commit left the row claiming a sha for a file git never had, and the push-sync short-circuits on a matching sha, so the row could never be repaired. `commitConfig` now reports whether it wrote, and the stamp happens only afterwards.
- Project creation (route and agent tool) wrote environments/settings to the `DbtProject` row and scaffolded `dbt/` but never committed `dbt/environments.yml`; the file only appeared after the first edit. Both paths now write it through at creation, like PATCH already did.

Related: #956 (epic for the remaining Mongo content paths).

## Test plan

- [x] `vitest run --config vitest.apps.config.ts src/apps/cloud-repo.service.test.ts` — 20 pass, including 4 new reconnect cases (same history, local ahead, remote ahead, diverged)
- [x] `vitest run src/dbt/dbt-config.service.test.ts` — 8 pass, including the new "row stays unstamped when nothing was written" case
- [x] `vitest run src/routes/dbt.routes.integration.test.ts` — 29 pass
- [x] `vitest run src/agent-lib/tools/dbt-job-tools.test.ts src/agent-lib/tools/dbt-file-tools.test.ts` — 13 pass
- [x] `tsc --noEmit` for api and app: no new errors (the 70 existing api errors are all in untouched test files)
- [x] eslint + prettier on changed files; `pnpm openapi:sync` produced no diff
- [ ] Prod: re-link `realadvisor/mako-workspace` and confirm the notice reads "Repository reconnected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCYXTiaLJrk23Q4JnGv5Fy

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCYXTiaLJrk23Q4JnGv5Fy)_