### PR TITLE
fix(app): stale connector schema cache blocks saving builtin-only PostHog flows

### DIFF
--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -219,7 +219,7 @@ export function SyncFlowForm({
 
   const connectorTypes = useConnectorCatalogStore(state => state.types);
   const fetchCatalog = useConnectorCatalogStore(state => state.fetchCatalog);
-  const { schemas, fetchSchema } = useConnectorCatalogStore();
+  const fetchSchema = useConnectorCatalogStore(state => state.fetchSchema);
 
   const webhookCapabilitiesByType = useMemo(() => {
     const map: Record<string, WebhookCapabilities> = {};
@@ -630,21 +630,28 @@ export function SyncFlowForm({
     }
   }, [suggestReconcile, watchBackfillScheduleEnabled, setValue, getValues]);
 
-  // transferQueries schema (GraphQL/PostHog-style connectors)
+  // transferQueries schema (GraphQL/PostHog-style connectors).
+  // Stale-while-revalidate: show the persisted cache immediately, but always
+  // refetch — the cache lives in localStorage, so schema changes (e.g.
+  // transferQueries.required flipping) would otherwise never reach the form.
   useEffect(() => {
     if (!selectedConnectorType) {
       setTransferQueriesSchema(null);
       return;
     }
-    const cachedSchema = schemas[selectedConnectorType];
-    if (cachedSchema?.transferQueries) {
-      setTransferQueriesSchema(cachedSchema.transferQueries);
-    } else {
-      fetchSchema(selectedConnectorType).then(schema => {
-        setTransferQueriesSchema(schema?.transferQueries ?? null);
-      });
+    const cachedSchema =
+      useConnectorCatalogStore.getState().schemas[selectedConnectorType];
+    if (cachedSchema) {
+      setTransferQueriesSchema(cachedSchema.transferQueries ?? null);
     }
-  }, [selectedConnectorType, schemas, fetchSchema]);
+    fetchSchema(selectedConnectorType, true).then(schema => {
+      if (schema) {
+        setTransferQueriesSchema(schema.transferQueries ?? null);
+      } else if (!cachedSchema) {
+        setTransferQueriesSchema(null);
+      }
+    });
+  }, [selectedConnectorType, fetchSchema]);
 
   // Multi-database servers (non-CDC destinations): list databases to pick one.
   useEffect(() => {

--- a/app/src/store/connectorCatalogStore.ts
+++ b/app/src/store/connectorCatalogStore.ts
@@ -146,7 +146,9 @@ export const useConnectorCatalogStore = create<CatalogState>()(
     })),
     {
       name: "connector-catalog-store",
-      version: 2,
+      // v3: invalidate schemas cached before PostHog transferQueries became
+      // optional — a stale required:true blocks saving builtin-only flows.
+      version: 3,
       partialize: state => ({ schemas: state.schemas }), // Only persist schemas, not types
     },
   ),


### PR DESCRIPTION
## Summary

Follow-up to #762. The connector catalog store persists connector schemas to `localStorage` and `fetchSchema` returned the cached copy without ever revalidating. Browsers that cached the PostHog schema **before** `transferQueries` became optional still see `required: true`, so `SyncFlowForm` shows "Add at least one query to define what data to sync" and blocks creating a flow with only built-in entities (Surveys, Feature Flags, …) enabled — even though the deployed backend no longer requires HogQL queries.

### Changes
- `connectorCatalogStore`: bump the persist version (2 → 3) so existing stale schema caches are dropped on next load
- `SyncFlowForm`: fetch the transferQueries schema stale-while-revalidate — show the cached value immediately but always refetch from the API, so future schema changes propagate without another version bump

## Test plan
- [x] `pnpm --filter app run typecheck`
- [x] `pnpm --filter app run lint`
- [ ] Manual: open New Sync with a PostHog source → banner reads "Optional: add HogQL queries, or sync built-in entities below" → Create succeeds with only built-in entities enabled and no HogQL query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5jkM8GVRgBAPYyAXYEXHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5jkM8GVRgBAPYyAXYEXHy)_