### PR TITLE
cli: route `mako connection probe` (shipped without its dispatch line)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,14 +15,15 @@ needed and starts its Vite dev server; the app's `makoData()` plugin
 (`@makoai/app-sdk/vite`) streams each binding's parquet from Mako using that
 login.
 
-Connectors: `mako connector test connectors/<slug>` runs a connector's code
-from your checkout against its own contract (offline checks without
-`--config`, the full check/discover/read with one). `mako connector probe
-<id|name> [--entity <name>] [--limit <n>]` runs a connector Mako has
-*configured*, with the credential Mako holds, live against its platform: the
-credential check plus one bounded page of an entity, written nowhere — the
-way to see that a new key works, or what a platform's data looks like before
-a flow lands it in the warehouse.
+Connectors and connections — a *connector* is code (`connectors/<slug>/` in
+your repo, or one of Mako's built-ins); a *connection* is a credential Mako
+holds, configured with one. `mako connector test connectors/<slug>` runs a
+connector's code from your checkout against its own contract (offline checks
+without `--config`, the full check/discover/read with one). `mako connection
+probe <id|name> [--entity <name>] [--limit <n>]` runs a configured connection
+live against its platform: the credential check plus one bounded page of an
+entity, written nowhere — the way to see that a new key works, or what a
+platform's data looks like before a flow lands it in the warehouse.
 
 Also: `mako whoami`, `mako logout`, `--api-url <host>` for self-hosted Mako
 (or `MAKO_API_URL` in the repo's `.env`). An API key in `.env`

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -6,6 +6,7 @@ import { dev } from "./dev.js";
 import { status } from "./status.js";
 import { publish } from "./publish.js";
 import { connector } from "./connector.js";
+import { connection } from "./connection.js";
 
 const HELP = `mako — Mako from your terminal
 
@@ -15,8 +16,8 @@ const HELP = `mako — Mako from your terminal
   mako dev     [<app>] [--port <n>] [--open]      run apps/<app> locally with real data
   mako status  [<app>]                            what is LIVE: published commit vs the tip of main
   mako publish [<app>]                            deploy the app's main branch now (enqueue + wait)
-  mako connector test [<path>] [--config <file>]  run a connector's own contract against it
-  mako connector probe <id|name> [--entity <e>]   run a configured connector live: check + one page, written nowhere
+  mako connector test [<path>] [--config <file>]  run a connector's code (connectors/<slug>) against its own contract
+  mako connection probe <id|name> [--entity <e>]  run a configured connection live: check + one page, written nowhere
 
 Run inside a workspace checkout; the host comes from --api-url, MAKO_API_URL,
 the repo's .env, or defaults to https://app.mako.ai. An API key in .env
@@ -63,6 +64,8 @@ export async function main(argv, io = { log: console.log }) {
       return publish(ctx, positional, io);
     case "connector":
       return connector(ctx, positional, flags, io);
+    case "connection":
+      return connection(ctx, positional, flags, io);
     default:
       io.log(`unknown command "${command}"\n\n${HELP}`);
       return 2;

--- a/packages/cli/src/main.test.mjs
+++ b/packages/cli/src/main.test.mjs
@@ -1,0 +1,39 @@
+/**
+ * The dispatcher: every command in HELP must actually be routed. `mako
+ * connection probe` shipped with its module wired to nothing — the tests
+ * exercised `connection()` directly and never noticed — so this pins the
+ * command table from the outside, through `main()`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "./main.js";
+
+async function run(argv) {
+  const lines = [];
+  const code = await main(argv, { log: line => lines.push(line) });
+  return { code, output: lines.join("\n") };
+}
+
+test("help lists connector test and connection probe, and both are routed", async () => {
+  const help = await run(["help"]);
+  assert.equal(help.code, 0);
+  assert.match(help.output, /mako connector test/);
+  assert.match(help.output, /mako connection probe/);
+  assert.doesNotMatch(help.output, /mako connector probe/);
+
+  // A bare subcommand family prints its own help and exits 0.
+  const connection = await run(["connection"]);
+  assert.equal(connection.code, 0);
+  assert.match(connection.output, /mako connection probe <id\|name>/);
+
+  // The old spelling is refused by the family that no longer owns it.
+  const stale = await run(["connector", "probe", "x"]);
+  assert.equal(stale.code, 2);
+  assert.match(stale.output, /mako connection probe/);
+});
+
+test("an unknown command is refused with the help", async () => {
+  const { code, output } = await run(["conection"]);
+  assert.equal(code, 2);
+  assert.match(output, /unknown command "conection"/);
+});


### PR DESCRIPTION
#954 added `packages/cli/src/connection.js` and its tests, but the edit wiring `connection` into `main.js` (import, HELP line, switch case) was lost, so `mako connection probe` answered "unknown command" while HELP still advertised `mako connector probe` and routed it to a module that no longer had it. Caught while trying the merged feature from the workspace checkout.

- `main.js`: import + `case "connection"` + HELP line; `mako connector probe` no longer advertised.
- `main.test.mjs` (new): pins the command table through `main()` — help lists both families, `connection` prints its help, `connector probe` is refused — so a routed-to-nothing module cannot pass again.
- `README.md`: the connector / connection paragraph that was meant to land in #954.

`cd packages/cli && node --test`: 17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAqUddVYbyx29sPbFULL4q