### PR TITLE
docs(connectors): document workspace-authored connectors (@makoai/connector-sdk)

### DIFF
--- a/docs/src/content/docs/guides/building-connectors.md
+++ b/docs/src/content/docs/guides/building-connectors.md
@@ -92,6 +92,133 @@ scanning `api/src/connectors/*` for a subdirectory containing a
 Dropping your connector directory in place (with the `index.ts` export below)
 is enough for it to register under the directory name as its `type`.
 
+## Workspace-Authored Connectors
+
+The connector above lives in this repo, in `api/src/connectors/`, and ships
+with a Mako release. A workspace can also ship its **own** connector, from
+its own repo, with no PR here at all.
+
+### Where it lives
+
+Put the connector in `connectors/<slug>/` in your workspace repo and push to
+the default branch. Mako indexes it automatically: it runs `spec`, builds the
+credential form from the result, and offers the connector in the picker.
+Nothing about the engine changes to support this — it cannot tell whether a
+connector is a class in `api/src` or a folder it runs in a sandbox.
+
+Each connector folder needs:
+
+- `connector.yaml` — the only file Mako reads without running anything:
+
+  ```yaml
+  runtime: node
+  entry: connector.ts # optional; this is the default
+  ```
+
+  Today `runtime` must be `node`. `entry` defaults to `connector.ts`.
+
+- The connector code itself (`connector.ts` by default), written against
+  `@makoai/connector-sdk`:
+
+  ```ts
+  // connectors/acme/connector.ts
+  import { defineConnector } from "@makoai/connector-sdk";
+
+  export default defineConnector({
+    name: "acme",
+    version: "1.0.0",
+    config: {
+      required: ["apiKey"],
+      properties: {
+        apiKey: { type: "string", title: "API key", airbyte_secret: true },
+      },
+    },
+    check: async ctx => {
+      await ctx.http.get("https://api.acme.com/v1/me", {
+        headers: { Authorization: `Bearer ${ctx.config.apiKey}` },
+      });
+      return true;
+    },
+    entities: {
+      widgets: {
+        primaryKey: ["id"],
+        cursorField: "updated_at",
+        schema: { id: "string", name: "string", updated_at: "timestamp" },
+        async *read(ctx, state) {
+          for await (const page of ctx.paginate(/* ... */)) {
+            yield {
+              records: page.records,
+              state: { cursor: page.cursor },
+              hasMore: page.hasMore,
+            };
+          }
+        },
+      },
+    },
+  });
+  ```
+
+  `check`, `discover` and a per-entity `read` generator are the whole
+  contract. The SDK handles HTTP retries (respecting `Retry-After`) and the
+  pagination shapes most REST APIs use, and speaks Airbyte's JSON-Lines
+  protocol underneath so a future runtime is a runtime, not a translator.
+
+  `config.properties` is not optional, even for a connector that needs no
+  credential (`properties: {}` is fine). It is the field list Mako encrypts
+  by — an omitted list is refused at push time rather than guessed at, because
+  guessing risks storing a customer's API key in plaintext. Mark every secret
+  field `airbyte_secret: true`.
+
+  The runner needs Node 22.6+ to import a `.ts` connector with no build step
+  (unflagged from 22.18; with `--experimental-strip-types` from 22.6). Mako's
+  own sandbox satisfies this; test locally on anything older and the runner
+  refuses with a message saying so.
+
+### Test it before you push
+
+```
+npx @makoai/cli connector test connectors/<slug>
+```
+
+This runs the same four commands (`spec`, `check`, `discover`, `read`) the
+engine runs, in the same order, against a local credential file — including
+that a bounded `read` reports a resumable position and resuming from it does
+not repeat or skip a row. Without `--config` only the offline checks run
+(`spec`, the config schema, the connector's shape), which is what CI can do
+without a secret.
+
+### `indexed` vs. `verified`
+
+A push carries no credential, so `check`, `discover` and `read` have nothing
+to run against — only `spec` runs. A connector whose spec succeeds is
+`indexed`: enough to appear in the picker so someone can enter a key. It only
+becomes `verified` once a real connection (a credential entered in the UI)
+passes a live check. A connector whose `spec` fails is `blocked`, with the
+reason, and cannot back a data source.
+
+### Where the code actually runs
+
+A workspace connector runs in a sandbox dedicated to that workspace's syncs,
+separate from anyone's session sandbox. Three things are deliberate there:
+
+- The sandbox never clones the workspace repo. Cloning would require a
+  workspace-scoped token capable of pushing back to that repo — apps, flows,
+  dbt models, every other connector. The API copies the connector folder in
+  instead, so the sandbox holds no Mako token at all.
+- A credential is written to a per-run file and deleted in a `finally`,
+  because a paused sandbox snapshots its disk and a credential must not
+  persist in that snapshot.
+- Only a bounded protocol stream comes back out of the sandbox — never
+  unbounded output.
+
+### Probing a live connection
+
+Once a connection exists, `npx @makoai/cli connection probe <id|name>
+[--entity <name>]` runs it live against the platform: the connector's `check`
+plus one bounded page, written nowhere. The same probe backs the
+`probe_connection` MCP tool and `POST /connectors/:id/probe` — a flow is not
+the only thing that can drive it.
+
 ## Best Practices
 
 - **Idempotency**: Ensure that running the sync twice for the same data doesn't create duplicates. Use `upsert` operations in the destination.


### PR DESCRIPTION
## Why

Commit e7dd734 (#948) shipped a second way to write a Mako connector: a workspace ships its own, in a folder under `connectors/<slug>/` in its own repo, auto-discovered on push to the default branch and written against `@makoai/connector-sdk` -- no PR to this repo, no `BaseConnector` subclass.

The `building-connectors` guide (`docs/src/content/docs/guides/building-connectors.md`) only documented the built-in path (`api/src/connectors/<slug>`). This feature had zero Starlight coverage.

## What

Adds a "Workspace-Authored Connectors" section to the existing guide (kept it one page rather than a new sidebar entry -- it's a variant of the same concept, not a different concept):

- `connector.yaml` + `defineConnector({ check, discover, read })` contract, based on `packages/connector-sdk/README.md`
- Local testing with `mako connector test` (offline vs. `--config`-backed checks)
- `indexed` vs. `verified` status -- a push alone only proves `spec`; `verified` requires a live credential check
- The sandbox execution model: folder copy (not a repo clone, so the sandbox never holds a Mako token), credential written per-run and deleted in `finally`
- Probing a live connection with `mako connection probe` (also backs the `probe_connection` MCP tool and the REST probe endpoint)

Verified against `packages/connector-sdk/README.md`, `packages/connector-sdk/bin/mako-connector.js`, `packages/cli/src/connector.js`, and `api/src/connectors/workspace/{sync-box,spec-translation,connector-file,catalog,reconcile.service}.ts`.

## Not in scope

`mako connection probe`'s CLI dispatch bug (missing `case` line, HELP text still said `connector probe`) is already fixed by #959 -- not duplicated here.

---
Opened by Aura as part of routine docs maintenance (commit range `280c7cb..80853e1`).