### PR TITLE
fix(close): nightly backfill of the Close CDC flows fails at leads with HTTP 400 since #677

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
-import { CloseConnector, formatCloseApiErrorResponse } from "./connector";
-import { buildCloseSearchFieldSelection } from "./schema";
+import {
+  CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH,
+  CloseConnector,
+  formatCloseApiErrorResponse,
+} from "./connector";
+import {
+  buildCloseSearchFieldSelection,
+  splitCloseSearchFieldSelection,
+} from "./schema";
 
 function createConnector() {
   return new CloseConnector({
@@ -12,16 +19,19 @@ function createConnector() {
 }
 
 function testCloseApiErrorResponseIsFormattedForLogs() {
-  const error = Object.assign(new Error("Request failed with status code 400"), {
-    isAxiosError: true,
-    response: {
-      status: 400,
-      data: {
-        error: "Invalid field selection",
-        "field-errors": { _fields: ["Unsupported field"] },
+  const error = Object.assign(
+    new Error("Request failed with status code 400"),
+    {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: "Invalid field selection",
+          "field-errors": { _fields: ["Unsupported field"] },
+        },
       },
     },
-  });
+  );
 
   assert.equal(
     formatCloseApiErrorResponse(error),
@@ -376,6 +386,409 @@ function testSearchFieldSelectionIncludesCustomFieldSelectors() {
   ]);
 }
 
+function makeCustomFields(count: number, appliesTo = "lead") {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `cf_${String(i).padStart(3, "0")}`,
+    name: `Field ${i}`,
+    type: "text",
+    appliesTo,
+  }));
+}
+
+// Close rejects a `_fields` list past an undocumented ceiling (~100+). The
+// selection must be split so no single request names more than the budget
+// of custom selectors, with the remainder shaped as by-id follow-ups that
+// each start with the `id` merge key.
+function testSplitFieldSelectionRespectsBudget() {
+  const plan = splitCloseSearchFieldSelection(
+    ["id", "name", "date_created"],
+    makeCustomFields(130),
+    60,
+  );
+
+  assert.equal(plan.primary.length, 3 + 60);
+  assert.deepEqual(plan.primary.slice(0, 3), ["id", "name", "date_created"]);
+  assert.equal(plan.primary[3], "custom.cf_000");
+  assert.equal(plan.primary[62], "custom.cf_059");
+
+  assert.equal(plan.supplemental.length, 2);
+  assert.equal(plan.supplemental[0][0], "id");
+  assert.equal(plan.supplemental[0].length, 61);
+  assert.equal(plan.supplemental[0][1], "custom.cf_060");
+  assert.equal(plan.supplemental[1][0], "id");
+  assert.equal(plan.supplemental[1].length, 11);
+  assert.equal(plan.supplemental[1][10], "custom.cf_129");
+
+  // Everything fits: no follow-ups, and `id` is always requested.
+  const small = splitCloseSearchFieldSelection(
+    ["name"],
+    makeCustomFields(5),
+    60,
+  );
+  assert.deepEqual(small.supplemental, []);
+  assert.equal(small.primary[0], "id");
+  assert.equal(small.primary.length, 2 + 5);
+
+  // Duplicate ids (a shared field listed twice) are requested once.
+  const dup = splitCloseSearchFieldSelection(
+    ["id"],
+    [...makeCustomFields(2), ...makeCustomFields(2)],
+    60,
+  );
+  assert.deepEqual(dup.primary, ["id", "custom.cf_000", "custom.cf_001"]);
+}
+
+/**
+ * Stub Close client for the lead backfill: serves one page of `pageRows`,
+ * rejects any search request whose `_fields.lead` is longer than
+ * `maxFields` with the 400 Close returns for an oversized selection, and
+ * answers by-id follow-ups with the requested selectors for each id.
+ */
+function stubLeadSearchApi(params: {
+  customFieldCount: number;
+  maxFields: number;
+  pageRows: Array<Record<string, unknown>>;
+}) {
+  const searchBodies: any[] = [];
+  let servedPage = false;
+  const post = async (_url: string, body: any) => {
+    if (body?.include_counts) {
+      return { data: { count: { total: params.pageRows.length }, data: [] } };
+    }
+    const idQuery = body?.query?.queries?.find((q: any) => q?.type === "or");
+    if (!idQuery && body?._limit === 1 && Array.isArray(body?.sort)) {
+      // Oldest-record probe used to seed the date window
+      return {
+        data: {
+          data: [
+            {
+              id: params.pageRows[0].id,
+              date_created: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+      };
+    }
+    if (!idQuery && body?._limit === 1) {
+      // Gap probe after the window is exhausted — no more data
+      return { data: { data: [] } };
+    }
+    searchBodies.push(body);
+    const fields: string[] = body?._fields?.lead ?? [];
+    if (fields.length > params.maxFields) {
+      throw Object.assign(new Error("Request failed with status code 400"), {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          headers: {},
+          data: { "field-errors": { _fields: ["Too many fields requested"] } },
+        },
+      });
+    }
+
+    if (idQuery) {
+      // By-id follow-up: return only the requested selectors for each id.
+      const ids: string[] = idQuery.queries.map((q: any) => q.value);
+      return {
+        data: {
+          data: params.pageRows
+            .filter(row => ids.includes(String(row.id)))
+            .map(row => {
+              const out: Record<string, unknown> = { id: row.id };
+              for (const field of fields) {
+                if (field !== "id" && field in row) out[field] = row[field];
+              }
+              return out;
+            }),
+          cursor: null,
+        },
+      };
+    }
+
+    if (!servedPage) {
+      servedPage = true;
+      return {
+        data: {
+          data: params.pageRows.map(row => {
+            const out: Record<string, unknown> = {};
+            for (const field of fields) {
+              if (field in row) out[field] = row[field];
+            }
+            return out;
+          }),
+          cursor: null,
+        },
+      };
+    }
+    return { data: { data: [], cursor: null } };
+  };
+
+  const api = {
+    get: async (url: string) => {
+      if (url === "/custom_field_schema/lead/") {
+        return { data: { fields: makeCustomFields(params.customFieldCount) } };
+      }
+      return { data: { data: [] } };
+    },
+    post,
+  };
+  return { api, searchBodies };
+}
+
+function makeLeadRow(id: string, customFieldCount: number) {
+  const row: Record<string, unknown> = {
+    id,
+    name: `Lead ${id}`,
+    date_created: "2026-01-02T00:00:00.000Z",
+    date_updated: "2026-01-03T00:00:00.000Z",
+  };
+  for (const field of makeCustomFields(customFieldCount)) {
+    row[`custom.${field.id}`] = `${id}:${field.id}`;
+  }
+  return row;
+}
+
+// Regression for the July 2026 outage: an org with 130 lead custom fields
+// must sync every one of them as a flat `custom_cf_*` key, without any
+// request exceeding the per-request selector budget.
+async function testLeadBackfillSplitsCustomFieldsAcrossRequests() {
+  const connector = createConnector();
+  const rows = [makeLeadRow("lead_a", 130), makeLeadRow("lead_b", 130)];
+  const { api, searchBodies } = stubLeadSearchApi({
+    customFieldCount: 130,
+    maxFields: 100,
+    pageRows: rows,
+  });
+  (connector as any).closeApi = api;
+
+  const batches: Record<string, unknown>[][] = [];
+  const state = await connector.fetchEntityChunk({
+    entity: "leads",
+    onBatch: async (batch: Record<string, unknown>[]) => {
+      batches.push(batch);
+    },
+    onProgress: () => {},
+    rateLimitDelay: 1,
+  } as any);
+
+  assert.equal(state.hasMore, false);
+  const pageRequests = searchBodies.filter(
+    b => !b.query?.queries?.some((q: any) => q?.type === "or"),
+  );
+  const byIdRequests = searchBodies.filter(b =>
+    b.query?.queries?.some((q: any) => q?.type === "or"),
+  );
+  // One paged request serves the rows; the loop then advances the window and
+  // issues one more paged request that comes back empty.
+  assert.ok(pageRequests.length >= 1, "a paged request for the window");
+  assert.equal(byIdRequests.length, 2, "two by-id follow-ups for the rest");
+  for (const body of searchBodies) {
+    const custom = (body._fields.lead as string[]).filter(f =>
+      f.startsWith("custom."),
+    );
+    assert.ok(
+      custom.length <= CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH,
+      `request named ${custom.length} custom selectors`,
+    );
+    assert.ok(
+      !(body._fields.lead as string[]).includes("custom"),
+      "deprecated custom blob must not be requested",
+    );
+  }
+  // Follow-ups target exactly the ids of the page.
+  for (const body of byIdRequests) {
+    const or = body.query.queries.find((q: any) => q.type === "or");
+    assert.deepEqual(
+      or.queries.map((q: any) => q.value),
+      ["lead_a", "lead_b"],
+    );
+    assert.equal(body._limit, 2);
+  }
+
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0].length, 2);
+  for (const record of batches[0]) {
+    const id = record.id as string;
+    assert.equal(record.name, `Lead ${id}`);
+    for (const field of makeCustomFields(130)) {
+      assert.equal(
+        record[`custom_${field.id}`],
+        `${id}:${field.id}`,
+        `${id} is missing custom_${field.id}`,
+      );
+    }
+    assert.ok(!Object.keys(record).some(k => k.startsWith("custom.")));
+  }
+}
+
+// If Close's ceiling is lower than the configured budget, the connector must
+// shrink the batch and retry the same page instead of failing the sync.
+async function testLeadBackfillShrinksBatchWhenCloseRejectsSelection() {
+  const connector = createConnector();
+  const rows = [makeLeadRow("lead_a", 70)];
+  const { api, searchBodies } = stubLeadSearchApi({
+    customFieldCount: 70,
+    maxFields: 40,
+    pageRows: rows,
+  });
+  (connector as any).closeApi = api;
+  const warnings: string[] = [];
+
+  const batches: Record<string, unknown>[][] = [];
+  await connector.fetchEntityChunk({
+    entity: "leads",
+    onBatch: async (batch: Record<string, unknown>[]) => {
+      batches.push(batch);
+    },
+    onLog: (level: string, message: string) => {
+      if (level === "warn") warnings.push(message);
+    },
+    rateLimitDelay: 1,
+  } as any);
+
+  const sizes = searchBodies.map(b => (b._fields.lead as string[]).length);
+  assert.ok(sizes[0] > 40, "first attempt used the default budget");
+  const rejected = sizes.filter(n => n > 40);
+  assert.equal(
+    rejected.length,
+    2,
+    `60 -> 30 -> 15: two attempts over the ceiling, got ${sizes.join(",")}`,
+  );
+  const lastRejected = sizes.lastIndexOf(rejected[rejected.length - 1]);
+  assert.ok(
+    sizes.slice(lastRejected + 1).every(n => n <= 40),
+    `after the last 400 every request fits the ceiling, got ${sizes.join(",")}`,
+  );
+  assert.ok(
+    searchBodies.some(b =>
+      b.query?.queries?.some((q: any) => q?.type === "or"),
+    ),
+    "the remaining fields are fetched by id",
+  );
+  assert.ok(
+    warnings.some(m => m.includes("fewer custom selectors")),
+    "the shrink is logged to the sync log",
+  );
+  assert.equal((connector as any).customSelectorBatchSize, 15);
+
+  assert.equal(batches.length, 1);
+  const record = batches[0][0];
+  for (const field of makeCustomFields(70)) {
+    assert.equal(record[`custom_${field.id}`], `lead_a:${field.id}`);
+  }
+}
+
+// Schema change mid-run: a custom field deleted in Close after the schema
+// was cached leaves a dangling selector that Close rejects. The connector
+// must re-read the schema, drop the selector, and carry on — not shrink the
+// batch, and not fail the sync.
+async function testLeadBackfillReplansWhenCustomFieldDeletedMidRun() {
+  const connector = createConnector();
+  const rows = [makeLeadRow("lead_a", 3)];
+  let schemaReads = 0;
+  const { api, searchBodies } = stubLeadSearchApi({
+    customFieldCount: 3,
+    maxFields: 1000,
+    pageRows: rows,
+  });
+  const basePost = api.post;
+  (connector as any).closeApi = {
+    get: async (url: string) => {
+      if (url === "/custom_field_schema/lead/") {
+        schemaReads++;
+        // First read: three fields. Later reads: cf_002 has been deleted.
+        return {
+          data: {
+            fields: makeCustomFields(schemaReads === 1 ? 3 : 2),
+          },
+        };
+      }
+      return { data: { data: [] } };
+    },
+    post: async (url: string, body: any) => {
+      const fields: string[] = body?._fields?.lead ?? [];
+      if (fields.includes("custom.cf_002")) {
+        throw Object.assign(new Error("Request failed with status code 400"), {
+          isAxiosError: true,
+          response: {
+            status: 400,
+            headers: {},
+            data: { "field-errors": { _fields: ["Unsupported field"] } },
+          },
+        });
+      }
+      return basePost(url, body);
+    },
+  };
+  const warnings: string[] = [];
+
+  const batches: Record<string, unknown>[][] = [];
+  await connector.fetchEntityChunk({
+    entity: "leads",
+    onBatch: async (batch: Record<string, unknown>[]) => {
+      batches.push(batch);
+    },
+    onLog: (level: string, message: string) => {
+      if (level === "warn") warnings.push(message);
+    },
+    rateLimitDelay: 1,
+  } as any);
+
+  assert.equal(schemaReads, 2, "schema is re-read after the rejection");
+  assert.ok(
+    warnings.some(m => m.includes("schema changed during the run")),
+    "the re-plan is logged to the sync log",
+  );
+  assert.equal(
+    (connector as any).customSelectorBatchSize,
+    CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH,
+    "a schema change must not shrink the batch",
+  );
+  assert.ok(
+    searchBodies.slice(1).every(b => !b._fields.lead.includes("custom.cf_002")),
+    "the deleted field is no longer requested",
+  );
+  assert.equal(batches.length, 1);
+  const record = batches[0][0];
+  assert.equal(record.custom_cf_000, "lead_a:cf_000");
+  assert.equal(record.custom_cf_001, "lead_a:cf_001");
+  assert.ok(!("custom_cf_002" in record));
+}
+
+// A 400 that is not about the selection (and a selection-less entity) must
+// still surface: shrinking is only for requests that carried selectors.
+async function testUnrelatedSearch400StillThrows() {
+  const connector = createConnector();
+  (connector as any).closeApi = {
+    get: async () => ({ data: { fields: [] } }),
+    post: async () => {
+      throw Object.assign(new Error("Request failed with status code 400"), {
+        isAxiosError: true,
+        response: { status: 400, headers: {}, data: { error: "Bad query" } },
+      });
+    },
+  };
+
+  await assert.rejects(
+    connector.fetchEntityChunk({
+      entity: "leads",
+      state: {
+        totalProcessed: 0,
+        hasMore: true,
+        iterationsInChunk: 0,
+        metadata: {
+          windowStart: "2026-01-01T00:00:00.000Z",
+          windowEnd: "2026-01-08T00:00:00.000Z",
+        },
+      },
+      onBatch: async () => {},
+      maxIterations: 1,
+      rateLimitDelay: 1,
+    } as any),
+    /status code 400/,
+  );
+}
+
 // End-to-end contract for the opportunity backfill path with a stubbed Close
 // client: the Search API request must enumerate `custom.cf_<id>` selectors,
 // and records handed to onBatch must arrive with flattened `custom_cf_*` keys.
@@ -437,7 +850,7 @@ async function testOpportunitySearchBackfillRequestsAndFlattensCustomFields() {
   const batches: Record<string, unknown>[][] = [];
   const state = await connector.fetchEntityChunk({
     entity: "opportunities",
-    onBatch: async batch => {
+    onBatch: async (batch: Record<string, unknown>[]) => {
       batches.push(batch);
     },
     onProgress: () => {},
@@ -452,8 +865,8 @@ async function testOpportunitySearchBackfillRequestsAndFlattensCustomFields() {
     `_fields should include custom.cf_renewal, got: ${requestedFields.join(",")}`,
   );
   assert.ok(
-    requestedFields.includes("custom"),
-    "_fields should keep the custom blob fallback",
+    !requestedFields.includes("custom"),
+    "_fields must not lean on the deprecated custom blob",
   );
 
   assert.equal(batches.length, 1);
@@ -658,6 +1071,11 @@ async function main() {
   testContactBackfillFlattensCustomFields();
   testSearchFieldSelectionIncludesCustomFieldSelectors();
   await testOpportunitySearchBackfillRequestsAndFlattensCustomFields();
+  testSplitFieldSelectionRespectsBudget();
+  await testLeadBackfillSplitsCustomFieldsAcrossRequests();
+  await testLeadBackfillShrinksBatchWhenCloseRejectsSelection();
+  await testLeadBackfillReplansWhenCustomFieldDeletedMidRun();
+  await testUnrelatedSearch400StillThrows();
   await testExpiredCursorRetriesWithNormalizedWindowStart();
   await testCreateWebhookSubscriptionReturnsSignatureKey();
   await testExistingWebhookSubscriptionReturnsSignatureKey();

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -17,8 +17,10 @@ import {
 } from "../base/BaseConnector";
 import {
   resolveCloseEntitySchema,
-  buildCloseSearchFieldSelection,
+  closeCustomFieldSelectors,
+  splitCloseSearchFieldSelection,
   type CloseCustomField,
+  type CloseSearchFieldSelectionPlan,
 } from "./schema";
 import axios, { AxiosInstance } from "axios";
 import * as crypto from "crypto";
@@ -27,6 +29,28 @@ import { loggers } from "../../logging";
 const logger = loggers.connector("close");
 
 const MAX_CLOSE_ERROR_RESPONSE_LENGTH = 2_000;
+
+/**
+ * How many `custom.cf_*` selectors one Search API request may name.
+ *
+ * Close returns HTTP 400 when `_fields` grows past an undocumented ceiling:
+ * ~80 total selectors are known to work, ~140 are known to fail. 60 custom
+ * selectors plus the ~30 base fields stays under the known-good mark; the
+ * rest of the custom fields are fetched for the same page with follow-up
+ * by-id requests. If Close still rejects a request the batch is halved
+ * (down to the minimum) and the page is retried, so a tighter ceiling
+ * degrades into more requests rather than a failed sync.
+ */
+export const CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH = 60;
+const CLOSE_SEARCH_MIN_CUSTOM_SELECTOR_BATCH = 5;
+
+function isCloseSearchCursorError(error: unknown): boolean {
+  return (
+    axios.isAxiosError(error) &&
+    error.response?.status === 400 &&
+    Boolean(error.response?.data?.["field-errors"]?.cursor)
+  );
+}
 
 export function formatCloseApiErrorResponse(
   error: unknown,
@@ -244,6 +268,13 @@ function throttledRequest<T>(
 export class CloseConnector extends BaseConnector {
   private customFieldSchemaCache = new Map<string, CloseCustomField[]>();
 
+  /**
+   * Current per-request budget of `custom.cf_*` selectors for the Search
+   * API. Starts at CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH and only ever shrinks,
+   * when Close answers a field selection with HTTP 400.
+   */
+  private customSelectorBatchSize = CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH;
+
   private static readonly ENTITY_TO_CUSTOM_FIELD_OBJECT_TYPE: Record<
     string,
     string
@@ -274,6 +305,20 @@ export class CloseConnector extends BaseConnector {
       CloseConnector.ENTITY_TO_CUSTOM_FIELD_OBJECT_TYPE[entity];
     if (!objectType) return [];
 
+    return this.fetchCustomFieldsViaSchema(objectType);
+  }
+
+  /**
+   * Re-read the custom-field schema from Close, bypassing the per-instance
+   * cache. Used when a Search request is rejected mid-run: a field deleted
+   * in Close after the schema was cached leaves a dangling `custom.cf_*`
+   * selector that Close refuses, and the fix is to re-plan with the current
+   * schema — not to shrink the batch.
+   */
+  private async refreshCustomFieldsViaSchema(
+    objectType: string,
+  ): Promise<CloseCustomField[]> {
+    this.customFieldSchemaCache.delete(objectType);
     return this.fetchCustomFieldsViaSchema(objectType);
   }
 
@@ -1159,7 +1204,6 @@ export class CloseConnector extends BaseConnector {
         "opportunities",
         "tasks",
         "integration_links",
-        "custom",
         "primary_email",
         "primary_phone",
       ],
@@ -1179,7 +1223,6 @@ export class CloseConnector extends BaseConnector {
         "updated_by",
         "integration_links",
         "timezone",
-        "custom",
       ],
       opportunity: [
         "id",
@@ -1217,7 +1260,6 @@ export class CloseConnector extends BaseConnector {
         "attachments",
         "is_stalled",
         "stall_status",
-        "custom",
       ],
     };
 
@@ -1303,21 +1345,27 @@ export class CloseConnector extends BaseConnector {
 
     // Core objects: enumerate every custom field as an explicit
     // `custom.cf_<id>` selector so values come back as flat keys (matching the
-    // schema's `custom_cf_*` columns) instead of relying solely on the
-    // aggregate `custom` blob. Resolved once per chunk; the custom-field
-    // schema lookup is cached per connector instance.
-    let coreFieldSelection: string[] | null = null;
+    // schema's `custom_cf_*` columns and the shape webhooks deliver) instead
+    // of the deprecated aggregate `custom` blob. The selection is split so no
+    // single request exceeds the per-request selector budget; see
+    // CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH. The custom-field schema lookup is
+    // cached per connector instance.
+    let coreCustomFields: CloseCustomField[] | null = null;
     if (
       objectType === "lead" ||
       objectType === "contact" ||
       objectType === "opportunity"
     ) {
-      const customFields = await this.fetchCustomFieldsViaSchema(objectType);
-      coreFieldSelection = buildCloseSearchFieldSelection(
-        fieldsMap[objectType] || [],
-        customFields,
-      );
+      coreCustomFields = await this.fetchCustomFieldsViaSchema(objectType);
     }
+    const planFieldSelection = (): CloseSearchFieldSelectionPlan | null =>
+      coreCustomFields
+        ? splitCloseSearchFieldSelection(
+            fieldsMap[objectType] || [],
+            coreCustomFields,
+            this.customSelectorBatchSize,
+          )
+        : null;
 
     // Forward-scanning ASC date windows avoid the non-deterministic row drops
     // that occur with DESC sort + cursor resets.  Close's Search API cursor is
@@ -1501,8 +1549,9 @@ export class CloseConnector extends BaseConnector {
           ],
         };
 
-        if (coreFieldSelection) {
-          body._fields = { [objectType]: coreFieldSelection };
+        const fieldPlan = planFieldSelection();
+        if (fieldPlan) {
+          body._fields = { [objectType]: fieldPlan.primary };
         } else if (fieldsMap[objectType]) {
           body._fields = { [objectType]: fieldsMap[objectType] };
         }
@@ -1511,8 +1560,17 @@ export class CloseConnector extends BaseConnector {
         }
 
         const response = await api.post("/data/search/", body);
-        const data = response.data.data || [];
+        let data: any[] = response.data.data || [];
         pageCursor = response.data.cursor || null;
+
+        if (fieldPlan && fieldPlan.supplemental.length > 0 && data.length > 0) {
+          data = await this.fetchSupplementalCustomFields(
+            api,
+            objectType,
+            data,
+            fieldPlan.supplemental,
+          );
+        }
 
         if (data.length > 0) {
           const records =
@@ -1646,6 +1704,32 @@ export class CloseConnector extends BaseConnector {
             ).toISOString();
           }
           pageCursor = null;
+        } else if (
+          coreCustomFields &&
+          axios.isAxiosError(error) &&
+          error.response?.status === 400
+        ) {
+          // Close rejected the field selection. Two causes, checked in order:
+          // the custom-field schema changed under us (a selector now names a
+          // deleted field) — re-plan with the fresh schema; or the list is
+          // simply too long — retry with a smaller per-request budget. The
+          // cursor is unchanged either way, so the same page is retried.
+          const refreshed = await this.refreshCustomFieldsViaSchema(objectType);
+          if (
+            this.customFieldSelectionChanged(
+              entity,
+              coreCustomFields,
+              refreshed,
+              error,
+            )
+          ) {
+            coreCustomFields = refreshed;
+            continue;
+          }
+          if (this.shrinkCustomSelectorBatch(error, entity, coreCustomFields)) {
+            continue;
+          }
+          throw error;
         } else {
           throw error;
         }
@@ -1664,6 +1748,216 @@ export class CloseConnector extends BaseConnector {
         windowField,
       },
     };
+  }
+
+  /**
+   * True when a re-read of the custom-field schema yields a different set of
+   * selectors than the one a rejected request was built from — i.e. the
+   * schema changed mid-run. Logs what changed so the sync log explains the
+   * retry.
+   */
+  private customFieldSelectionChanged(
+    entity: string,
+    previous: readonly CloseCustomField[],
+    refreshed: readonly CloseCustomField[],
+    error: unknown,
+  ): boolean {
+    const before = closeCustomFieldSelectors(previous);
+    const after = new Set(closeCustomFieldSelectors(refreshed));
+    const beforeSet = new Set(before);
+    const removed = before.filter(selector => !after.has(selector));
+    const added = [...after].filter(selector => !beforeSet.has(selector));
+    if (removed.length === 0 && added.length === 0) return false;
+
+    const details = {
+      entity,
+      removed,
+      added,
+      responseBody: formatCloseApiErrorResponse(error),
+    };
+    this.emitSyncLog(
+      "warn",
+      "Close custom-field schema changed during the run, re-planning the field selection",
+      details,
+    );
+    logger.warn("Close custom-field schema changed mid-run", details);
+    return true;
+  }
+
+  /**
+   * Decide whether an HTTP 400 from the Search API should be treated as
+   * "too many `_fields` selectors" and, if so, halve the per-request budget.
+   * Returns true when the caller should retry with the smaller budget.
+   *
+   * Close does not document the ceiling, and the error text is not stable
+   * enough to match on, so any 400 that is not the known cursor error, on a
+   * request that carried custom selectors, shrinks the budget — until the
+   * minimum is reached, at which point the error propagates.
+   */
+  private shrinkCustomSelectorBatch(
+    error: unknown,
+    entity: string,
+    customFields: readonly CloseCustomField[] | null,
+  ): boolean {
+    if (!axios.isAxiosError(error) || error.response?.status !== 400) {
+      return false;
+    }
+    if (isCloseSearchCursorError(error)) return false;
+    if (!customFields || closeCustomFieldSelectors(customFields).length === 0) {
+      return false;
+    }
+    if (
+      this.customSelectorBatchSize <= CLOSE_SEARCH_MIN_CUSTOM_SELECTOR_BATCH
+    ) {
+      return false;
+    }
+
+    const previous = this.customSelectorBatchSize;
+    this.customSelectorBatchSize = Math.max(
+      CLOSE_SEARCH_MIN_CUSTOM_SELECTOR_BATCH,
+      Math.floor(previous / 2),
+    );
+    const details = {
+      entity,
+      previousBatchSize: previous,
+      newBatchSize: this.customSelectorBatchSize,
+      responseBody: formatCloseApiErrorResponse(error),
+    };
+    this.emitSyncLog(
+      "warn",
+      "Close rejected the field selection, retrying with fewer custom selectors per request",
+      details,
+    );
+    logger.warn(
+      "Close rejected Search API field selection, shrinking batch",
+      details,
+    );
+    return true;
+  }
+
+  /**
+   * Re-fetch one already-paged set of rows by id, one request per selector
+   * batch, and merge the returned `custom.cf_*` keys into the rows.
+   *
+   * This is what lets every custom field be requested explicitly on orgs
+   * with more fields than Close accepts in a single `_fields` list: the paged
+   * request carries the base fields plus the first batch, and each remaining
+   * batch is fetched here for exactly the ids of that page. Row order and
+   * the page cursor are untouched.
+   */
+  private async fetchSupplementalCustomFields(
+    api: AxiosInstance,
+    objectType: string,
+    rows: any[],
+    supplemental: string[][],
+  ): Promise<any[]> {
+    const ids = rows
+      .map(row => (typeof row?.id === "string" ? row.id : ""))
+      .filter(id => id.length > 0);
+    if (ids.length === 0) return rows;
+
+    const byId = new Map<string, Record<string, unknown>>();
+    for (const row of rows) {
+      if (row && typeof row.id === "string") byId.set(row.id, row);
+    }
+
+    const idQuery = {
+      negate: false,
+      type: "and",
+      queries: [
+        { negate: false, type: "object_type", object_type: objectType },
+        {
+          negate: false,
+          type: "or",
+          queries: ids.map(id => ({ negate: false, type: "id", value: id })),
+        },
+      ],
+    };
+
+    // Work through the batches; a batch that Close rejects is re-split with
+    // the (now smaller) budget instead of being dropped.
+    let pending: string[][] = supplemental.map(batch => [...batch]);
+    while (pending.length > 0) {
+      const batch = pending[0];
+      try {
+        const response = await api.post("/data/search/", {
+          query: idQuery,
+          _limit: ids.length,
+          _fields: { [objectType]: batch },
+        });
+        const extra: any[] = response.data?.data || [];
+        for (const row of extra) {
+          if (!row || typeof row.id !== "string") continue;
+          const target = byId.get(row.id);
+          if (!target) continue;
+          for (const [key, value] of Object.entries(row)) {
+            if (key === "id" || key === "__object_type") continue;
+            target[key] = value;
+          }
+        }
+        pending.shift();
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 429) {
+          const retryAfter = parseInt(
+            error.response.headers["retry-after"] || "60",
+          );
+          this.emitSyncLog("warn", "Close API rate limited, waiting", {
+            retryAfterSeconds: retryAfter,
+            objectType,
+          });
+          await this.sleep(retryAfter * 1000);
+          continue;
+        }
+        const remainingFields: CloseCustomField[] = pending
+          .flatMap(b => b.filter(field => field !== "id"))
+          .map(selector => ({
+            id: selector.replace(/^custom\./, ""),
+            name: selector,
+            type: "text",
+            appliesTo: objectType,
+          }));
+        const replan = (fields: readonly CloseCustomField[]) => {
+          const plan = splitCloseSearchFieldSelection(
+            [],
+            fields,
+            this.customSelectorBatchSize,
+          );
+          // `primary` is `id` + the first batch; the rest are already
+          // shaped as supplemental batches.
+          pending = plan.supplemental;
+          if (plan.primary.length > 1) pending.unshift(plan.primary);
+        };
+
+        if (axios.isAxiosError(error) && error.response?.status === 400) {
+          const refreshed = await this.refreshCustomFieldsViaSchema(objectType);
+          const current = new Set(closeCustomFieldSelectors(refreshed));
+          const stillValid = remainingFields.filter(field =>
+            current.has(`custom.${field.id}`),
+          );
+          if (
+            stillValid.length !== remainingFields.length &&
+            this.customFieldSelectionChanged(
+              objectType,
+              remainingFields,
+              stillValid,
+              error,
+            )
+          ) {
+            replan(stillValid);
+            continue;
+          }
+          if (
+            this.shrinkCustomSelectorBatch(error, objectType, remainingFields)
+          ) {
+            replan(remainingFields);
+            continue;
+          }
+        }
+        throw error;
+      }
+    }
+
+    return rows;
   }
 
   /**

--- a/api/src/connectors/close/schema.ts
+++ b/api/src/connectors/close/schema.ts
@@ -564,12 +564,68 @@ export function buildCloseSearchFieldSelection(
   baseFields: readonly string[],
   customFields: CloseCustomField[],
 ): string[] {
-  const fields = new Set<string>([...baseFields, "custom"]);
-  for (const field of customFields) {
-    if (!field.id) continue;
-    fields.add(`custom.${field.id}`);
+  const fields = new Set<string>(baseFields);
+  for (const selector of closeCustomFieldSelectors(customFields)) {
+    fields.add(selector);
   }
   return Array.from(fields);
+}
+
+/** `custom.cf_<id>` selectors for every custom field, deduplicated, in order. */
+export function closeCustomFieldSelectors(
+  customFields: readonly CloseCustomField[],
+): string[] {
+  const selectors: string[] = [];
+  const seen = new Set<string>();
+  for (const field of customFields) {
+    if (!field.id) continue;
+    const selector = `custom.${field.id}`;
+    if (seen.has(selector)) continue;
+    seen.add(selector);
+    selectors.push(selector);
+  }
+  return selectors;
+}
+
+export interface CloseSearchFieldSelectionPlan {
+  /** Fields for the paged Search request: base fields + the first batch. */
+  primary: string[];
+  /**
+   * Fields for follow-up requests that re-fetch the SAME page by id. Each
+   * entry starts with `id` (the merge key) followed by one batch of
+   * `custom.cf_*` selectors. Empty when everything fits in `primary`.
+   */
+  supplemental: string[][];
+}
+
+/**
+ * Split a Search API field selection so no single request names more than
+ * `maxCustomSelectorsPerRequest` custom-field selectors.
+ *
+ * Close rejects a `_fields` list past a certain size with HTTP 400. Orgs with
+ * 100+ lead custom fields hit that ceiling the moment every field is
+ * requested explicitly (which we do so values arrive as flat `custom.cf_*`
+ * keys — the same shape webhooks deliver — instead of through the deprecated
+ * `custom` blob). Rather than drop selectors, the selection is spread over
+ * one primary request and as many supplemental by-id requests as needed.
+ */
+export function splitCloseSearchFieldSelection(
+  baseFields: readonly string[],
+  customFields: readonly CloseCustomField[],
+  maxCustomSelectorsPerRequest: number,
+): CloseSearchFieldSelectionPlan {
+  const base = Array.from(new Set(baseFields));
+  if (!base.includes("id")) base.unshift("id");
+
+  const selectors = closeCustomFieldSelectors(customFields);
+  const size = Math.max(1, Math.floor(maxCustomSelectorsPerRequest));
+
+  const primary = [...base, ...selectors.slice(0, size)];
+  const supplemental: string[][] = [];
+  for (let offset = size; offset < selectors.length; offset += size) {
+    supplemental.push(["id", ...selectors.slice(offset, offset + size)]);
+  }
+  return { primary, supplemental };
 }
 
 export function resolveCloseEntitySchema(

--- a/api/src/connectors/probe.service.ts
+++ b/api/src/connectors/probe.service.ts
@@ -432,7 +432,18 @@ export async function probeConnection(input: ProbeInput): Promise<ProbeResult> {
       error.message = redactSecrets(error.message, secrets);
       throw error;
     }
-    const message = error instanceof Error ? error.message : String(error);
+    let message = error instanceof Error ? error.message : String(error);
+    // A vendor's 4xx body is the actionable part ("Unsupported field",
+    // "Invalid cursor", ...); axios only puts the status code in `message`.
+    const responseBody = (error as { response?: { data?: unknown } })?.response
+      ?.data;
+    if (responseBody !== undefined) {
+      const serialized =
+        typeof responseBody === "string"
+          ? responseBody
+          : JSON.stringify(responseBody);
+      message = `${message} — ${serialized.slice(0, 2_000)}`;
+    }
     throw new Error(redactSecrets(message, secrets));
   }
 }


### PR DESCRIPTION
## TL;DR

The four Close → BigQuery CDC flows (`ch_close_crm`, `fr_close_crm`, `es_close_crm`, `it_close_crm`) fail their nightly 03:00 UTC backfill at **leads** with HTTP 400, every night since **8 July 2026**, the day #677 merged. The webhook stream itself is healthy; it is the full reconcile that never completes.

Cause: #677 requests every custom field as an explicit `custom.cf_<id>` selector in the Search API `_fields`, and Close rejects that list once it gets long. These four orgs have 110–145 lead custom fields; the orgs that still work have under 50.

This PR keeps the explicit selectors (flat `custom.cf_*` keys, the same shape webhooks deliver, no reliance on the deprecated `custom` blob) but never sends more than a bounded number per request, fetches the rest by id for the same page, and self-heals when Close rejects a request or a custom field is deleted mid-run.

## Evidence

Reproduced live with `probe_connection`, which runs the same `fetchEntityChunk` path the backfill uses:

| Connection | Lead custom fields | `leads` probe |
|---|---|---|
| ch_close | ~113 | **400** |
| fr_close | ~123 | **400** |
| es_close | ~143 | **400** |
| it_close | ~111 | **400** |
| pl_close | 46 | OK |
| pt_close | 48 | OK |
| ch_close_sellers | 45 | OK |

On ch_close, `opportunities` (45 selectors) and `contacts` (1) probe fine, so it is the length of the lead field list, nothing else. ~80 total selectors work, ~140 fail; Close does not document the number.

Production state: `cdc_state_transitions` shows `backfill FAIL / Backfill execution failed` for these flows on every nightly run (e.g. `es_close_crm` from 2026-07-08 17:14 onward). `webhookevents` for the same flows are all `applyStatus: applied`, and `cdc_entity_state.lastMaterializedAt` is current, so live changes still land.

## The fix

**`schema.ts`**
- `splitCloseSearchFieldSelection(base, customFields, batch)` returns `primary` (base fields + first `batch` custom selectors) and `supplemental` (remaining selectors in batches of `batch`, each prefixed with `id` as the merge key).
- `closeCustomFieldSelectors()` dedupes selectors (shared fields are listed under several object types).

**`connector.ts` — `fetchViaSearchApi`**
- The paged request sends `primary` (60 custom selectors by default, `CLOSE_SEARCH_CUSTOM_SELECTOR_BATCH`).
- For each page received, `fetchSupplementalCustomFields` issues one by-id Search request per remaining batch (`or` of `id` queries for exactly that page's ids, `_limit` = page size) and merges the returned `custom.cf_*` keys into the rows by id. Row order and the page cursor are untouched. es_close costs 3 requests per page instead of 1.
- On a 400 for a request that carried selectors, two recoveries in order:
  1. **Schema changed mid-run** — re-read `/custom_field_schema/<type>/`; if the selector set differs (a field was deleted in Close after we cached the schema), re-plan and retry the same page. No shrink.
  2. **List too long** — halve the per-request batch (floor 5) and retry the same page. A ceiling lower than 60 costs requests, not the sync.
  Both write Close's response body to the sync log, so the real limit will be visible after the first run.
- The deprecated `custom` blob is no longer requested on lead, contact or opportunity. `flattenCustomFields` still accepts the nested form for webhook payloads.

**`probe.service.ts`**
- A failed probe now includes the vendor response body in its error. Axios only puts the status code in the message, which is why the 400 was opaque over MCP.

## Schema changes

- **Field added in Close** — webhooks carry it immediately; the CDC consumer resolves the connector schema per materialization with a fresh connector instance, and the BigQuery/ClickHouse adapters `ADD COLUMN IF NOT EXISTS`. Backfills pick it up on the next run.
- **Field deleted in Close** — previously a dangling selector would 400 the backfill forever. Now recovery (1) above. The destination column stays; values stop arriving.
- **Type changed** — unchanged: the BigQuery adapter's `evolveSchemaIfNeeded` already migrates drifted columns.

## Tests (`connector.test.ts`, 5 new)

- `splitCloseSearchFieldSelection` respects the budget, always requests `id`, dedupes.
- 130-field lead backfill against a stub that 400s above 100 fields: every request stays within budget, two by-id follow-ups target exactly the page's ids, all 130 fields land as `custom_cf_*`, no `custom` blob requested.
- Stub ceiling of 40: batch shrinks 60 → 30 → 15, sync succeeds, shrink is logged.
- Field deleted mid-run: schema re-read, selector dropped, batch **not** shrunk, sync succeeds.
- Unrelated 400 still propagates.

Also ran: probe service suite (15 passing), eslint on touched files, `tsc` with no new errors in touched files.

## Not verified against live Close

No Close API key in this environment, so two things are proven only by the stubbed tests:
1. The by-id follow-up request shape (`{type:"or", queries:[{type:"id", value}, …]}`, per the Advanced Filtering docs).
2. The batch size of 60.

Fast check after deploy: `probe_connection` on `ch_close`, entity `leads`. It runs this exact path and now includes Close's error body if anything is still wrong.

## After merge

- The nightly backfills should complete at 03:00 UTC.
- The four CDC flows carry a stale `streamState: error` badge (the state machine only leaves `error` via RECOVER). Trigger a stream RECOVER on each once a backfill has completed.

## Out of scope

The scheduled Close → RevOps (Mongo) flows fail with the same 400 and would also recover, but they are legacy and candidates for deletion rather than a reason for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012526nAND54r2uYpktZRRNw