### PR TITLE
fix(acp): retire local sessions whose Mako MCP token expired

### DIFF
--- a/app/src/lib/acp-client.ts
+++ b/app/src/lib/acp-client.ts
@@ -128,6 +128,8 @@ export const acpClient = {
     mcpServerName?: string;
     makoAgentSessionId?: string;
     makoWorkspaceId?: string;
+    /** ISO expiry of the MCP Bearer so Local Agent retires stale sessions. */
+    mcpTokenExpiresAt?: string;
     /** Lean workspace guidance for Claude systemPrompt.append (not full skills). */
     systemPromptAppend?: string;
     /** Preferred Claude/Codex model (`fable`, `sonnet`, …). */

--- a/app/src/lib/acp-session-expiry.test.ts
+++ b/app/src/lib/acp-session-expiry.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAKO_MCP_TOKEN_TTL_MS,
+  MAKO_MCP_TOKEN_REUSE_MARGIN_MS,
+  isMakoMcpTokenStale,
+  makoMcpTokenExpiresAtMs,
+} from "./acp-session-expiry";
+
+const NOW = Date.parse("2026-09-03T10:00:00.000Z");
+const HOUR = 60 * 60 * 1000;
+
+describe("isMakoMcpTokenStale", () => {
+  it("ignores sessions without Mako MCP attached", () => {
+    expect(
+      isMakoMcpTokenStale(
+        {
+          makoMcpAttached: false,
+          createdAt: new Date(NOW - 48 * HOUR).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("uses the explicit expiry when the session carries one", () => {
+    const base = {
+      makoMcpAttached: true,
+      createdAt: new Date(NOW - 20 * HOUR).toISOString(),
+    };
+    expect(
+      isMakoMcpTokenStale(
+        { ...base, makoMcpTokenExpiresAt: new Date(NOW + HOUR).toISOString() },
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      isMakoMcpTokenStale(
+        { ...base, makoMcpTokenExpiresAt: new Date(NOW - 1000).toISOString() },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a token inside the reuse margin as stale", () => {
+    const soon = new Date(
+      NOW + MAKO_MCP_TOKEN_REUSE_MARGIN_MS - 1000,
+    ).toISOString();
+    expect(
+      isMakoMcpTokenStale(
+        { makoMcpAttached: true, createdAt: "", makoMcpTokenExpiresAt: soon },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to createdAt + default TTL for older Local Agents", () => {
+    const createdAt = new Date(NOW - 2 * HOUR).toISOString();
+    expect(makoMcpTokenExpiresAtMs({ makoMcpAttached: true, createdAt })).toBe(
+      NOW - 2 * HOUR + DEFAULT_MAKO_MCP_TOKEN_TTL_MS,
+    );
+    expect(isMakoMcpTokenStale({ makoMcpAttached: true, createdAt }, NOW)).toBe(
+      false,
+    );
+    expect(
+      isMakoMcpTokenStale(
+        {
+          makoMcpAttached: true,
+          createdAt: new Date(NOW - 9 * HOUR).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("never marks a session stale when no expiry can be derived", () => {
+    expect(
+      isMakoMcpTokenStale({ makoMcpAttached: true, createdAt: "garbage" }, NOW),
+    ).toBe(false);
+  });
+});

--- a/app/src/lib/acp-session-expiry.ts
+++ b/app/src/lib/acp-session-expiry.ts
@@ -1,0 +1,51 @@
+/**
+ * Decide whether a local ACP session's Mako MCP Bearer is still usable.
+ *
+ * The `mcpat_` token is minted once on session/new and baked into the
+ * adapter's MCP headers — it cannot be refreshed. Past its expiry every
+ * `mako-workspace` tool call fails with "requires re-authorization (token
+ * expired)" while `makoMcpAttached` still reads true, so Chat must stop
+ * reusing such sessions and mint a fresh token instead.
+ */
+import type { AcpSessionInfo } from "./acp-types";
+
+/**
+ * Fallback lifetime when the session carries no explicit expiry (older Local
+ * Agent, or Chat reloaded and lost the minted value). Mirrors
+ * `ACCESS_TOKEN_TTL_MS` in `api/src/auth/mcp-oauth.service.ts`; the token is
+ * minted immediately before session/new so `createdAt` is a close proxy.
+ */
+export const DEFAULT_MAKO_MCP_TOKEN_TTL_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Stop reusing a session this long before the token actually expires so a
+ * long turn does not lose its tools halfway through.
+ */
+export const MAKO_MCP_TOKEN_REUSE_MARGIN_MS = 10 * 60 * 1000;
+
+type SessionLike = Pick<
+  AcpSessionInfo,
+  "makoMcpAttached" | "makoMcpTokenExpiresAt" | "createdAt"
+>;
+
+/** Epoch ms when the session's Mako MCP token expires; null when unknown. */
+export function makoMcpTokenExpiresAtMs(session: SessionLike): number | null {
+  if (!session.makoMcpAttached) return null;
+  if (session.makoMcpTokenExpiresAt) {
+    const explicit = Date.parse(session.makoMcpTokenExpiresAt);
+    if (Number.isFinite(explicit)) return explicit;
+  }
+  const created = Date.parse(session.createdAt || "");
+  if (!Number.isFinite(created)) return null;
+  return created + DEFAULT_MAKO_MCP_TOKEN_TTL_MS;
+}
+
+/** True when the session must not be reused for a new turn. */
+export function isMakoMcpTokenStale(
+  session: SessionLike,
+  now: number = Date.now(),
+): boolean {
+  const expiresAt = makoMcpTokenExpiresAtMs(session);
+  if (expiresAt === null) return false;
+  return now + MAKO_MCP_TOKEN_REUSE_MARGIN_MS >= expiresAt;
+}

--- a/app/src/lib/acp-types.ts
+++ b/app/src/lib/acp-types.ts
@@ -106,6 +106,11 @@ export interface AcpSessionInfo {
   busy: boolean;
   /** True when Mako `/api/mcp` was attached on session/new. */
   makoMcpAttached?: boolean;
+  /**
+   * ISO time this session's Mako MCP Bearer expires. Newer Local Agents echo
+   * it back; Chat also keeps it locally for older agents.
+   */
+  makoMcpTokenExpiresAt?: string;
   currentModel?: string | null;
   availableModels?: AcpModelChoice[];
 }

--- a/app/src/lib/local-acp-chat.ts
+++ b/app/src/lib/local-acp-chat.ts
@@ -26,6 +26,7 @@ import {
   type AcpToolUpdate,
 } from "./local-acp-parts";
 import { isAcpConnectionClosedError } from "./acp-connection-errors";
+import { isMakoMcpTokenStale } from "./acp-session-expiry";
 import {
   persistLocalAcpChat,
   type LocalAcpChatBinding,
@@ -167,6 +168,19 @@ export async function ensureAcpSessionForProvider(
   // Always reconcile with Local Agent — Desktop/agent restarts leave stale ids.
   await useAcpStore.getState().refreshSessions();
   const liveIds = new Set(useAcpStore.getState().sessions.map(s => s.id));
+  // The Mako MCP Bearer is fixed for the life of a process session and lives
+  // ~8h. Reusing a session past that makes every mako-workspace tool fail
+  // with "requires re-authorization" while the session still looks attached.
+  // Retire such sessions here so the fresh-session path below mints a new
+  // token (Chat continuity seed restores the transcript).
+  for (const stale of useAcpStore
+    .getState()
+    .sessions.filter(
+      s => s.providerId === providerId && isMakoMcpTokenStale(s),
+    )) {
+    useAcpStore.getState().forgetSession(stale.id);
+    liveIds.delete(stale.id);
+  }
   const modelPreference = options?.model?.trim() || null;
 
   if (

--- a/app/src/lib/mako-mcp-attach.ts
+++ b/app/src/lib/mako-mcp-attach.ts
@@ -14,6 +14,8 @@ export interface MakoMcpAttachCredentials {
   mcpUrl: string;
   mcpAuthorization: string;
   expiresIn: number;
+  /** ISO time the Bearer stops working; null when the API did not say. */
+  expiresAt: string | null;
   mcpServerName: string;
   agentSessionId: string;
 }
@@ -64,10 +66,18 @@ export async function mintMakoMcpAttach(
     throw new Error("Mako MCP access token is missing its agent session");
   }
 
+  const expiresIn =
+    typeof data?.expiresIn === "number" && Number.isFinite(data.expiresIn)
+      ? data.expiresIn
+      : 0;
   return {
     mcpUrl: resolveAbsoluteMcpUrl(),
     mcpAuthorization: authorization,
-    expiresIn: data?.expiresIn ?? 0,
+    expiresIn,
+    expiresAt:
+      expiresIn > 0
+        ? new Date(Date.now() + expiresIn * 1000).toISOString()
+        : null,
     mcpServerName: MAKO_WORKSPACE_MCP_NAME,
     agentSessionId: data.agentSessionId,
   };

--- a/app/src/store/acpStore.ts
+++ b/app/src/store/acpStore.ts
@@ -223,6 +223,11 @@ export const useAcpStore = create<AcpState>()(
             makoWorkspaceId:
               existingById.get(session.id)?.makoWorkspaceId ??
               session.makoWorkspaceId,
+            // Older Local Agents don't echo the token expiry; keep the value
+            // Chat recorded at mint time so stale-session checks still work.
+            makoMcpTokenExpiresAt:
+              session.makoMcpTokenExpiresAt ??
+              existingById.get(session.id)?.makoMcpTokenExpiresAt,
           }));
         });
       } catch (error) {
@@ -481,6 +486,7 @@ export const useAcpStore = create<AcpState>()(
           mcpServerName: creds.mcpServerName,
           makoAgentSessionId: creds.agentSessionId,
           makoWorkspaceId: workspaceId,
+          mcpTokenExpiresAt: creds.expiresAt ?? undefined,
           systemPromptAppend,
           model: options?.model?.trim() || undefined,
         });
@@ -504,6 +510,8 @@ export const useAcpStore = create<AcpState>()(
           makoAgentSessionId:
             session.makoAgentSessionId ?? creds.agentSessionId,
           makoWorkspaceId: session.makoWorkspaceId ?? workspaceId,
+          makoMcpTokenExpiresAt:
+            session.makoMcpTokenExpiresAt ?? creds.expiresAt ?? undefined,
         };
         set(s => {
           s.sessions = [

--- a/docs/src/content/docs/coding-agents-acp.md
+++ b/docs/src/content/docs/coding-agents-acp.md
@@ -90,6 +90,15 @@ workspace tools** banner — one click remints the token and starts a fresh ACP
 session with `mako-workspace`. You should **not** run `claude mcp` or authorize
 Claude.ai’s separate “Mako” connector.
 
+The minted MCP token is valid for 8 hours and is fixed for the life of the
+local session (the adapter cannot refresh it). Chat tracks the expiry and
+automatically retires a session whose token is about to expire, starting a
+fresh one with a new token on your next message — the transcript carries over.
+If you still see `MCP server "mako-workspace" requires re-authorization (token
+expired)` in a tool result, the session predates this check: switch the model
+away and back, or fully quit and reopen Mako Desktop, then send again. Do not
+run `/mcp` in Claude Code — there is no OAuth flow to re-run for this server.
+
 If Claude already replied that Mako needs auth, click **Enable workspace
 tools**, then send another message (or start a **New chat**). Local Agent also
 probes `/api/mcp` before session start so bad hosts/tokens fail with a clear

--- a/packages/local-agent/src/acp/mako-mcp-token-expiry.ts
+++ b/packages/local-agent/src/acp/mako-mcp-token-expiry.ts
@@ -1,0 +1,26 @@
+/**
+ * The Mako MCP Bearer (`mcpat_…`) is minted once per ACP session/new and baked
+ * into the adapter's MCP server headers; nothing can refresh it mid-session.
+ * Once it expires every `mako-workspace` tool call fails with Claude Code's
+ * "requires re-authorization (token expired)" while the session itself looks
+ * healthy. Local Agent records the expiry so prompt() can retire the session
+ * and let Chat mint a fresh token instead of reusing a dead one.
+ */
+import type { AcpSessionInfo } from "./types";
+
+/** Normalize a client-supplied expiry to ISO; undefined when absent/invalid. */
+export function parseMcpTokenExpiresAt(raw: unknown): string | undefined {
+  if (typeof raw !== "string" || !raw.trim()) return undefined;
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString();
+}
+
+export function isMakoMcpTokenExpired(
+  info: Pick<AcpSessionInfo, "makoMcpAttached" | "makoMcpTokenExpiresAt">,
+  now: number = Date.now(),
+): boolean {
+  if (!info.makoMcpAttached || !info.makoMcpTokenExpiresAt) return false;
+  const expiresAt = Date.parse(info.makoMcpTokenExpiresAt);
+  return Number.isFinite(expiresAt) && now >= expiresAt;
+}

--- a/packages/local-agent/src/acp/manager.test.ts
+++ b/packages/local-agent/src/acp/manager.test.ts
@@ -172,6 +172,52 @@ describe("AcpSessionManager with mock agent", () => {
     await manager.closeSession(without.id);
   });
 
+  it("retires a session whose Mako MCP token expired instead of prompting", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("{}", { status: 200 })) as typeof fetch;
+    try {
+      const expired = new Date(Date.now() - 1000).toISOString();
+      const session = await manager.createSession({
+        providerId: "claude",
+        cwd: process.cwd(),
+        title: "mcp-expired",
+        attachMakoMcp: true,
+        mcpUrl: "https://app.mako.ai/api/mcp",
+        mcpAuthorization: "Bearer mcpat_test",
+        mcpServerName: "mako-workspace",
+        mcpTokenExpiresAt: expired,
+      });
+      assert.equal(session.makoMcpTokenExpiresAt, expired);
+      await assert.rejects(
+        () => manager.prompt(session.id, "hello"),
+        /Send again to reconnect/,
+      );
+      assert.equal(
+        manager.listSessions().some(s => s.id === session.id),
+        false,
+      );
+
+      const fresh = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const live = await manager.createSession({
+        providerId: "claude",
+        cwd: process.cwd(),
+        title: "mcp-live",
+        attachMakoMcp: true,
+        mcpUrl: "https://app.mako.ai/api/mcp",
+        mcpAuthorization: "Bearer mcpat_test",
+        mcpServerName: "mako-workspace",
+        mcpTokenExpiresAt: fresh,
+      });
+      assert.equal(live.makoMcpTokenExpiresAt, fresh);
+      const result = await manager.prompt(live.id, "hello");
+      assert.equal(typeof result.stopReason, "string");
+      await manager.closeSession(live.id);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("rejects session/new when mcpUrl host is not a Mako API", async () => {
     await assert.rejects(
       () =>

--- a/packages/local-agent/src/acp/manager.ts
+++ b/packages/local-agent/src/acp/manager.ts
@@ -21,6 +21,10 @@ import { shouldAutoApprovePermission } from "./permissions";
 import { assertAllowedMakoMcpUrl } from "./mako-mcp-url";
 import { probeMakoMcpHttp } from "./mcp-probe";
 import {
+  isMakoMcpTokenExpired,
+  parseMcpTokenExpiresAt,
+} from "./mako-mcp-token-expiry";
+import {
   hasCodexAuthFile,
   probeCodexLoginStatus,
   shouldAutoAuthenticateOnSessionNew,
@@ -1043,6 +1047,9 @@ export class AcpSessionManager {
         makoWorkspaceId: attachMakoMcp
           ? body.makoWorkspaceId?.trim()
           : undefined,
+        makoMcpTokenExpiresAt: attachMakoMcp
+          ? parseMcpTokenExpiresAt(body.mcpTokenExpiresAt)
+          : undefined,
       };
 
       const managed: ManagedSession = {
@@ -1178,6 +1185,20 @@ export class AcpSessionManager {
     if (!session?.active) {
       throw new Error(
         `Unknown or expired ACP session: ${sessionId}. Send again to reconnect.`,
+      );
+    }
+    // The Mako MCP Bearer cannot be refreshed inside a running adapter
+    // session. Prompting past its expiry would make every mako-workspace tool
+    // fail with "requires re-authorization" — retire the session instead so
+    // Chat's reconnect path mints a fresh token and starts a new one.
+    if (isMakoMcpTokenExpired(session.info)) {
+      acpLog.info("ACP session Mako MCP token expired — closing session", {
+        sessionId,
+        expiresAt: session.info.makoMcpTokenExpiresAt,
+      });
+      await this.closeSession(sessionId);
+      throw new Error(
+        `Unknown or expired ACP session: ${sessionId} (Mako workspace token expired). Send again to reconnect.`,
       );
     }
     if (!text.trim() && images.length === 0) {

--- a/packages/local-agent/src/acp/types.ts
+++ b/packages/local-agent/src/acp/types.ts
@@ -61,6 +61,12 @@ export interface AcpSessionInfo {
   makoAgentSessionId?: string;
   /** Workspace bound to the attached Mako MCP token. */
   makoWorkspaceId?: string;
+  /**
+   * ISO time the attached Mako MCP Bearer stops working. The header is fixed
+   * for the life of the adapter session, so prompt() retires the session once
+   * this passes and Chat mints a fresh token on the next send.
+   */
+  makoMcpTokenExpiresAt?: string;
   /** Current Claude/Codex model id from session configOptions (when known). */
   currentModel?: string | null;
   /** Selectable models advertised by the adapter for this session. */
@@ -183,6 +189,8 @@ export interface CreateAcpSessionRequest {
   makoAgentSessionId?: string;
   /** Workspace bound to the attached MCP token. */
   makoWorkspaceId?: string;
+  /** ISO time the MCP Bearer expires (from the mint response `expiresIn`). */
+  mcpTokenExpiresAt?: string;
   /**
    * MCP server name advertised to the agent (Claude tool prefix mcp__{name}__).
    * Default `mako-workspace` — avoid `mako` which collides with Claude.ai connectors.


### PR DESCRIPTION
## Problem

Using Claude Code (local) in Desktop, every `mako-workspace` tool call eventually fails with:

```
MCP server "mako-workspace" requires re-authorization (token expired)
```

The `mcpat_` Bearer attached on ACP `session/new` is minted once with an 8h TTL (`ACCESS_TOKEN_TTL_MS`) and baked into the adapter's MCP headers, so it can never be refreshed. Chat kept reusing the same Local Agent process session across chats for as long as Desktop stayed open, and once the token lapsed the API answered 401 while the session still reported `makoMcpAttached=true`. The **Enable workspace tools** banner therefore never showed, the error arrives as tool-result content rather than an ACP error so the reconnect path never fired, and the only recovery was quitting and reopening Desktop. Claude's own advice (`/mcp` re-auth) cannot apply: there is no OAuth flow for this server.

## Fix

- **Chat (`app`)** records the token expiry from the mint response (`expiresIn`) on the session. Before each turn, `ensureAcpSessionForProvider` forgets any session whose token is expired or within 10 minutes of expiring, then falls through to the existing fresh-session path, which mints a new token. The transcript carries over through the continuity seed. Sessions without a recorded expiry (older Desktop builds, reloaded tab) fall back to `createdAt + 8h`, so this works against today's Desktop without an update.
- **Local Agent** accepts `mcpTokenExpiresAt` on `session/new`, echoes it back as `makoMcpTokenExpiresAt`, and refuses to prompt an expired session: it closes it and returns the existing "Send again to reconnect" error that Chat already auto-recovers from. Ships with the next Desktop release.
- **Docs** (`coding-agents-acp.md`) explain the 8h token and that `/mcp` re-auth does not apply.

Out of scope: a token revoked manually under Workspace Settings → MCP connections shows the same error; not handled here.

## Verification

- `packages/local-agent`: `tsc --noEmit` clean; `manager.test.ts` 11/11 pass including the new expired/live token test.
- `app`: `tsc --noEmit` clean; eslint clean on touched files; new `acp-session-expiry.test.ts` passes.
- No API route or schema change, so no `openapi:sync` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR9DkbHG1t2KaE6o1DzJAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR9DkbHG1t2KaE6o1DzJAE)_