### PR TITLE
fix(app): periodic full reconcile is opt-in, never switched on for the user

### DIFF
--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -293,7 +293,6 @@ export function SyncFlowForm({
   // guards against. Reset to false whenever a different existing flow loads;
   // always "touched" for brand-new flows (nothing saved to protect there).
   const formTouchedRef = useRef(isNew);
-  const reconcileAutoEnabledRef = useRef(false);
 
   const toggleStep = (stepIndex: number) => {
     // Keep Triggers open while provisioning, and after success until the
@@ -613,24 +612,11 @@ export function SyncFlowForm({
     setValue,
   ]);
 
-  // Auto-suggest (and once soft-enable) periodic reconcile for Incremental
-  // flows whose selected entities are created-anchor or none — polls alone
-  // cannot catch updates / will silent-full-repull those streams.
-  useEffect(() => {
-    if (!suggestReconcile || !formTouchedRef.current) return;
-    if (watchBackfillScheduleEnabled) return;
-    if (reconcileAutoEnabledRef.current) return;
-    reconcileAutoEnabledRef.current = true;
-    setValue("backfillScheduleEnabled", true, { shouldDirty: true });
-    const cron = getValues("backfillScheduleCron");
-    if (!cron) {
-      setValue("backfillScheduleCron", "0 3 * * *", { shouldDirty: true });
-    }
-    const tz = getValues("backfillScheduleTimezone");
-    if (!tz) {
-      setValue("backfillScheduleTimezone", "UTC", { shouldDirty: true });
-    }
-  }, [suggestReconcile, watchBackfillScheduleEnabled, setValue, getValues]);
+  // The periodic full reconcile is opt-in. When Incremental polls cannot see
+  // updates for the selected entities (created-anchor or none), the form
+  // RECOMMENDS it (warning + "Enable daily" button, see step 3) but never
+  // switches it on by itself: a reconcile re-upserts every current record on
+  // a cron, which is a cost and a load on the source the user must choose.
 
   // transferQueries schema (GraphQL/PostHog-style connectors).
   // Stale-while-revalidate: show the persisted cache immediately, but always


### PR DESCRIPTION
## Summary

The sync form flipped the **Periodic full reconcile** trigger on by itself whenever an Incremental flow's selected entities were created-anchor or none: immediately for a new flow, and for an existing flow the moment any field was touched. Users who deliberately left it off then saved a daily cron they never chose, and the checkbox appeared to re-check itself.

This removes the effect that set the value. The recommendation stays as an opt-in: the warning box, the "Enable daily" button, and the "Enable reconcile" button in the Sync Mode step still work, but nothing turns the trigger on for the user. A reconcile re-upserts every current record on a schedule, which is a cost and a load on the source that the user has to choose.

## Changes

- `app/src/components/SyncFlowForm.tsx`: drop the auto-enable `useEffect` and its `reconcileAutoEnabledRef` guard; leave the suggestion UI untouched.

## Verification

- `tsc --noEmit` and `eslint` pass for the app package.
- The pre-commit lint-staged hooks (eslint --fix, prettier) ran clean.

## Not in this PR

The `"undefined" is not valid JSON` error seen in the Flows sidebar while saving `it_close → bigquery_write` was investigated but not reproduced; the flow update route, its validator, the git write-through, and the typed client were all ruled out. The server log entry `Error updating flow` / `Unhandled API error` for that request is needed to pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHiztpVEmnJPdpBn4P9cu1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHiztpVEmnJPdpBn4P9cu1)_