### PR TITLE
fix(flows): harden GET/list against unsavable git files

### DIFF
--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -394,6 +394,26 @@ describe("GET/list from git", () => {
     expect(plain.writeMode).toBe("append_dedup");
   });
 
+  it("does not 500 GET/list when one file's connector_id is not an ObjectId", async () => {
+    await push({
+      "flows/a-by-name.yml": flowYaml("By name").replace(
+        `connector_id: ${CONNECTOR}`,
+        "connector_id: close",
+      ),
+      "flows/z-good-one.yml": flowYaml("Good"),
+    });
+
+    await expect(loadLiveFlows(WS)).resolves.toHaveLength(2);
+    const plains = (await loadLiveFlows(WS)).map(item =>
+      liveFlowToPlain(item, WS),
+    );
+    const bad = plains.find(item => item.slug === "a-by-name");
+    const good = plains.find(item => item.slug === "z-good-one");
+    expect(bad?.definitionInvalid).toBeTruthy();
+    expect(good?.name).toBe("Good");
+    expect(good?.definitionInvalid).toBeUndefined();
+  });
+
   it("does not list leftover local git or Mongo when no GitHub repo is bound", async () => {
     await push({ "flows/leftover.yml": flowYaml("Leftover") });
     await syncFlowsFromRepo(WS, "user-42");

--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -351,6 +351,30 @@ describe("GET/list from git", () => {
     expect(await loadLiveFlowById(WS, row!._id.toString())).toBeNull();
   });
 
+  it("does not throw when a file at main parses but fails schema save", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+    await syncFlowsFromRepo(WS, "user-42");
+    await push({
+      "flows/close-to-bigquery.yml": flowYaml("Renamed").replace(
+        "write_mode: append_dedup",
+        "write_mode: not_a_real_mode",
+      ),
+    });
+
+    // GET/list must not 500 the explorer because one file is unsavable.
+    // syncFlowsFromRepo already swallows this; ensureFlowDerivedCache did not.
+    await expect(loadLiveFlows(WS)).resolves.toHaveLength(1);
+    const row = await Flow.findOne({
+      workspaceId: WS,
+      slug: "close-to-bigquery",
+    });
+    expect(row?.name).toBe("Close → BigQuery");
+    expect(row?.writeMode).toBe("append_dedup");
+    expect(row?.definitionInvalid?.reason).toMatch(
+      /writeMode|write_mode|enum/i,
+    );
+  });
+
   it("does not list leftover local git or Mongo when no GitHub repo is bound", async () => {
     await push({ "flows/leftover.yml": flowYaml("Leftover") });
     await syncFlowsFromRepo(WS, "user-42");

--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -375,6 +375,25 @@ describe("GET/list from git", () => {
     );
   });
 
+  it("does not serve a schema-invalid file as a live definition", async () => {
+    await push({ "flows/close-to-bigquery.yml": flowYaml("Close → BigQuery") });
+    await syncFlowsFromRepo(WS, "user-42");
+    await push({
+      "flows/close-to-bigquery.yml": flowYaml("Renamed").replace(
+        "write_mode: append_dedup",
+        "write_mode: not_a_real_mode",
+      ),
+    });
+
+    const listed = await loadLiveFlows(WS);
+    const plain = liveFlowToPlain(listed[0], WS);
+    // Git is the store, but a file the reactor cannot save must not be
+    // applied over the last-good row or look valid in GET/list.
+    expect(plain.definitionInvalid).toBeTruthy();
+    expect(plain.name).toBe("Close → BigQuery");
+    expect(plain.writeMode).toBe("append_dedup");
+  });
+
   it("does not list leftover local git or Mongo when no GitHub repo is bound", async () => {
     await push({ "flows/leftover.yml": flowYaml("Leftover") });
     await syncFlowsFromRepo(WS, "user-42");

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -377,7 +377,17 @@ export async function ensureFlowDerivedCache(flow: {
   }
   row.definitionInvalid = undefined;
   row.sourceBlobSha = sha;
-  await row.save();
+  try {
+    await row.save();
+  } catch (error) {
+    // applyDefinition already mutated `row`. Saving that document again
+    // (via markFlowInvalid) would re-raise the same ValidationError and
+    // 500 GET/list. Reload the persisted row, then stamp invalid.
+    const reason = error instanceof Error ? error.message : String(error);
+    const fresh = await Flow.findById(flow._id);
+    if (fresh) await markFlowInvalid(fresh, reason, path);
+    return "invalid";
+  }
   return "resynced";
 }
 

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -285,8 +285,8 @@ export async function loadLiveFlowById(
 
 /**
  * Git definition overlaid on the Mongo runtime row (or a stub when the
- * file has no row). Never copies a Mongo-only definition into the
- * response: the body comes from the file when it parses.
+ * file has no row). The body comes from the file when it parses AND
+ * applies; a file the reactor would refuse must not look valid in GET.
  */
 export function liveFlowToPlain(
   live: LiveFlow,
@@ -305,18 +305,37 @@ export function liveFlowToPlain(
   base._id = live.id;
   base.slug = live.def.slug;
   base.workspaceId = live.row?.workspaceId ?? new Types.ObjectId(workspaceId);
-  if (live.def.parsed) {
-    applyDefinition(base as unknown as IFlow, live.def.parsed);
-    base.sourceBlobSha = live.def.oid;
-    delete base.definitionInvalid;
-  } else {
+  const parsed = live.def.parsed;
+  const createdBy =
+    typeof live.row?.createdBy === "string" && live.row.createdBy
+      ? live.row.createdBy
+      : "git";
+  if (!parsed) {
     base.definitionInvalid = live.row?.definitionInvalid ?? {
       reason: "unparseable flow file",
       at: new Date(),
       path: live.def.path,
     };
     base.sourceBlobSha = live.def.oid;
+    return base;
   }
+  const applyFailure = flowFileApplyFailure(parsed, {
+    workspaceId,
+    slug: live.def.slug,
+    createdBy,
+  });
+  if (applyFailure) {
+    base.definitionInvalid = live.row?.definitionInvalid ?? {
+      reason: applyFailure,
+      at: new Date(),
+      path: live.def.path,
+    };
+    base.sourceBlobSha = live.def.oid;
+    return base;
+  }
+  applyDefinition(base as unknown as IFlow, parsed);
+  base.sourceBlobSha = live.def.oid;
+  delete base.definitionInvalid;
   return base;
 }
 
@@ -516,6 +535,17 @@ function applyDefinition(doc: IFlow, file: FlowFile): string | null {
     } as IFlow["conflictConfig"];
   }
   return null;
+}
+
+/** Why a parsed file cannot become a row — refusal or schema, same as save(). */
+function flowFileApplyFailure(
+  file: FlowFile,
+  args: { workspaceId: string; slug: string; createdBy: string },
+): string | null {
+  const hydrated = hydrateFlowRow(file, args);
+  if (hydrated.refusal) return hydrated.refusal;
+  if (hydrated.schemaErrors.length === 0) return null;
+  return hydrated.schemaErrors.map(e => `${e.path}: ${e.message}`).join("; ");
 }
 
 /** What a file would produce if it were written onto a fresh row. */

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -586,7 +586,12 @@ export function hydrateFlowRow(
     createdBy: args.createdBy,
   }) as unknown as IFlow;
 
-  const refusal = applyDefinition(doc, file);
+  let refusal: string | null;
+  try {
+    refusal = applyDefinition(doc, file);
+  } catch (error) {
+    refusal = error instanceof Error ? error.message : String(error);
+  }
   if (refusal) return { refusal, schemaErrors: [] };
 
   // validateSync() runs the schema's own validators in-process and touches no


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #969 (flows GET/list from git at main). Three adversarial passes against the new read path each found a real break; each got a fix.

1. **GET/list 500ed** when a file at main parsed but `save()` failed schema validation (`write_mode` outside the enum). `ensureFlowDerivedCache` now reloads the persisted row and marks it invalid instead of throwing.
2. **GET served the unsavable file as live.** `liveFlowToPlain` applied any YAML that parsed and cleared `definitionInvalid`. It now probes with `hydrateFlowRow` and keeps the last-good row flagged invalid.
3. **GET/list 500ed** on a git-only file whose `connector_id` is not an ObjectId (`close`). `hydrateFlowRow` now treats `applyDefinition` throws as a refusal, matching the push reactor, so one bad file cannot take down the list.

Writes from #961 are unchanged. Unbound GET/list is still `200 { data: [] }`. The Flow collection is still the derived index.

## Test plan

- [x] Round 1: `loadLiveFlows` does not throw on `write_mode: not_a_real_mode`; Mongo row kept and marked invalid
- [x] Round 2: `liveFlowToPlain` keeps last-good name/writeMode and `definitionInvalid` for that file
- [x] Round 3: git-only `connector_id: close` plus a valid neighbor — list returns both, bad file flagged, good file intact
- [x] Existing GET/list cases (git-only, Mongo-only, unbound leftover git, stale SHA)
- [x] `pnpm --filter api run lint` (0 errors)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c6a1fa1-5920-4740-b6b1-fe953969d02a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c6a1fa1-5920-4740-b6b1-fe953969d02a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

