### PR TITLE
Restore fullscreen app sharing

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -26,6 +26,9 @@ concurrency:
 # stays in the prod project. Project-scoped values live on each deploy job.
 env:
   GCP_REGION: ${{ vars.GCP_REGION }}
+  # Workspace GitHub installation ids are copied into preview databases and
+  # are scoped to this App. Every environment must therefore use one App.
+  EXPECTED_MAKO_GITHUB_APP_ID: "4106865"
 
 permissions:
   contents: read
@@ -239,6 +242,13 @@ jobs:
       MAKO_GITHUB_APP_CLIENT_ID: ${{ vars.MAKO_GITHUB_APP_CLIENT_ID }}
       MAKO_GITHUB_APP_CLIENT_SECRET: ${{ secrets.MAKO_GITHUB_APP_CLIENT_SECRET }}
     steps:
+      - name: Validate canonical GitHub App
+        run: |
+          if [ "${MAKO_GITHUB_APP_ID}" != "${EXPECTED_MAKO_GITHUB_APP_ID}" ]; then
+            echo "::error title=GitHub App mismatch::All environments must use GitHub App ${EXPECTED_MAKO_GITHUB_APP_ID}; this job resolved ${MAKO_GITHUB_APP_ID:-unset}."
+            exit 1
+          fi
+
       - name: Warn if branch Inngest event key is missing
         # NOTE: the `secrets` context is NOT allowed in `if:` conditionals — it
         # makes the whole workflow file invalid (every run fails at 0s with no
@@ -909,6 +919,13 @@ jobs:
       MAKO_GITHUB_APP_CLIENT_ID: ${{ vars.MAKO_GITHUB_APP_CLIENT_ID }}
       MAKO_GITHUB_APP_CLIENT_SECRET: ${{ secrets.MAKO_GITHUB_APP_CLIENT_SECRET }}
     steps:
+      - name: Validate canonical GitHub App
+        run: |
+          if [ "${MAKO_GITHUB_APP_ID}" != "${EXPECTED_MAKO_GITHUB_APP_ID}" ]; then
+            echo "::error title=GitHub App mismatch::All environments must use GitHub App ${EXPECTED_MAKO_GITHUB_APP_ID}; this job resolved ${MAKO_GITHUB_APP_ID:-unset}."
+            exit 1
+          fi
+
       - name: Resolve production deployment target
         env:
           CONFIG: ${{ env.PROD_DEPLOY_CONFIG }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -153,6 +153,9 @@ jobs:
       GCP_PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
       GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_DEV_ARTIFACT_REPOSITORY }}
       GCS_DASHBOARD_BUCKET: ${{ vars.GCS_DEV_DASHBOARD_BUCKET }}
+      # The cloned DB references immutable deployments published in prod.
+      # Preview writes remain in GCS_DASHBOARD_BUCKET; this source is read-only.
+      APPS_ARTIFACT_SOURCE_BUCKET: ${{ vars.APPS_ARTIFACT_SOURCE_BUCKET }}
       PR_NUMBER: ${{ needs.detect-changes.outputs.pr_number }}
       BASE_URL: https://pr-${{ needs.detect-changes.outputs.pr_number }}.mako.ai
       CLIENT_URL: https://pr-${{ needs.detect-changes.outputs.pr_number }}.mako.ai
@@ -246,6 +249,10 @@ jobs:
         run: |
           if [ "${MAKO_GITHUB_APP_ID}" != "${EXPECTED_MAKO_GITHUB_APP_ID}" ]; then
             echo "::error title=GitHub App mismatch::All environments must use GitHub App ${EXPECTED_MAKO_GITHUB_APP_ID}; this job resolved ${MAKO_GITHUB_APP_ID:-unset}."
+            exit 1
+          fi
+          if [ -z "${APPS_ARTIFACT_SOURCE_BUCKET}" ]; then
+            echo "::error title=Published app source missing::APPS_ARTIFACT_SOURCE_BUCKET must point at the canonical published-app bucket."
             exit 1
           fi
 
@@ -604,6 +611,7 @@ jobs:
             --set-env-vars DASHBOARD_ARTIFACT_STORE=gcs \
             --set-env-vars DATABASE_URL=${{ steps.db-url.outputs.db_url }} \
             --set-env-vars GCS_DASHBOARD_BUCKET=${GCS_DASHBOARD_BUCKET} \
+            --set-env-vars APPS_ARTIFACT_SOURCE_BUCKET=${APPS_ARTIFACT_SOURCE_BUCKET} \
             --set-env-vars DISABLE_SCHEDULED_SYNC=true \
             --set-env-vars PRODUCTION_URL=${PRODUCTION_URL} \
             --set-env-vars ENCRYPTION_KEY=${ENCRYPTION_KEY} \

--- a/api/src/apps/cloud-repo.service.test.ts
+++ b/api/src/apps/cloud-repo.service.test.ts
@@ -5,8 +5,8 @@
  * GitHub auth are mocked at the module boundary. What must hold:
  *
  *  - a workspace binding is the mirror, but only where the
- *    connected tier is enabled (prod / explicit opt-in) — previews and dev on
- *    prod-cloned DBs must treat customer bindings as inert
+ *    connected tier is enabled (prod / explicit opt-in) for WRITES; previews
+ *    and dev may restore the local cache from it but must never push
  *  - connect-time adoption: seed an empty repo, import a non-empty repo into
  *    an empty workspace, reconnect a repo that shares the workspace's
  *    history (unlink never touches the local repo, so a re-link finds both
@@ -71,6 +71,7 @@ import {
   resolveMirrorTarget,
   freshenForServe,
 } from "./cloud-repo.service";
+import { boundRepoDirIfExists } from "./workspace-repo-required";
 
 let tmpRoot: string;
 let remotesRoot: string;
@@ -170,6 +171,44 @@ describe("resolveMirrorTarget", () => {
     state.binding = { owner: "acme", repo: "site" };
     const target = await resolveMirrorTarget(workspaceId);
     expect(target).toBeNull();
+  });
+});
+
+describe("read-only mirror access", () => {
+  it("restores a cold preview cache without enabling pushes", async () => {
+    delete process.env.APPS_CONNECTED_REPO_PUSH;
+    const remoteDir = path.join(remotesRoot, "acme", "preview.git");
+    await fs.mkdir(path.dirname(remoteDir), { recursive: true });
+    await initRepo(remoteDir, {
+      "apps/site/mako.json": "{}",
+      "consoles/report.sql": "select 1",
+      "dbt/dbt_project.yml": "name: preview",
+    });
+    state.binding = { owner: "acme", repo: "preview" };
+
+    const restoredRepoDir = await boundRepoDirIfExists(workspaceId);
+
+    expect(restoredRepoDir).toBe(repoDirFor(workspaceId));
+    expect(await repoExists(repoDirFor(workspaceId))).toBe(true);
+    expect(
+      (await listTree(repoDirFor(workspaceId), DEFAULT_BRANCH)).map(
+        entry => entry.path,
+      ),
+    ).toEqual([
+      "apps/site/mako.json",
+      "consoles/report.sql",
+      "dbt/dbt_project.yml",
+    ]);
+
+    await commitFiles(
+      repoDirFor(workspaceId),
+      { "preview-only.txt": "must stay local" },
+      "preview-only change",
+    );
+    await mirrorPushNow(workspaceId);
+    expect(
+      (await listTree(remoteDir, DEFAULT_BRANCH)).map(entry => entry.path),
+    ).not.toContain("preview-only.txt");
   });
 });
 

--- a/api/src/apps/cloud-repo.service.ts
+++ b/api/src/apps/cloud-repo.service.ts
@@ -12,11 +12,13 @@
  * mirror is reset to it with its commits parked under `refs/mako/diverged/*`
  * (`fetchFromCloud`).
  *
- * The connected tier only engages on production (APPS_REQUIRE_CONNECTED_REPO)
- * or under the explicit APPS_CONNECTED_REPO_PUSH=allow opt-in. Previews and
- * dev run on prod-cloned databases that carry REAL customer bindings, and a
- * test commit must never land in a customer repo — gated environments treat
- * the binding as inert metadata and keep local-only bare repos.
+ * Reads always use a connected repo when one is bound: serverless preview
+ * instances have an empty filesystem and must be able to rebuild their local
+ * cache. Writes to that repo only engage on production
+ * (APPS_REQUIRE_CONNECTED_REPO) or under the explicit
+ * APPS_CONNECTED_REPO_PUSH=allow opt-in. Previews and dev can therefore read
+ * real workspace content without a test commit ever landing in a customer
+ * repo.
  *
  * The local bare repo remains the working store the API reads from; the
  * mirror is the durable replica. Mirror pushes run after commits/merges
@@ -68,13 +70,15 @@ export type MirrorTarget = {
 };
 
 /**
- * The workspace's durable mirror: the connected repo when one is bound and
- * the tier is enabled here, else null (local-only).
+ * Resolve the bound repository for read-only clone/fetch operations.
+ *
+ * This deliberately ignores the push gate. Preview instances start with an
+ * empty APPS_GIT_ROOT, so treating the binding as wholly inert also makes all
+ * git-backed apps, consoles, and dbt files disappear.
  */
-export async function resolveMirrorTarget(
+async function resolveReadableMirrorTarget(
   workspaceId: string,
 ): Promise<MirrorTarget | null> {
-  if (!connectedTierEnabled()) return null;
   const binding = await getWorkspaceRepo(workspaceId).catch(() => null);
   if (!binding) return null;
   return {
@@ -83,6 +87,17 @@ export async function resolveMirrorTarget(
     repo: binding.repo,
     installationId: binding.installationId,
   };
+}
+
+/**
+ * The workspace's durable mirror: the connected repo when one is bound and
+ * pushes are enabled here, else null (local-only writes).
+ */
+export async function resolveMirrorTarget(
+  workspaceId: string,
+): Promise<MirrorTarget | null> {
+  if (!connectedTierEnabled()) return null;
+  return resolveReadableMirrorTarget(workspaceId);
 }
 
 async function tokenFor(target: MirrorTarget): Promise<string | undefined> {
@@ -155,7 +170,7 @@ export async function ensureLocalRepo(workspaceId: string): Promise<void> {
   const existing = cloneInFlight.get(workspaceId);
   if (existing) return existing;
   const run = (async () => {
-    const target = await resolveMirrorTarget(workspaceId);
+    const target = await resolveReadableMirrorTarget(workspaceId);
     if (!target) return;
     const token = await tokenFor(target);
     await cloneMirrorInto(
@@ -400,7 +415,7 @@ export async function fetchFromCloud(
   workspaceId: string,
   branch: string,
 ): Promise<void> {
-  const target = await resolveMirrorTarget(workspaceId);
+  const target = await resolveReadableMirrorTarget(workspaceId);
   if (!target) return;
   const repoDir = repoDirFor(workspaceId);
   const token = await tokenFor(target);

--- a/api/src/apps/deployment.service.test.ts
+++ b/api/src/apps/deployment.service.test.ts
@@ -12,10 +12,32 @@ vi.mock("../services/dashboard-artifact-store.service", () => ({
   getArtifactSourceStore: () => stores.source ?? null,
 }));
 
+vi.mock("./bindings.service", () => ({
+  bindingArtifactKeyByName: vi.fn(
+    async () => "apps/bindings/connection/binding.parquet",
+  ),
+  readBindings: vi.fn(async () => []),
+}));
+
+vi.mock("../database/workspace-schema", () => ({
+  AppProject: {
+    findById: vi.fn(async () => ({ _id: "project" })),
+    updateOne: vi.fn(),
+  },
+}));
+
+vi.mock("../services/artifact-delivery.service", () => ({
+  serveParquetArtifact: vi.fn(
+    async (store, key) =>
+      new Response(`${store === stores.source}:${key}`, { status: 200 }),
+  ),
+}));
+
 import {
   deploymentExists,
   deploymentKey,
   readDeploymentAsset,
+  serveDeploymentFile,
 } from "./deployment.service";
 
 function mockStore(existingKeys: string[]): DashboardArtifactStore {
@@ -66,5 +88,21 @@ describe("published deployment artifact source", () => {
 
     expect(stores.primary.exists).toHaveBeenCalledWith(indexKey);
     expect(stores.source.exists).not.toHaveBeenCalled();
+  });
+
+  it("serves published binding data from the read-only source", async () => {
+    const bindingKey = "apps/bindings/connection/binding.parquet";
+    stores.source = mockStore([bindingKey]);
+
+    const response = await serveDeploymentFile({
+      projectId,
+      sha,
+      assetPath: "__data/icp_customers.parquet",
+    });
+
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe(`true:${bindingKey}`);
+    expect(stores.primary.exists).toHaveBeenCalledWith(bindingKey);
+    expect(stores.source.exists).toHaveBeenCalledWith(bindingKey);
   });
 });

--- a/api/src/apps/deployment.service.test.ts
+++ b/api/src/apps/deployment.service.test.ts
@@ -1,0 +1,70 @@
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardArtifactStore } from "../services/dashboard-artifact-store.service";
+
+const stores = vi.hoisted(() => ({
+  primary: undefined as DashboardArtifactStore | undefined,
+  source: undefined as DashboardArtifactStore | undefined,
+}));
+
+vi.mock("../services/dashboard-artifact-store.service", () => ({
+  getDashboardArtifactStore: () => stores.primary,
+  getArtifactSourceStore: () => stores.source ?? null,
+}));
+
+import {
+  deploymentExists,
+  deploymentKey,
+  readDeploymentAsset,
+} from "./deployment.service";
+
+function mockStore(existingKeys: string[]): DashboardArtifactStore {
+  const keys = new Set(existingKeys);
+  return {
+    type: "gcs",
+    exists: vi.fn(async key => keys.has(key)),
+    put: vi.fn(),
+    putBuffer: vi.fn(),
+    getSignedUrl: vi.fn(),
+    openReadStream: vi.fn(async key =>
+      keys.has(key) ? Readable.from(["deployment"]) : null,
+    ),
+    getSize: vi.fn(async key => (keys.has(key) ? 10 : null)),
+    delete: vi.fn(),
+  };
+}
+
+describe("published deployment artifact source", () => {
+  const projectId = "6a9411eb4c8b33609a65e665";
+  const sha = "38ce8e7b28e8ace0c1d83bdacb95e28df3d5175b";
+  const indexKey = deploymentKey(projectId, sha, "index.html");
+
+  beforeEach(() => {
+    stores.primary = mockStore([]);
+    stores.source = undefined;
+  });
+
+  it("falls back to the read-only source when the preview bucket is empty", async () => {
+    stores.source = mockStore([indexKey]);
+
+    const asset = await readDeploymentAsset(projectId, sha, "");
+
+    expect(asset).toMatchObject({
+      contentType: "text/html; charset=utf-8",
+      size: 10,
+    });
+    expect(stores.primary.exists).toHaveBeenCalledWith(indexKey);
+    expect(stores.primary.openReadStream).not.toHaveBeenCalled();
+    expect(stores.source.openReadStream).toHaveBeenCalledWith(indexKey);
+  });
+
+  it("prefers the isolated writable store when it has the deployment", async () => {
+    stores.primary = mockStore([indexKey]);
+    stores.source = mockStore([indexKey]);
+
+    expect(await deploymentExists(projectId, sha)).toBe(true);
+
+    expect(stores.primary.exists).toHaveBeenCalledWith(indexKey);
+    expect(stores.source.exists).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -21,7 +21,11 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import fs from "node:fs/promises";
 import os from "node:os";
-import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
+import {
+  getArtifactSourceStore,
+  getDashboardArtifactStore,
+  type DashboardArtifactStore,
+} from "../services/dashboard-artifact-store.service";
 import { serveParquetArtifact } from "../services/artifact-delivery.service";
 import { bindingArtifactKeyByName, readBindings } from "./bindings.service";
 import { AppProject, type IAppProject } from "../database/workspace-schema";
@@ -56,18 +60,31 @@ export function legacyDeploymentKey(
   return `apps-v2/${projectId}/deployments/${sha}/${assetPath}`;
 }
 
-/** The key that actually holds `assetPath` for this deployment, or null. */
-async function existingDeploymentKey(
+interface StoredDeploymentAsset {
+  store: DashboardArtifactStore;
+  key: string;
+}
+
+/** The store and key that actually hold `assetPath`, or null. */
+async function existingDeploymentAsset(
   projectId: string,
   sha: string,
   assetPath: string,
-): Promise<string | null> {
-  const store = getDashboardArtifactStore();
+): Promise<StoredDeploymentAsset | null> {
+  const primary = getDashboardArtifactStore();
+  // Rehearsal environments use a cloned production database but an isolated
+  // writable artifact bucket. Their publishedSha therefore names a deployment
+  // that may only exist in the canonical source bucket. Reads fall back there;
+  // uploads still use `primary`, so a PR preview can never overwrite prod.
+  const source = getArtifactSourceStore();
+  const stores = source ? [primary, source] : [primary];
   for (const key of [
     deploymentKey(projectId, sha, assetPath),
     legacyDeploymentKey(projectId, sha, assetPath),
   ]) {
-    if (await store.exists(key)) return key;
+    for (const store of stores) {
+      if (await store.exists(key)) return { store, key };
+    }
   }
   return null;
 }
@@ -192,7 +209,7 @@ export async function deploymentExists(
   projectId: string,
   sha: string,
 ): Promise<boolean> {
-  return (await existingDeploymentKey(projectId, sha, "index.html")) !== null;
+  return (await existingDeploymentAsset(projectId, sha, "index.html")) !== null;
 }
 
 export interface DeploymentAsset {
@@ -213,21 +230,20 @@ export async function readDeploymentAsset(
   sha: string,
   assetPath: string,
 ): Promise<DeploymentAsset | null> {
-  const store = getDashboardArtifactStore();
   const clean = assetPath.replace(/^\/+/, "") || "index.html";
 
   const candidates = [clean];
   if (!path.extname(clean)) candidates.push("index.html");
 
   for (const candidate of candidates) {
-    const key = await existingDeploymentKey(projectId, sha, candidate);
-    if (!key) continue;
-    const stream = await store.openReadStream(key);
+    const stored = await existingDeploymentAsset(projectId, sha, candidate);
+    if (!stored) continue;
+    const stream = await stored.store.openReadStream(stored.key);
     if (stream) {
       return {
         stream,
         contentType: contentTypeFor(candidate),
-        size: await store.getSize(key),
+        size: await stored.store.getSize(stored.key),
       };
     }
   }

--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -65,26 +65,33 @@ interface StoredDeploymentAsset {
   key: string;
 }
 
+/** The writable store first, then the optional read-only canonical source. */
+async function artifactStoreForRead(
+  key: string,
+): Promise<DashboardArtifactStore | null> {
+  const primary = getDashboardArtifactStore();
+  if (await primary.exists(key)) return primary;
+  const source = getArtifactSourceStore();
+  if (source && (await source.exists(key))) return source;
+  return null;
+}
+
 /** The store and key that actually hold `assetPath`, or null. */
 async function existingDeploymentAsset(
   projectId: string,
   sha: string,
   assetPath: string,
 ): Promise<StoredDeploymentAsset | null> {
-  const primary = getDashboardArtifactStore();
   // Rehearsal environments use a cloned production database but an isolated
   // writable artifact bucket. Their publishedSha therefore names a deployment
   // that may only exist in the canonical source bucket. Reads fall back there;
   // uploads still use `primary`, so a PR preview can never overwrite prod.
-  const source = getArtifactSourceStore();
-  const stores = source ? [primary, source] : [primary];
   for (const key of [
     deploymentKey(projectId, sha, assetPath),
     legacyDeploymentKey(projectId, sha, assetPath),
   ]) {
-    for (const store of stores) {
-      if (await store.exists(key)) return { store, key };
-    }
+    const store = await artifactStoreForRead(key);
+    if (store) return { store, key };
   }
   return null;
 }
@@ -389,7 +396,6 @@ export async function serveDeploymentFile(input: {
     /^__data\/([A-Za-z0-9_][A-Za-z0-9_-]*)\.parquet$/,
   );
   if (dataMatch) {
-    const store = getDashboardArtifactStore();
     // Resolve by name through the binding's DEFINITION, exactly as the
     // preview route does — artifacts are keyed
     // `apps/bindings/<connectionId>/<definitionHash>.parquet`. The old
@@ -400,6 +406,8 @@ export async function serveDeploymentFile(input: {
       ? await bindingArtifactKeyByName(project, dataMatch[1], "", sha)
       : null;
     if (!key) return null;
+    const store = await artifactStoreForRead(key);
+    if (!store) return null;
     return await serveParquetArtifact(store, key, {
       cacheControl: input.private ? "private, no-store" : "no-store",
     });

--- a/api/src/apps/workspace-prompt.test.ts
+++ b/api/src/apps/workspace-prompt.test.ts
@@ -54,7 +54,9 @@ beforeEach(async () => {
 
 describe("workspace prompt in git", () => {
   it("reads null with no repo or no file; round-trips a commit", async () => {
+    await unbindTestWorkspaceRepo(WS);
     expect(await readWorkspacePromptFile(WS)).toBeNull();
+    await bindTestWorkspaceRepo(WS);
     await initRepo(repoDirFor(WS), { "README.md": "x\n" });
     expect(await readWorkspacePromptFile(WS)).toBeNull();
 

--- a/api/src/apps/workspace-repo-required.ts
+++ b/api/src/apps/workspace-repo-required.ts
@@ -10,7 +10,7 @@
  * not count.
  */
 import { RepoRequiredError } from "./config";
-import { ensureWorkspaceRepo } from "./cloud-repo.service";
+import { ensureLocalRepo, ensureWorkspaceRepo } from "./cloud-repo.service";
 import { getWorkspaceRepo } from "../services/workspace-repos.service";
 import { repoDirFor, repoExists } from "./repository.service";
 
@@ -36,6 +36,7 @@ export async function boundRepoDirIfExists(
   workspaceId: string,
 ): Promise<string | null> {
   if (!(await getWorkspaceRepo(workspaceId))) return null;
+  await ensureLocalRepo(workspaceId);
   const repoDir = repoDirFor(workspaceId);
   return (await repoExists(repoDir)) ? repoDir : null;
 }

--- a/api/src/dbt/dbt-rules-turn.service.test.ts
+++ b/api/src/dbt/dbt-rules-turn.service.test.ts
@@ -58,9 +58,12 @@ async function seedProject(name: string, workspaceId = WS, rules?: string) {
     defaultEnvironment: "dev",
     createdBy: "tester",
   });
-  if (rules !== undefined) {
-    await seedDbtGitTree(workspaceId, { ".makorules.md": rules });
-  }
+  await seedDbtGitTree(
+    workspaceId,
+    rules === undefined
+      ? { "README.md": "dbt project\n" }
+      : { ".makorules.md": rules },
+  );
   return project._id.toString();
 }
 

--- a/api/src/routes/apps-github-required.test.ts
+++ b/api/src/routes/apps-github-required.test.ts
@@ -51,10 +51,18 @@ assert.ok(
   /if\s*\(!\(await getWorkspaceRepo\(workspaceId\)\)\)/.test(gate),
   "requireWorkspaceRepo must refuse when no GitHub binding exists — leftover local git is not a skip",
 );
+const requireWorkspaceRepoBody =
+  /export async function requireWorkspaceRepo[\s\S]*?\n}/.exec(gate)?.[0] ?? "";
 assert.equal(
-  gate.includes("ensureLocalRepo"),
+  requireWorkspaceRepoBody.includes("ensureLocalRepo"),
   false,
   "requireWorkspaceRepo must not fall through to a local-only repo",
+);
+assert.ok(
+  /export async function boundRepoDirIfExists[\s\S]*?getWorkspaceRepo[\s\S]*?ensureLocalRepo/.test(
+    gate,
+  ),
+  "bound read helpers must restore a cold serverless repo cache",
 );
 
 console.log("apps github-required tests passed");

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -89,7 +89,10 @@ import {
   previewStagingDir,
   RepoRequiredError,
 } from "../apps/config";
-import { registerPublicShareRoutes } from "./lib/public-share-routes";
+import {
+  registerPublicShareRoutes,
+  serializePublicShare,
+} from "./lib/public-share-routes";
 import {
   registerCollaboratorRoutes,
   registerSharingSettingsRoutes,
@@ -722,6 +725,9 @@ appsRoutes.openapi(
             // else shared with you under "Shared with me", not "My Apps".
             owner_id: state?.owner_id,
             workspaceRole: state?.workspaceRole,
+            // Only safe metadata leaves the API. The password hash and its
+            // encrypted reveal copy never do.
+            publicShare: serializePublicShare(state?.publicShare),
             publishedSha: state?.publishedSha,
             publishedAt: state?.publishedAt,
           };

--- a/api/src/routes/lib/public-share-routes.ts
+++ b/api/src/routes/lib/public-share-routes.ts
@@ -125,7 +125,7 @@ async function hashSharePassword(password: string): Promise<string> {
   return bcrypt.hash(password, rounds);
 }
 
-function serialize(publicShare?: IPublicShare) {
+export function serializePublicShare(publicShare?: IPublicShare) {
   if (!publicShare?.enabled || !publicShare.token) {
     return { enabled: false as const };
   }
@@ -220,7 +220,10 @@ export function registerPublicShareRoutes(
         doc.markModified("publicShare");
         await doc.save();
 
-        return c.json({ success: true, data: serialize(doc.publicShare) });
+        return c.json({
+          success: true,
+          data: serializePublicShare(doc.publicShare),
+        });
       } catch (error) {
         logger.error(`Error enabling public share for ${resourceName}`, {
           error,
@@ -342,7 +345,10 @@ export function registerPublicShareRoutes(
         doc.markModified("publicShare");
         await doc.save();
 
-        return c.json({ success: true, data: serialize(doc.publicShare) });
+        return c.json({
+          success: true,
+          data: serializePublicShare(doc.publicShare),
+        });
       } catch (error) {
         logger.error(`Error updating public share for ${resourceName}`, {
           error,

--- a/api/src/services/dashboard-artifact-store.service.ts
+++ b/api/src/services/dashboard-artifact-store.service.ts
@@ -662,12 +662,12 @@ export function getDashboardArtifactStore(): DashboardArtifactStore {
 }
 
 /**
- * A read-only artifact store to COPY existing artifacts FROM, distinct from
- * the live store written TO. Set APPS_ARTIFACT_SOURCE_BUCKET to a GCS
- * bucket to hydrate a rehearsal environment (e.g. dev, cloned from prod's DB
- * but NOT its artifact store) with prod's parquet — the migration then adopts
- * real data instead of finding nothing local. Unset (prod and normal runs) →
- * null, and callers read from the main store exactly as before.
+ * A read-only artifact store for existing app artifacts, distinct from the
+ * live store written TO. Set APPS_ARTIFACT_SOURCE_BUCKET to a GCS bucket when
+ * a rehearsal environment uses a cloned production database but an isolated
+ * writable artifact store. Published deployment reads may fall back to this
+ * source; writes always stay in the live store. Unset (prod and normal runs)
+ * returns null, and callers use the main store exactly as before.
  */
 export function getArtifactSourceStore(): DashboardArtifactStore | null {
   const bucket = process.env.APPS_ARTIFACT_SOURCE_BUCKET; // pre-rename name

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       "src/connectors/probe.service.test.ts",
       "src/agent-lib/tools/connector-tools.test.ts",
       "src/apps/preview.service.test.ts",
+      "src/apps/deployment.service.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",
       // These two were written as vitest suites but listed in no vitest
       // config, so neither runner could execute them: tsx dies on them

--- a/app/src/components/AppWorkspace.tsx
+++ b/app/src/components/AppWorkspace.tsx
@@ -39,6 +39,7 @@ import {
   Play as PlayIcon,
   Plus as PlusIcon,
   RefreshCw as RefreshIcon,
+  Share2 as ShareIcon,
   Square as StopIcon,
   TerminalSquare as TerminalIcon,
 } from "lucide-react";
@@ -46,6 +47,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { useWorkspace } from "../contexts/workspace-context";
+import { useAuth } from "../contexts/auth-context";
 import { useRealtimeStore } from "../store/realtimeStore";
 import { useAppsStore } from "../store/appsStore";
 import AppHistoryPopover from "./AppHistoryPopover";
@@ -55,6 +57,8 @@ import { setIframeDragGuard } from "../lib/iframe-drag-guard";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { useUIStore } from "../store/uiStore";
 import { TerminalTypeAhead } from "../lib/terminal-type-ahead";
+import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
+import ShareDialog from "./ShareDialog";
 
 // ---------------------------------------------------------------------------
 // Terminal panel
@@ -1091,7 +1095,9 @@ export default function AppWorkspace({
   appId: string;
 }) {
   const { currentWorkspace } = useWorkspace();
+  const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
 
   const app = useAppsStore(s => s.apps.find(a => a.id === appId));
   const status = useAppsStore(s => s.statusByApp[appId]);
@@ -1222,6 +1228,7 @@ export default function AppWorkspace({
   const stopDev = useAppsStore(s => s.stopDev);
 
   const [historyAnchor, setHistoryAnchor] = useState<null | HTMLElement>(null);
+  const [shareOpen, setShareOpen] = useState(false);
   // Bumping this remounts the preview iframe — a plain page refresh.
   const [previewNonce, setPreviewNonce] = useState(0);
 
@@ -1439,6 +1446,36 @@ export default function AppWorkspace({
             </Button>
           </span>
         </Tooltip>
+        <Tooltip
+          title={
+            app?.publishedSha
+              ? "Share the fullscreen published app"
+              : "Publish the app before sharing it"
+          }
+        >
+          <span>
+            {isMobile ? (
+              <IconButton
+                size="small"
+                aria-label="Share app"
+                disabled={!app?.publishedSha}
+                onClick={() => setShareOpen(true)}
+              >
+                <ShareIcon size={16} />
+              </IconButton>
+            ) : (
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<ShareIcon size={15} />}
+                disabled={!app?.publishedSha}
+                onClick={() => setShareOpen(true)}
+              >
+                Share
+              </Button>
+            )}
+          </span>
+        </Tooltip>
         {!isMobile && (
           <Tooltip title={`History (${status?.branch ?? "main"})`}>
             <IconButton
@@ -1621,6 +1658,35 @@ export default function AppWorkspace({
         branch={status?.branch ?? "main"}
         publishedSha={app?.publishedSha}
       />
+      {app && (
+        <ShareDialog
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          resourceType="app"
+          resourceId={app.id}
+          resourceName={app.title}
+          ownerId={app.owner_id}
+          access={app.access ?? "workspace"}
+          workspaceRole={app.workspaceRole ?? "viewer"}
+          publicShare={app.publicShare}
+          canManage={
+            !app.owner_id || app.owner_id === user?.id || isWorkspaceAdmin
+          }
+          onSharingChanged={changes => {
+            useAppsStore.setState(state => {
+              const currentApp = state.apps.find(item => item.id === app.id);
+              if (!currentApp) return;
+              if (changes.access) currentApp.access = changes.access;
+              if (changes.workspaceRole) {
+                currentApp.workspaceRole = changes.workspaceRole;
+              }
+              if (changes.publicShare) {
+                currentApp.publicShare = changes.publicShare;
+              }
+            });
+          }}
+        />
+      )}
     </Box>
   );
 }

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -694,6 +694,7 @@ export default function AppsExplorer() {
           ownerId={shareApp.owner_id}
           access={shareApp.access ?? "workspace"}
           workspaceRole={shareApp.workspaceRole ?? "viewer"}
+          publicShare={shareApp.publicShare}
           canManage={
             !shareApp.owner_id ||
             shareApp.owner_id === userId ||
@@ -706,6 +707,9 @@ export default function AppsExplorer() {
               if (changes.access) app.access = changes.access;
               if (changes.workspaceRole) {
                 app.workspaceRole = changes.workspaceRole;
+              }
+              if (changes.publicShare) {
+                app.publicShare = changes.publicShare;
               }
             });
             // A folder-only app gets its row (and a real id) on first share;

--- a/app/src/components/ShareDialog.tsx
+++ b/app/src/components/ShareDialog.tsx
@@ -82,6 +82,8 @@ const SUPPORTS_PUBLIC: Record<ShareResourceType, boolean> = {
   app: true,
 };
 
+type AppLinkScope = "workspace" | "public-password" | "public";
+
 // Stable fallback so the Zustand selector never returns a fresh `[]` per call
 // (a new reference each render makes useSyncExternalStore loop forever and
 // blocks the initial commit — blank page with no error).
@@ -278,9 +280,19 @@ export default function ShareDialog({
   const [showPassword, setShowPassword] = useState(false);
   const [editingLink, setEditingLink] = useState(false);
   const [linkDraft, setLinkDraft] = useState("");
+  const [requestedAppScope, setRequestedAppScope] =
+    useState<AppLinkScope | null>(null);
 
   const supportsPublic = SUPPORTS_PUBLIC[resourceType];
   const label = RESOURCE_LABEL[resourceType];
+  const currentAppScope: AppLinkScope | null = publicShare.enabled
+    ? publicShare.hasPassword
+      ? "public-password"
+      : "public"
+    : access === "workspace"
+      ? "workspace"
+      : null;
+  const selectedAppScope = requestedAppScope ?? currentAppScope;
 
   useEffect(() => {
     if (!open) return;
@@ -292,6 +304,7 @@ export default function ShareDialog({
     setShowPassword(false);
     setEditingLink(false);
     setLinkDraft("");
+    setRequestedAppScope(null);
     setAccess(accessProp ?? "private");
     setWorkspaceRole(workspaceRoleProp ?? "viewer");
     setPublicShare(publicShareProp ?? { enabled: false });
@@ -382,19 +395,103 @@ export default function ShareDialog({
     }
   };
 
+  const handleAppScopeChange = async (nextScope: AppLinkScope) => {
+    if (!workspaceId || !resourceId) return;
+
+    if (nextScope === "public-password" && !publicShare.hasPassword) {
+      setRequestedAppScope(nextScope);
+      setPassword("");
+      return;
+    }
+
+    setRequestedAppScope(null);
+    if (nextScope === "workspace") {
+      await run(async () => {
+        const settingsResult = await updateSharingSettings(
+          resourceType,
+          workspaceId,
+          resourceId,
+          { access: "workspace" },
+        );
+        if (!settingsResult.ok) return settingsResult;
+        if (settingsResult.settings) {
+          setAccess(settingsResult.settings.access);
+          setWorkspaceRole(settingsResult.settings.workspaceRole);
+          onSharingChanged?.({
+            access: settingsResult.settings.access,
+            workspaceRole: settingsResult.settings.workspaceRole,
+          });
+        }
+
+        if (!publicShare.enabled) return { ok: true };
+        const publicResult = await disablePublicShare(
+          resourceType,
+          workspaceId,
+          resourceId,
+        );
+        if (publicResult.ok) {
+          const disabledShare = { enabled: false } as const;
+          setPublicShare(disabledShare);
+          onSharingChanged?.({ publicShare: disabledShare });
+        }
+        return publicResult;
+      });
+      return;
+    }
+
+    await run(async () => {
+      let nextPublicShare = publicShare;
+      if (!nextPublicShare.enabled) {
+        const enableResult = await enablePublicShare(
+          resourceType,
+          workspaceId,
+          resourceId,
+        );
+        if (!enableResult.ok || !enableResult.publicShare) {
+          return enableResult;
+        }
+        nextPublicShare = enableResult.publicShare;
+      }
+
+      if (nextScope === "public" && nextPublicShare.hasPassword) {
+        const updateResult = await updatePublicShare(
+          resourceType,
+          workspaceId,
+          resourceId,
+          { password: null },
+        );
+        if (!updateResult.ok || !updateResult.publicShare) {
+          return updateResult;
+        }
+        nextPublicShare = updateResult.publicShare;
+      }
+
+      setPublicShare(nextPublicShare);
+      setRevealedPassword(null);
+      setShowPassword(false);
+      onSharingChanged?.({ publicShare: nextPublicShare });
+      return { ok: true };
+    });
+  };
+
   const handleSetPassword = async () => {
     if (!workspaceId || !resourceId || !password) return;
     await run(async () => {
-      const result = await updatePublicShare(
-        resourceType,
-        workspaceId,
-        resourceId,
-        { password },
-      );
+      const result = publicShare.enabled
+        ? await updatePublicShare(resourceType, workspaceId, resourceId, {
+            password,
+          })
+        : await enablePublicShare(
+            resourceType,
+            workspaceId,
+            resourceId,
+            password,
+          );
       if (result.ok && result.publicShare) {
         setPublicShare(result.publicShare);
         setRevealedPassword(password);
         setPassword("");
+        setRequestedAppScope(null);
         onSharingChanged?.({ publicShare: result.publicShare });
       }
       return result;
@@ -520,11 +617,15 @@ export default function ShareDialog({
     setTimeout(() => setCopied(false), 2000);
   };
 
-  // Workspace-internal link for logged-in collaborators. The desktop shell
-  // has no address bar, so this button is the only way to get the URL there.
+  // The primary app link always opens the published app fullscreen. Public
+  // scopes use the anonymous token; workspace-only uses the authenticated
+  // deployment route (whose auth gate returns signed-out people after login).
   const handleCopyInternalLink = async () => {
     if (!resourceId) return;
-    const url = buildWorkspaceResourceUrl(resourceType, resourceId);
+    const url =
+      resourceType === "app" && publicShare.enabled && publicShare.token
+        ? buildPublicShareUrl(publicShare.token, currentWorkspace?.name)
+        : buildWorkspaceResourceUrl(resourceType, resourceId, workspaceId);
     if (!(await copyTextToClipboard(url))) {
       setError("Failed to copy link");
       return;
@@ -713,111 +814,240 @@ export default function ShareDialog({
           })}
         </Box>
 
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>
-          General access
-        </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-          <IconCircle tint={access === "workspace" ? "primary" : "neutral"}>
-            {access === "workspace" ? (
-              <Building2 size={18} />
-            ) : (
-              <Lock size={18} />
-            )}
-          </IconCircle>
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            {canManage ? (
-              <Select
-                size="small"
-                variant="standard"
-                disableUnderline
-                value={access}
-                disabled={busy}
-                onChange={e =>
-                  void persistSettings({
-                    access: e.target.value as ShareAccess,
-                  })
-                }
-                sx={{
-                  fontSize: 14,
-                  fontWeight: 500,
-                  "& .MuiSelect-select": { py: 0, pr: 3 },
-                }}
-              >
-                <MenuItem value="private">Restricted</MenuItem>
-                <MenuItem value="workspace">Workspace</MenuItem>
-              </Select>
-            ) : (
-              <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                {access === "private" ? "Restricted" : "Workspace"}
-              </Typography>
-            )}
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ display: "block" }}
-            >
-              {access === "private"
-                ? "Only people with access can open it"
-                : workspaceRole === "editor"
-                  ? "Everyone in the workspace can edit"
-                  : "Everyone in the workspace can view"}
-            </Typography>
-          </Box>
-          {access === "workspace" && (
-            <Select
-              size="small"
-              variant="standard"
-              disableUnderline
-              value={workspaceRole}
-              disabled={!canManage || busy}
-              onChange={e =>
-                void persistSettings({
-                  workspaceRole: e.target.value as ShareRole,
-                })
-              }
-              sx={{
-                fontSize: 14,
-                color: "text.secondary",
-                "& .MuiSelect-select": { py: 0.25, pr: 3 },
-              }}
-            >
-              <MenuItem value="viewer">Viewer</MenuItem>
-              <MenuItem value="editor">Editor</MenuItem>
-            </Select>
-          )}
-        </Box>
-
-        {supportsPublic && (
+        {resourceType === "app" ? (
           <>
-            <Box
-              sx={{ display: "flex", alignItems: "center", gap: 1.5, mt: 2 }}
-            >
-              <IconCircle tint={publicShare.enabled ? "success" : "neutral"}>
-                <Globe size={18} />
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Link access
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <IconCircle
+                tint={
+                  selectedAppScope === "workspace"
+                    ? "primary"
+                    : selectedAppScope
+                      ? "success"
+                      : "neutral"
+                }
+              >
+                {selectedAppScope === "workspace" ? (
+                  <Building2 size={18} />
+                ) : selectedAppScope === "public-password" ? (
+                  <Lock size={18} />
+                ) : selectedAppScope === "public" ? (
+                  <Globe size={18} />
+                ) : (
+                  <Lock size={18} />
+                )}
               </IconCircle>
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                  Public link
-                </Typography>
+                {canManage ? (
+                  <Select
+                    size="small"
+                    variant="standard"
+                    disableUnderline
+                    value={selectedAppScope ?? ""}
+                    disabled={busy}
+                    onChange={e =>
+                      void handleAppScopeChange(e.target.value as AppLinkScope)
+                    }
+                    sx={{
+                      fontSize: 14,
+                      fontWeight: 500,
+                      "& .MuiSelect-select": { py: 0, pr: 3 },
+                    }}
+                  >
+                    {!selectedAppScope && (
+                      <MenuItem value="" disabled>
+                        Choose link access
+                      </MenuItem>
+                    )}
+                    <MenuItem value="workspace">
+                      Workspace members only
+                    </MenuItem>
+                    <MenuItem value="public-password">
+                      Public with password
+                    </MenuItem>
+                    <MenuItem value="public">Public without password</MenuItem>
+                  </Select>
+                ) : (
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {!selectedAppScope
+                      ? "Only invited people"
+                      : selectedAppScope === "workspace"
+                        ? "Workspace members only"
+                        : selectedAppScope === "public-password"
+                          ? "Public with password"
+                          : "Public without password"}
+                  </Typography>
+                )}
                 <Typography
                   variant="caption"
                   color="text.secondary"
                   sx={{ display: "block" }}
                 >
-                  {publicShare.enabled
-                    ? publicShare.hasPassword
-                      ? "Anyone with the link and password can view a snapshot"
-                      : "Anyone with the link can view a snapshot"
-                    : "Off — not accessible outside the workspace"}
+                  {!selectedAppScope
+                    ? "Choose a sharing scope to create a fullscreen link for others"
+                    : selectedAppScope === "workspace"
+                      ? "Anyone in this workspace can open the fullscreen app after signing in"
+                      : selectedAppScope === "public-password"
+                        ? "Anyone with the link and password can open the fullscreen app"
+                        : "Anyone with the link can open the fullscreen app"}
                 </Typography>
               </Box>
-              <Switch
-                size="small"
-                checked={publicShare.enabled}
-                disabled={!canManage || busy}
-                onChange={e => void handlePublicToggle(e.target.checked)}
-              />
             </Box>
+            {requestedAppScope === "public-password" &&
+              !publicShare.enabled &&
+              canManage && (
+                <TextField
+                  size="small"
+                  fullWidth
+                  autoFocus
+                  type="password"
+                  placeholder="Choose a password"
+                  value={password}
+                  disabled={busy}
+                  onChange={e => setPassword(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === "Enter" && password && !busy) {
+                      e.preventDefault();
+                      void handleSetPassword();
+                    }
+                  }}
+                  sx={{ mt: 1, ml: 6.5, width: "calc(100% - 52px)" }}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Lock size={14} />
+                      </InputAdornment>
+                    ),
+                    endAdornment: password ? (
+                      <InputAdornment position="end">
+                        <Button
+                          size="small"
+                          variant="contained"
+                          disableElevation
+                          disabled={busy}
+                          onClick={() => void handleSetPassword()}
+                        >
+                          Protect link
+                        </Button>
+                      </InputAdornment>
+                    ) : undefined,
+                  }}
+                />
+              )}
+          </>
+        ) : (
+          <>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              General access
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <IconCircle tint={access === "workspace" ? "primary" : "neutral"}>
+                {access === "workspace" ? (
+                  <Building2 size={18} />
+                ) : (
+                  <Lock size={18} />
+                )}
+              </IconCircle>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                {canManage ? (
+                  <Select
+                    size="small"
+                    variant="standard"
+                    disableUnderline
+                    value={access}
+                    disabled={busy}
+                    onChange={e =>
+                      void persistSettings({
+                        access: e.target.value as ShareAccess,
+                      })
+                    }
+                    sx={{
+                      fontSize: 14,
+                      fontWeight: 500,
+                      "& .MuiSelect-select": { py: 0, pr: 3 },
+                    }}
+                  >
+                    <MenuItem value="private">Restricted</MenuItem>
+                    <MenuItem value="workspace">Workspace</MenuItem>
+                  </Select>
+                ) : (
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {access === "private" ? "Restricted" : "Workspace"}
+                  </Typography>
+                )}
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block" }}
+                >
+                  {access === "private"
+                    ? "Only people with access can open it"
+                    : workspaceRole === "editor"
+                      ? "Everyone in the workspace can edit"
+                      : "Everyone in the workspace can view"}
+                </Typography>
+              </Box>
+              {access === "workspace" && (
+                <Select
+                  size="small"
+                  variant="standard"
+                  disableUnderline
+                  value={workspaceRole}
+                  disabled={!canManage || busy}
+                  onChange={e =>
+                    void persistSettings({
+                      workspaceRole: e.target.value as ShareRole,
+                    })
+                  }
+                  sx={{
+                    fontSize: 14,
+                    color: "text.secondary",
+                    "& .MuiSelect-select": { py: 0.25, pr: 3 },
+                  }}
+                >
+                  <MenuItem value="viewer">Viewer</MenuItem>
+                  <MenuItem value="editor">Editor</MenuItem>
+                </Select>
+              )}
+            </Box>
+          </>
+        )}
+
+        {supportsPublic && (
+          <>
+            {resourceType !== "app" && (
+              <Box
+                sx={{ display: "flex", alignItems: "center", gap: 1.5, mt: 2 }}
+              >
+                <IconCircle tint={publicShare.enabled ? "success" : "neutral"}>
+                  <Globe size={18} />
+                </IconCircle>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    Public link
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: "block" }}
+                  >
+                    {publicShare.enabled
+                      ? publicShare.hasPassword
+                        ? "Anyone with the link and password can view a snapshot"
+                        : "Anyone with the link can view a snapshot"
+                      : "Off — not accessible outside the workspace"}
+                  </Typography>
+                </Box>
+                <Switch
+                  size="small"
+                  checked={publicShare.enabled}
+                  disabled={!canManage || busy}
+                  onChange={e => void handlePublicToggle(e.target.checked)}
+                />
+              </Box>
+            )}
 
             {publicShare.enabled && (
               <Box
@@ -1006,7 +1236,8 @@ export default function ShareDialog({
                         Remove
                       </Button>
                     </Box>
-                  ) : (
+                  ) : resourceType !== "app" ||
+                    requestedAppScope === "public-password" ? (
                     <TextField
                       size="small"
                       fullWidth
@@ -1048,7 +1279,7 @@ export default function ShareDialog({
                         ) : undefined,
                       }}
                     />
-                  ))}
+                  ) : null)}
 
                 {resourceType === "app" && canManage && (
                   <Box
@@ -1088,17 +1319,37 @@ export default function ShareDialog({
         )}
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2.5, justifyContent: "space-between" }}>
-        <Tooltip title="Copy a link for people with access — they must be signed in to open it">
+        <Tooltip
+          title={
+            resourceType === "app"
+              ? requestedAppScope === "public-password"
+                ? "Choose a password to create the protected link"
+                : !currentAppScope
+                  ? "Choose a sharing scope before copying the app link"
+                  : publicShare.enabled
+                    ? "Copy the public fullscreen app link"
+                    : "Copy the fullscreen app link — workspace sign-in is required"
+              : "Copy a link for people with access — they must be signed in to open it"
+          }
+        >
           <span>
             <Button
               variant="outlined"
               startIcon={
                 internalCopied ? <Check size={16} /> : <LinkIcon size={16} />
               }
-              disabled={!resourceId}
+              disabled={
+                !resourceId ||
+                requestedAppScope !== null ||
+                (resourceType === "app" && !currentAppScope)
+              }
               onClick={() => void handleCopyInternalLink()}
             >
-              {internalCopied ? "Copied" : "Copy link"}
+              {internalCopied
+                ? "Copied"
+                : resourceType === "app"
+                  ? "Copy app link"
+                  : "Copy link"}
             </Button>
           </span>
         </Tooltip>

--- a/app/src/pages/PublicSharePage.tsx
+++ b/app/src/pages/PublicSharePage.tsx
@@ -22,13 +22,26 @@ import PublicDashboardViewer, {
  */
 
 interface ShareMeta {
-  type: "dashboard";
+  type: "dashboard" | "app";
   title: string;
   passwordRequired: boolean;
   unlocked: boolean;
 }
 
-type ShareContent = PublicDashboardContent;
+interface PublicAppContent {
+  kind: "app";
+  title: string;
+  published: boolean;
+  entry: string;
+}
+
+type ShareContent = PublicDashboardContent | PublicAppContent;
+
+function isPublicAppContent(
+  content: ShareContent,
+): content is PublicAppContent {
+  return "kind" in content && content.kind === "app";
+}
 
 export default function PublicSharePage() {
   const { token = "" } = useParams<{ token: string }>();
@@ -80,6 +93,15 @@ export default function PublicSharePage() {
       }
     })();
   }, [token, loadContent]);
+
+  // A git-backed app is already a complete built deployment. Navigate to its
+  // token-gated entrypoint instead of framing it so the app owns the whole
+  // browser viewport and password cookies accompany its module assets.
+  useEffect(() => {
+    if (content && isPublicAppContent(content) && content.published) {
+      window.location.replace(content.entry);
+    }
+  }, [content]);
 
   const handleUnlock = async () => {
     setUnlocking(true);
@@ -210,13 +232,50 @@ export default function PublicSharePage() {
     );
   }
 
+  if (isPublicAppContent(content)) {
+    if (!content.published) {
+      return (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100vh",
+            gap: 1,
+          }}
+        >
+          <Typography variant="h6">
+            This app has not been published yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Ask the owner to publish it before sharing the link.
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100vh",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
   return (
     <PublicDashboardViewer
       token={token}
       content={content}
       reloadContent={async () => {
         const next = await loadContent();
-        if (next) {
+        if (next && !isPublicAppContent(next)) {
           setContent(next);
           return next;
         }

--- a/app/src/store/appsStore.ts
+++ b/app/src/store/appsStore.ts
@@ -18,6 +18,7 @@ import { focusAppsTab, reconcileAppsTabs } from "../apps-runtime/shell";
 import { onRealtimeEvent } from "./lib/realtime-channel";
 import { useConsoleStore } from "./consoleStore";
 import { useUIStore } from "./uiStore";
+import type { PublicShareInfo } from "./shareStore";
 
 /**
  * After connect/disconnect the derived git index in Mongo has changed.
@@ -70,6 +71,8 @@ export interface AppMeta {
   owner_id?: string;
   /** What workspace members may do with a workspace-access app. */
   workspaceRole?: "viewer" | "editor";
+  /** Safe public-link metadata; password material never leaves the API. */
+  publicShare?: PublicShareInfo;
 }
 
 export interface AppFileEntry {

--- a/app/src/store/shareStore.test.ts
+++ b/app/src/store/shareStore.test.ts
@@ -6,11 +6,10 @@ import {
   type ShareResourceType,
 } from "./shareStore";
 
-/** Deep-link pattern that must hydrate each shareable resource's URL. */
-const TAB_PATTERN_FOR_RESOURCE: Record<ShareResourceType, RegExp> = {
+/** Deep-link pattern for resources that open inside the Mako shell. */
+const TAB_PATTERN_FOR_RESOURCE: Partial<Record<ShareResourceType, RegExp>> = {
   dashboard: TAB_DEEP_LINK_PATTERNS.dashboard,
   console: TAB_DEEP_LINK_PATTERNS.console,
-  app: TAB_DEEP_LINK_PATTERNS.app,
 };
 
 describe("buildWorkspaceResourceUrl", () => {
@@ -27,8 +26,17 @@ describe("buildWorkspaceResourceUrl", () => {
     "produces a hydratable deep link for %s",
     resourceType => {
       const url = new URL(buildWorkspaceResourceUrl(resourceType, "abc-123"));
-      const match = url.pathname.match(TAB_PATTERN_FOR_RESOURCE[resourceType]);
+      const pattern = TAB_PATTERN_FOR_RESOURCE[resourceType];
+      expect(pattern).toBeDefined();
+      if (!pattern) throw new Error(`Missing pattern for ${resourceType}`);
+      const match = url.pathname.match(pattern);
       expect(match?.[1]).toBe("abc-123");
     },
   );
+
+  it("builds a fullscreen published-app URL for workspace members", () => {
+    expect(buildWorkspaceResourceUrl("app", "app-123", "workspace-456")).toBe(
+      `${window.location.origin}/api/workspaces/workspace-456/apps/app-123/live/`,
+    );
+  });
 });

--- a/app/src/store/shareStore.ts
+++ b/app/src/store/shareStore.ts
@@ -96,14 +96,21 @@ const RESOURCE_URL_PREFIX: Record<ShareResourceType, string> = {
 };
 
 /**
- * Workspace-internal URL for logged-in collaborators (/a/:id, /d/:id, /c/:id).
- * Built from the resource id rather than read off the address bar so it also
- * works in the desktop shell, which has no address bar to copy from.
+ * Workspace-internal URL for logged-in collaborators. Apps use their
+ * published deployment route so the copied link opens fullscreen without the
+ * Mako shell; other resources still open their normal deep-linked tab.
+ *
+ * Built from ids rather than read off the address bar so it also works in the
+ * desktop shell, which has no address bar to copy from.
  */
 export function buildWorkspaceResourceUrl(
   resourceType: ShareResourceType,
   resourceId: string,
+  workspaceId?: string,
 ): string {
+  if (resourceType === "app" && workspaceId) {
+    return `${window.location.origin}/api/workspaces/${encodeURIComponent(workspaceId)}/apps/${encodeURIComponent(resourceId)}/live/`;
+  }
   return `${window.location.origin}/${RESOURCE_URL_PREFIX[resourceType]}/${resourceId}`;
 }
 

--- a/apps.md
+++ b/apps.md
@@ -2600,9 +2600,12 @@ prod-vs-preview signal `MAKO_CLOUD_REPO_PREFIX=ws` is replaced by an explicit
 **The rule users see:** connect GitHub, or nothing saves. In production,
 creating an app or saving a console in a workspace without a connected repo
 returns 412 `github_required` with "Connect a GitHub repository first
-(Settings → GitHub)". Dev, tests and previews keep local-only bare repos
-(nothing durable — previews are throwaway by design). The consoles CLI lost
-`--create-repo`; adoption happens on the first save after connecting.
+(Settings → GitHub)". A PR preview restores its empty local cache from the
+connected repo so git-backed apps, consoles, and dbt remain visible, but its
+push gate stays closed: preview commits never write back to the customer's
+repo and remain throwaway. Dev and tests may still use local-only bare repos.
+The consoles CLI lost `--create-repo`; adoption happens on the first save
+after connecting.
 
 Six test repos in `mako-ai-cloud` remain to be deleted by hand (`gh repo
 delete` needs the `delete_repo` scope). Cut through complexity: one tier,

--- a/scripts/GITHUB_APP_DEPLOY.md
+++ b/scripts/GITHUB_APP_DEPLOY.md
@@ -1,24 +1,20 @@
-# GitHub App — PR preview + production
+# GitHub App — all environments
 
-Mako uses **two** GitHub Apps so prod isn't tied to a dev-named app. The
-product name is **Mako AI** (GitHub still lists these as Mako Transforms until
-the rename in GitHub's UI lands). **Do not create a `https://github.com/apps/mako`
-app and do not rotate `GITHUB_APP_*` / `MAKO_GITHUB_APP_*`** — the existing
-credentials are the right ones. After a display-name rename, update
-`GITHUB_APP_SLUG` only if GitHub also changes the slug.
+Mako uses **one GitHub App in every environment**: **Mako AI** (`mako-ai`,
+App ID `4106865`, public). Workspace bindings persist a GitHub installation
+id, and those ids belong to one App. PR databases are copied from production,
+so using a different App in previews makes every token mint return 404 and all
+git-backed workspace content disappear.
 
-| App | Used by | Where creds live |
-| --- | --- | --- |
-| **Mako AI** (currently `mako-transforms`, App ID `4106865`, public) | **Production** (`app.mako.ai`) | GitHub Actions **`production` environment** vars/secrets |
-| **Mako AI (Dev)** (currently `mako-transforms-jonas-dev`, App ID `4093709`) | PR previews + local dev | **repo-level** vars/secrets |
+The canonical `MAKO_GITHUB_APP_*` variables and secrets live at GitHub
+**repository scope** so production, PR previews, and manually dispatched
+preview deployments all inherit the same identity. Do not add environment-level
+overrides or create a separate dev App. The deploy workflow fails early if the
+resolved App ID is not `4106865`.
 
-The deploy workflow's `deploy-production` job runs under `environment: production`,
-so environment-scoped `MAKO_GITHUB_APP_*` override the repo-level ones — prod
-uses the prod app, previews/local use the dev app.
-
-To rename in GitHub: App settings → General → change the name to **Mako AI**
-(and **Mako AI (Dev)** for the preview app). Leave id, PEM, client secret, and
-webhook secret alone.
+To rename in GitHub: App settings → General → change the name to **Mako AI**.
+Leave id, PEM, client secret, and webhook secret alone. After a display-name
+rename, update `GITHUB_APP_SLUG` only if GitHub also changes the slug.
 
 If you ever need to (re)create an app (not the rename path):
 
@@ -28,16 +24,16 @@ BASE_URL=https://app.mako.ai CLIENT_URL=https://app.mako.ai \
 GITHUB_APP_NAME="Mako AI" GITHUB_APP_ORG=<org-or-omit-for-personal> \
 GITHUB_APP_PUBLIC=1 GITHUB_APP_OUTPUT_JSON=.secrets/prod-github-app.json \
 node scripts/register-github-app.mjs
-# then set the production-environment vars/secrets from that JSON:
-#   gh variable set MAKO_GITHUB_APP_{ID,SLUG,CLIENT_ID} --env production --repo mako-ai/mako ...
-#   gh secret   set MAKO_GITHUB_APP_{CLIENT_SECRET,WEBHOOK_SECRET,PRIVATE_KEY} --env production --repo mako-ai/mako ...
+# then set the repository-level vars/secrets from that JSON:
+#   gh variable set MAKO_GITHUB_APP_{ID,SLUG,CLIENT_ID} --repo mako-ai/mako ...
+#   gh secret   set MAKO_GITHUB_APP_{CLIENT_SECRET,WEBHOOK_SECRET,PRIVATE_KEY} --repo mako-ai/mako ...
 ```
 
-The manifest already enables *Request user authorization (OAuth) during
-installation*, sets the Callback URL to `/api/github/setup`, and marks the app
+The manifest already enables _Request user authorization (OAuth) during
+installation_, sets the Callback URL to `/api/github/setup`, and marks the app
 public — no manual GitHub-UI steps needed for a manifest-created app.
 
-## 1. Repo secrets and variables (dev app — PR previews + local)
+## 1. Repository secrets and variables (all deployed environments)
 
 ```bash
 # From repo root (private key at .secrets/github-app.pem)
@@ -46,26 +42,28 @@ gh secret set MAKO_GITHUB_APP_WEBHOOK_SECRET --body "your-webhook-secret"
 # OAuth client used to verify the installing user controls the installation
 # (required — without it /api/github/setup refuses to bind, anti-IDOR).
 gh secret set MAKO_GITHUB_APP_CLIENT_SECRET --body "your-app-client-secret"
-gh variable set MAKO_GITHUB_APP_ID --body 4093709
-gh variable set MAKO_GITHUB_APP_SLUG --body mako-transforms-jonas-dev
+gh variable set MAKO_GITHUB_APP_ID --body 4106865
+gh variable set MAKO_GITHUB_APP_SLUG --body mako-ai
 gh variable set MAKO_GITHUB_APP_CLIENT_ID --body Iv1.xxxxxxxxxxxxxxxx
 ```
 
-`deploy-app.yml` passes these to Cloud Run for **PR previews** and **production**.
+`deploy-app.yml` passes these to Cloud Run for **PR previews** and
+**production**. Keep the `production` GitHub environment free of
+`MAKO_GITHUB_APP_*` overrides so both jobs resolve the repository-level values.
 
 ## 2. GitHub App settings (github.com → Settings → Developer settings → GitHub Apps)
 
-| Field | Production value |
-| --- | --- |
-| Homepage URL | `https://app.mako.ai` |
-| Callback URL (App OAuth) | `https://app.mako.ai/api/github/setup` |
+| Field                                                      | Production value                                                                  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Homepage URL                                               | `https://app.mako.ai`                                                             |
+| Callback URL (App OAuth)                                   | `https://app.mako.ai/api/github/setup`                                            |
 | **Request user authorization (OAuth) during installation** | ✅ **enabled** (required — delivers the `code` `/setup` uses to verify ownership) |
-| Setup URL | `https://app.mako.ai/api/github/setup` |
-| Webhook URL | `https://app.mako.ai/api/github/webhook` |
-| Webhook secret | same as `GITHUB_APP_WEBHOOK_SECRET` |
-| Logo | upload `.secrets/github-app-icon.png` (Mako icon) |
+| Setup URL                                                  | `https://app.mako.ai/api/github/setup`                                            |
+| Webhook URL                                                | `https://app.mako.ai/api/github/webhook`                                          |
+| Webhook secret                                             | same as `GITHUB_APP_WEBHOOK_SECRET`                                               |
+| Logo                                                       | upload `.secrets/github-app-icon.png` (Mako icon)                                 |
 
-> When *Request user authorization during installation* is on, GitHub makes the Setup URL unavailable and redirects through the **Callback URL** with both `code` and `installation_id` — so the App's Callback URL must point at `/api/github/setup`. Grab the **Client ID** and a generated **Client secret** from the App's General page for `MAKO_GITHUB_APP_CLIENT_ID` / `MAKO_GITHUB_APP_CLIENT_SECRET`.
+> When _Request user authorization during installation_ is on, GitHub makes the Setup URL unavailable and redirects through the **Callback URL** with both `code` and `installation_id` — so the App's Callback URL must point at `/api/github/setup`. Grab the **Client ID** and a generated **Client secret** from the App's General page for `MAKO_GITHUB_APP_CLIENT_ID` / `MAKO_GITHUB_APP_CLIENT_SECRET`.
 
 **Visibility:** set to **Any account** for multi-tenant SaaS.
 
@@ -86,8 +84,8 @@ Requires user session on prod API during setup (cookie on `app.mako.ai`). If coo
 # .env
 BASE_URL=http://localhost:8090
 CLIENT_URL=[REDACTED]
-GITHUB_APP_ID=...
-GITHUB_APP_SLUG=...
+GITHUB_APP_ID=4106865
+GITHUB_APP_SLUG=mako-ai
 GITHUB_APP_PRIVATE_KEY="-----BEGIN..."
 GITHUB_APP_WEBHOOK_SECRET=...
 GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
@@ -96,10 +94,10 @@ GITHUB_APP_CLIENT_SECRET=...
 pnpm configure:github-app   # writes GITHUB_APP_* from .secrets/github-app.pem
 ```
 
-`pnpm register:github-app` (manifest flow) captures `GITHUB_APP_CLIENT_ID` /
-`GITHUB_APP_CLIENT_SECRET` automatically and enables OAuth-on-install. For an
-existing App, copy them from the App's General page and enable *Request user
-authorization (OAuth) during installation* manually.
+Use the same Mako AI App credentials locally. `pnpm register:github-app` creates
+a new App and therefore must not be used for routine local setup. For the
+existing App, copy the values from the approved secret store and keep _Request
+user authorization (OAuth) during installation_ enabled.
 
 For local install callback, either point GitHub App setup URL at a tunnel, or seed `github_installations` manually after installing on github.com.
 


### PR DESCRIPTION
## Summary

- restore the Share button in the app workspace
- provide fullscreen links for workspace-only and public app access
- expose the three app sharing scopes: workspace members, public with password, and public without password
- route public app shares to their published deployment instead of the dashboard renderer
- return only safe public-share metadata in the apps list
- restore git-backed Apps, Consoles, and dbt content in serverless PR previews
- standardize every deployment on the canonical Mako AI GitHub App and fail deployment if its App ID drifts
- let cloned-DB previews read immutable published app bundles and binding data from the canonical artifact bucket while keeping all preview writes isolated in dev

## Root causes fixed

PR databases copy production workspace bindings, including GitHub installation IDs. Those IDs are scoped to a GitHub App, but previews used a separate dev App, so GitHub returned 404 while minting the installation token and the cold preview instance could not clone the workspace repository.

The canonical production App credentials now live at repository scope for every environment; the obsolete production-only overrides were removed.

The cloned database also retained each app's production `publishedSha`, while PR previews only read their isolated dev artifact bucket. The app existed in Git and MongoDB, but its built `index.html`, JS/CSS, and Parquet bindings existed only in the canonical production artifact bucket, so the fullscreen URL returned `Not found` and binding requests returned 404.

Preview reads now prefer their isolated dev bucket and fall back to the canonical bucket. Writes still target dev only. The preview runtime has conditional `storage.objectViewer` access limited to the `apps/` and legacy `apps-v2/` object prefixes; it cannot write production artifacts or read dashboard/notebook objects.

## Validation

- `pnpm --filter app run build`
- `pnpm --filter app exec vitest run src/store/shareStore.test.ts`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`
- `pnpm run openapi:sync`
- `pnpm --filter api exec tsx src/auth/login-redirect.test.ts`
- `pnpm --filter api exec vitest run --config vitest.apps.config.ts src/apps/deployment.service.test.ts` (3 focused artifact-fallback tests)
- `pnpm --filter api exec tsc -p tsconfig.build.json --noEmit`
- `git diff --check`
- PR deployment workflow passed, including the canonical GitHub App and published-app source guards
- verified in authenticated `pr-974.mako.ai` that Apps, Consoles, and the RealAdvisor dbt project load from Git without the installation-token error
- verified the exact copied fullscreen URL for `0-moments-distribution-supply-demand`: HTML and JS/CSS render, KPI/trend/table binding data loads, and the page has zero 404 or failed-load messages

The app build completes with the repository's five existing ESLint warnings. The full API test script also reached an unrelated pre-existing failure in `parquet-build.readonly.test.ts`; the affected focused suite, API compile, lint, and production build pass.
