### PR TITLE
Harden every git overlay (flows, skills, consoles, dbt) against the six bug classes #975 found

### DIFF
--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -77,6 +77,7 @@ import {
   unbindTestWorkspaceRepo,
 } from "../../apps/bind-test-workspace-repo";
 import { DBT_ENVIRONMENTS_PATH } from "../../dbt/dbt-config-files";
+import { commitDbtJobFile, reserveJobSlug } from "../../dbt/dbt-config.service";
 
 let mongo: MongoMemoryServer;
 let tmpRoot: string;
@@ -121,10 +122,16 @@ async function seedProject(): Promise<string> {
   return project._id.toString();
 }
 
-async function seedJob(projectId: string): Promise<string> {
+/**
+ * A job is live only when `dbt/jobs/<slug>.yml` exists at main (the tools
+ * resolve through the git overlay); seed the row AND commit its file.
+ */
+async function seedJob(projectId: string, opts?: { mongoOnly?: boolean }) {
+  const project = await DbtProject.findById(projectId);
   const job = await DbtJob.create({
     workspaceId: new Types.ObjectId(WS),
     projectId: new Types.ObjectId(projectId),
+    slug: await reserveJobSlug(new Types.ObjectId(projectId), "nightly"),
     name: "nightly",
     environment: "dev",
     commands: ["build"],
@@ -132,6 +139,7 @@ async function seedJob(projectId: string): Promise<string> {
     deferToProduction: false,
     createdBy: "tester",
   });
+  if (!opts?.mongoOnly) await commitDbtJobFile(project!, job);
   return job._id.toString();
 }
 
@@ -179,6 +187,15 @@ describe("dbt_delete_job", () => {
     expect(result.jobId).toBe(jobId);
     expect(result.name).toBe("nightly");
     expect(await DbtJob.countDocuments({})).toBe(0);
+  });
+
+  it("refuses a row whose file is not at main (not a live definition)", async () => {
+    const projectId = await seedProject();
+    const jobId = await seedJob(projectId, { mongoOnly: true });
+    const result = await deleteJob({ projectId, jobId });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    expect(await DbtJob.countDocuments({})).toBe(1);
   });
 
   it("returns an error for an unknown job id", async () => {

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -70,6 +70,7 @@ import {
   loadLiveJobs,
   liveJobToPlain,
   reserveJobSlug,
+  resolveLiveJobRow,
 } from "../../dbt/dbt-config.service";
 import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
@@ -1001,11 +1002,9 @@ export const createDbtServerTools = (
           if (!Types.ObjectId.isValid(jobId)) {
             return { success: false, error: "Invalid job id" };
           }
-          const job = await DbtJob.findOne({
-            _id: new Types.ObjectId(jobId),
-            projectId: project._id,
-          });
-          if (!job) return { success: false, error: "Job not found" };
+          const resolved = await resolveLiveJobRow(project, jobId);
+          if (!resolved.ok) return { success: false, error: resolved.error };
+          const job = resolved.row;
           const run = await triggerDbtJobRun({
             workspaceId,
             job,
@@ -1353,11 +1352,9 @@ export const createDbtServerTools = (
           if (!Types.ObjectId.isValid(jobId)) {
             return { success: false, error: "Invalid job id" };
           }
-          const job = await DbtJob.findOne({
-            _id: new Types.ObjectId(jobId),
-            projectId: project._id,
-          });
-          if (!job) return { success: false, error: "Job not found" };
+          const resolved = await resolveLiveJobRow(project, jobId);
+          if (!resolved.ok) return { success: false, error: resolved.error };
+          const job = resolved.row;
 
           const merged = {
             environment: updates.environment ?? job.environment,
@@ -1415,11 +1412,9 @@ export const createDbtServerTools = (
           if (!Types.ObjectId.isValid(jobId)) {
             return { success: false, error: "Invalid job id" };
           }
-          const job = await DbtJob.findOne({
-            _id: new Types.ObjectId(jobId),
-            projectId: project._id,
-          });
-          if (!job) return { success: false, error: "Job not found" };
+          const resolved = await resolveLiveJobRow(project, jobId);
+          if (!resolved.ok) return { success: false, error: resolved.error };
+          const job = resolved.row;
           const name = job.name;
           await deleteDbtJobFile(project, job.slug, actingUserId);
           await DbtJob.deleteOne({ _id: job._id, projectId: project._id });

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -35,6 +35,7 @@ import {
   type ISavedConsole,
 } from "../../database/workspace-schema";
 import { ConsoleManager } from "../../utils/console-manager";
+import { liveConsoleCode } from "../../apps/workspace-consoles.service";
 import { workspaceService } from "../../services/workspace.service";
 import { publishRealtimeEvent } from "../../services/realtime.service";
 import {
@@ -181,6 +182,10 @@ export function createServerConsoleTools({
         error: `Console with ID ${consoleId} not found. Use list_open_consoles or search_consoles to see available consoles.`,
       };
     }
+    // Git is the definition: the agent edits and runs the file at main, not
+    // the row's last pushed copy.
+    const liveCode = await liveConsoleCode(workspaceId, consoleId);
+    if (liveCode) doc.code = liveCode.code;
     return { doc };
   };
 

--- a/api/src/apps/workspace-consoles.service.test.ts
+++ b/api/src/apps/workspace-consoles.service.test.ts
@@ -8,7 +8,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import {
@@ -320,6 +328,80 @@ describe("write-through", () => {
     });
     expect(again.unchanged).toBe(true);
     expect(await resolveCommit(repoDirFor(WS), MAIN)).toBe(before);
+  });
+});
+
+describe("sync hardening", () => {
+  it("one file that fails to reconcile does not skip the files after it or the deletion pass", async () => {
+    const a = await manager.saveConsole(
+      "Finance/aaa",
+      "SELECT 1",
+      WS,
+      USER,
+      undefined,
+      undefined,
+      undefined,
+      { access: "workspace", language: "sql" },
+    );
+    const b = await manager.saveConsole(
+      "Finance/bbb",
+      "SELECT 2",
+      WS,
+      USER,
+      undefined,
+      undefined,
+      undefined,
+      { access: "workspace", language: "sql" },
+    );
+    const doomed = await manager.saveConsole(
+      "Finance/ccc",
+      "SELECT 3",
+      WS,
+      USER,
+      undefined,
+      undefined,
+      undefined,
+      { access: "workspace", language: "sql" },
+    );
+    const edit = (n: number) =>
+      serializeConsoleFile({
+        name: "x",
+        language: "sql",
+        code: `SELECT ${n} -- laptop`,
+      });
+    await externalCommit(
+      {
+        "consoles/Finance/aaa.sql": edit(10),
+        "consoles/Finance/bbb.sql": edit(20),
+      },
+      ["consoles/Finance/ccc.sql"],
+    );
+    // The first row write throws (a value the schema cannot cast, a race,
+    // any Mongo error); it used to escape the loop.
+    const original = SavedConsole.updateOne.bind(SavedConsole);
+    let failed = false;
+    const spy = vi.spyOn(SavedConsole, "updateOne").mockImplementation(((
+      ...args: Parameters<typeof original>
+    ) => {
+      const filter = args[0] as { _id?: unknown };
+      if (!failed && String(filter?._id) === String(a._id)) {
+        failed = true;
+        throw new Error("simulated cast failure");
+      }
+      return original(...args);
+    }) as typeof SavedConsole.updateOne);
+    try {
+      const stats = await syncConsolesIndexFromRepo(WS, USER);
+      expect(stats.deleted).toBe(1);
+      expect(failed).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    expect((await SavedConsole.findById(a._id))?.code).toBe("SELECT 1");
+    expect((await SavedConsole.findById(b._id))?.code).toBe(
+      "SELECT 20 -- laptop",
+    );
+    expect((await SavedConsole.findById(doomed._id))?.is_deleted).toBe(true);
   });
 });
 

--- a/api/src/apps/workspace-consoles.service.ts
+++ b/api/src/apps/workspace-consoles.service.ts
@@ -557,6 +557,26 @@ export async function loadLiveConsoles(
  * Resolve a console id for GET. Drafts stay on the Mongo working copy;
  * saved consoles are live only when the file exists at main.
  */
+/**
+ * The code to EXECUTE for a console: the file at main when the console is
+ * live there, else null (draft, unbound workspace, file gone). Every runner
+ * — the execute route, the scheduled executor, the agent's load — used to
+ * run `SavedConsole.code`, i.e. the last push, so a query edited in git ran
+ * stale until the webhook landed.
+ */
+export async function liveConsoleCode(
+  workspaceId: string,
+  consoleId: string,
+): Promise<{ code: string; language: ConsoleLanguage; path: string } | null> {
+  const hit = await loadLiveConsoleById(workspaceId, consoleId);
+  if (!hit || !("live" in hit)) return null;
+  return {
+    code: hit.live.parsed.code,
+    language: hit.live.location.language,
+    path: hit.live.path,
+  };
+}
+
 export async function loadLiveConsoleById(
   workspaceId: string,
   consoleId: string,
@@ -974,135 +994,146 @@ async function syncNow(
   }
 
   for (const entry of consoleEntries) {
-    const location = parseConsoleRepoPath(entry.path);
-    if (!location) continue;
-    const sidecar = byPath.get(chartSidecarPath(entry.path));
-    let row = rowByPath.get(entry.path);
+    // One file's failure is that file's problem: a folder-name validation
+    // error or a front-matter value the schema cannot cast must not skip
+    // every file after it, the deletion pass, and the realtime events.
+    try {
+      const location = parseConsoleRepoPath(entry.path);
+      if (!location) continue;
+      const sidecar = byPath.get(chartSidecarPath(entry.path));
+      let row = rowByPath.get(entry.path);
 
-    if (!row) {
-      const candidates = orphanByBlob.get(entry.oid);
-      const moved = candidates?.shift();
-      if (moved) {
-        row = moved;
-        stats.renamed++;
+      if (!row) {
+        const candidates = orphanByBlob.get(entry.oid);
+        const moved = candidates?.shift();
+        if (moved) {
+          row = moved;
+          stats.renamed++;
+        }
       }
-    }
 
-    if (row) {
-      seenRows.add(row._id.toString());
-      const contentSame =
-        row.sourceBlobSha === entry.oid && row.path === entry.path;
-      const chartSame = await sidecarMatches(sidecar, row.chartSpec);
-      if (contentSame && chartSame && !row.is_deleted) {
-        stats.skipped++;
+      if (row) {
+        seenRows.add(row._id.toString());
+        const contentSame =
+          row.sourceBlobSha === entry.oid && row.path === entry.path;
+        const chartSame = await sidecarMatches(sidecar, row.chartSpec);
+        if (contentSame && chartSame && !row.is_deleted) {
+          stats.skipped++;
+          continue;
+        }
+        if (row.is_deleted) stats.restored++;
+        else if (row.path === entry.path) stats.updated++;
+      }
+
+      const contents = await readAt(repoDir, entry.path);
+      // Unreadable files are not healed from Mongo. Skip; GET/list omits them.
+      if (contents === null) continue;
+      const parsed = parseConsoleFile(contents, location.language);
+      const chartSpec = sidecar
+        ? parseChartSpec((await readAt(repoDir, sidecar.path)) ?? "")
+        : undefined;
+      const access: ConsoleAccessLevel =
+        location.scope === "private" ? "private" : "workspace";
+      const ownerId =
+        location.scope === "private" && location.ownerId
+          ? location.ownerId
+          : (row?.owner_id ?? row?.createdBy ?? actor);
+      // A folder that first appears from git belongs to whoever pushed it
+      // (the console's owner), so they can rename or delete it later.
+      const folderId = await ensureFolderChain(
+        location.folderSegments,
+        workspaceId,
+        { access, ownerId },
+      );
+
+      const set: Record<string, unknown> = {
+        path: entry.path,
+        sourceBlobSha: entry.oid,
+        name: location.name,
+        language: location.language,
+        code: parsed.code,
+        folderId: folderId ?? null,
+        access,
+        isPrivate: access === "private",
+        owner_id: ownerId,
+        connectionId:
+          parsed.meta.connectionId &&
+          Types.ObjectId.isValid(parsed.meta.connectionId)
+            ? new Types.ObjectId(parsed.meta.connectionId)
+            : null,
+        databaseName: parsed.meta.databaseName ?? null,
+        databaseId: parsed.meta.databaseId ?? null,
+        resultsViewMode: parsed.meta.resultsViewMode ?? null,
+        mongoOptions: parsed.meta.mongoOptions ?? null,
+        chartSpec: chartSpec ?? null,
+        is_deleted: false,
+        isSaved: true,
+        lastDraftOrigin: "user",
+        updatedAt: new Date(),
+      };
+      if (parsed.meta.description) {
+        set.description = parsed.meta.description;
+        set.descriptionSource = "authored";
+      } else if (row && descriptionIsAuthored(row)) {
+        // The author removed their description: the generated one takes over
+        // on the next derivation.
+        set.description = "";
+        set.descriptionSource = "generated";
+      }
+      const scheduleSet = scheduleFields(parsed.meta.schedule, row);
+      Object.assign(set, scheduleSet.set);
+
+      if (row) {
+        await SavedConsole.updateOne(
+          { _id: row._id },
+          {
+            $set: set,
+            $inc: { version: 1, draftRevision: 1 },
+            $unset: { deletedAt: "", ...scheduleSet.unset },
+          },
+        );
+        const fresh = await SavedConsole.findById(row._id);
+        if (fresh) touched.push(fresh);
         continue;
       }
-      if (row.is_deleted) stats.restored++;
-      else if (row.path === entry.path) stats.updated++;
-    }
 
-    const contents = await readAt(repoDir, entry.path);
-    // Unreadable files are not healed from Mongo. Skip; GET/list omits them.
-    if (contents === null) continue;
-    const parsed = parseConsoleFile(contents, location.language);
-    const chartSpec = sidecar
-      ? parseChartSpec((await readAt(repoDir, sidecar.path)) ?? "")
-      : undefined;
-    const access: ConsoleAccessLevel =
-      location.scope === "private" ? "private" : "workspace";
-    const ownerId =
-      location.scope === "private" && location.ownerId
-        ? location.ownerId
-        : (row?.owner_id ?? row?.createdBy ?? actor);
-    // A folder that first appears from git belongs to whoever pushed it
-    // (the console's owner), so they can rename or delete it later.
-    const folderId = await ensureFolderChain(
-      location.folderSegments,
-      workspaceId,
-      { access, ownerId },
-    );
-
-    const set: Record<string, unknown> = {
-      path: entry.path,
-      sourceBlobSha: entry.oid,
-      name: location.name,
-      language: location.language,
-      code: parsed.code,
-      folderId: folderId ?? null,
-      access,
-      isPrivate: access === "private",
-      owner_id: ownerId,
-      connectionId:
-        parsed.meta.connectionId &&
-        Types.ObjectId.isValid(parsed.meta.connectionId)
-          ? new Types.ObjectId(parsed.meta.connectionId)
-          : null,
-      databaseName: parsed.meta.databaseName ?? null,
-      databaseId: parsed.meta.databaseId ?? null,
-      resultsViewMode: parsed.meta.resultsViewMode ?? null,
-      mongoOptions: parsed.meta.mongoOptions ?? null,
-      chartSpec: chartSpec ?? null,
-      is_deleted: false,
-      isSaved: true,
-      lastDraftOrigin: "user",
-      updatedAt: new Date(),
-    };
-    if (parsed.meta.description) {
-      set.description = parsed.meta.description;
-      set.descriptionSource = "authored";
-    } else if (row && descriptionIsAuthored(row)) {
-      // The author removed their description: the generated one takes over
-      // on the next derivation.
-      set.description = "";
-      set.descriptionSource = "generated";
-    }
-    const scheduleSet = scheduleFields(parsed.meta.schedule, row);
-    Object.assign(set, scheduleSet.set);
-
-    if (row) {
-      await SavedConsole.updateOne(
-        { _id: row._id },
-        {
-          $set: set,
-          $inc: { version: 1, draftRevision: 1 },
-          $unset: { deletedAt: "", ...scheduleSet.unset },
-        },
-      );
-      const fresh = await SavedConsole.findById(row._id);
-      if (fresh) touched.push(fresh);
-      continue;
-    }
-
-    try {
-      const created = await SavedConsole.create({
-        _id: derivedConsoleId(workspaceId, entry.path),
-        workspaceId: ws,
-        createdBy: actor,
-        executionCount: 0,
-        version: 1,
-        draftRevision: 1,
-        ...set,
-      });
-      stats.created++;
-      seenRows.add(created._id.toString());
-      touched.push(created);
-    } catch {
-      // Unique-id race with a concurrent list/sync: keep the winner so a
-      // git-only file that already appeared under the derived id does not
-      // mint a second row.
-      const winner =
-        (await SavedConsole.findById(
-          derivedConsoleId(workspaceId, entry.path),
-        )) ??
-        (await SavedConsole.findOne({
+      try {
+        const created = await SavedConsole.create({
+          _id: derivedConsoleId(workspaceId, entry.path),
           workspaceId: ws,
-          path: entry.path,
-          isSaved: true,
-        }));
-      if (!winner) throw new Error("Could not persist the console index row");
-      stats.created++;
-      seenRows.add(winner._id.toString());
-      touched.push(winner);
+          createdBy: actor,
+          executionCount: 0,
+          version: 1,
+          draftRevision: 1,
+          ...set,
+        });
+        stats.created++;
+        seenRows.add(created._id.toString());
+        touched.push(created);
+      } catch {
+        // Unique-id race with a concurrent list/sync: keep the winner so a
+        // git-only file that already appeared under the derived id does not
+        // mint a second row.
+        const winner =
+          (await SavedConsole.findById(
+            derivedConsoleId(workspaceId, entry.path),
+          )) ??
+          (await SavedConsole.findOne({
+            workspaceId: ws,
+            path: entry.path,
+            isSaved: true,
+          }));
+        if (!winner) throw new Error("Could not persist the console index row");
+        stats.created++;
+        seenRows.add(winner._id.toString());
+        touched.push(winner);
+      }
+    } catch (error) {
+      logger.warn("Console file could not be reconciled; skipped", {
+        workspaceId,
+        path: entry.path,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -1546,6 +1577,12 @@ export async function projectSavedConsole(input: {
   onInsert?: Record<string, unknown>;
   actorUserId: string;
   message: string;
+  /**
+   * The file the save replaces when there is no row yet (a git-only console
+   * saved under its derived id): without it the projection writes a second
+   * file next to the original instead of moving it.
+   */
+  previousPath?: string | null;
 }): Promise<Projection> {
   const base: Record<string, unknown> = input.current
     ? (input.current.toObject() as Record<string, unknown>)
@@ -1566,7 +1603,7 @@ export async function projectSavedConsole(input: {
     if (value !== undefined) desired[key] = value;
   }
   const row = desired as unknown as RowLike;
-  const previousPath = input.current?.path ?? null;
+  const previousPath = input.current?.path ?? input.previousPath ?? null;
   const committed = await commitConsoleState({
     row,
     previousPath,

--- a/api/src/apps/workspace-skills.service.test.ts
+++ b/api/src/apps/workspace-skills.service.test.ts
@@ -150,6 +150,102 @@ describe("write-through", () => {
   });
 });
 
+describe("sync hardening (one bad file, markers, reverts)", () => {
+  it("a file that stops parsing keeps its row (marked), and one bad file never aborts the rest", async () => {
+    await commitSkillSave(WS, skill("keeps_row"));
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    const before = await Skill.findOne({ name: "keeps_row" });
+    expect(before).not.toBeNull();
+    await Skill.updateOne({ _id: before!._id }, { $set: { useCount: 7 } });
+
+    // aaa_ sorts first: a body past the schema cap used to throw out of the
+    // loop (ValidationError on create) and skip everything after it.
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      {
+        writes: {
+          [skillFilePath("aaa_too_long")]: serializeSkillFile(
+            skill("aaa_too_long", "x".repeat(20_001)),
+          ),
+          [skillFilePath("keeps_row")]: "not a skill file at all\n",
+          [skillFilePath("zzz_fine")]: serializeSkillFile(skill("zzz_fine")),
+        },
+      },
+      { message: "hostile batch" },
+    );
+    await expect(
+      syncSkillsIndexFromRepo(WS, "user-1"),
+    ).resolves.toBeUndefined();
+
+    expect(await Skill.findOne({ name: "aaa_too_long" })).toBeNull();
+    expect(await Skill.findOne({ name: "zzz_fine" })).not.toBeNull();
+    const kept = await Skill.findOne({ name: "keeps_row" });
+    expect(kept?.useCount).toBe(7);
+    expect(kept?.body).toBe("Do the thing.");
+    expect(typeof kept?.definitionInvalid?.reason).toBe("string");
+
+    // The list carries the reason (not `{}`), and does not rewrite it.
+    const live = await loadLiveSkills(WS);
+    const plain = liveSkillToPlain(
+      live.find(item => item.def.name === "keeps_row")!,
+      WS,
+    );
+    expect(
+      (plain.definitionInvalid as { reason?: string } | undefined)?.reason,
+    ).toBe(kept?.definitionInvalid?.reason);
+    const at = (await Skill.findOne({ name: "keeps_row" }))?.definitionInvalid
+      ?.at;
+    await loadLiveSkills(WS);
+    expect(
+      (await Skill.findOne({ name: "keeps_row" }))?.definitionInvalid?.at,
+    ).toEqual(at);
+  });
+
+  it("an unset marker is not 'invalid', and reverting to identical content clears a real one", async () => {
+    await commitSkillSave(WS, skill("revertable"));
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    const good = await fileAt(skillFilePath("revertable"));
+    const row = await Skill.findOne({ name: "revertable" });
+    // Mongoose materialises the unset nested path as `{}` on a hydrated
+    // doc; that must not read as a marker anywhere.
+    expect(row?.definitionInvalid?.reason).toBeUndefined();
+    let plain = liveSkillToPlain(
+      (await loadLiveSkills(WS)).find(item => item.def.name === "revertable")!,
+      WS,
+    );
+    expect(plain.definitionInvalid).toBeUndefined();
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { writes: { [skillFilePath("revertable")]: "broken\n" } },
+      { message: "break" },
+    );
+    await loadLiveSkills(WS);
+    expect(
+      typeof (await Skill.findOne({ name: "revertable" }))?.definitionInvalid
+        ?.reason,
+    ).toBe("string");
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { writes: { [skillFilePath("revertable")]: good! } },
+      { message: "revert" },
+    );
+    await syncSkillsIndexFromRepo(WS, "user-1");
+    expect(
+      (await Skill.findOne({ name: "revertable" }))?.definitionInvalid?.reason,
+    ).toBeUndefined();
+    plain = liveSkillToPlain(
+      (await loadLiveSkills(WS)).find(item => item.def.name === "revertable")!,
+      WS,
+    );
+    expect(plain.definitionInvalid).toBeUndefined();
+  });
+});
+
 describe("sync from repo", () => {
   it("an external skill edit reaches the index; removal deletes the row", async () => {
     await commitSkillSave(WS, skill("synced"));

--- a/api/src/apps/workspace-skills.service.ts
+++ b/api/src/apps/workspace-skills.service.ts
@@ -253,7 +253,7 @@ function skillIndexDrift(
     const row = byName.get(def.name);
     if (!row) continue;
     if (row.sourceBlobSha !== def.oid) return true;
-    if (row.definitionInvalid && def.parsed) return true;
+    if (isSkillMarkedInvalid(row) && def.parsed) return true;
   }
   return false;
 }
@@ -290,19 +290,48 @@ function applySkillDefinition(doc: ISkill, file: WorkspaceSkillFile): void {
   doc.suppressed = file.suppressed;
 }
 
+/**
+ * Mongoose materialises an unset nested path as `{}` on a hydrated doc, so
+ * the marker's presence is its `reason`, never the object's truthiness —
+ * `if (row.definitionInvalid)` reads every healthy row as invalid.
+ */
+export function isSkillMarkedInvalid(row: {
+  definitionInvalid?: { reason?: string } | null;
+}): boolean {
+  return typeof row.definitionInvalid?.reason === "string";
+}
+
+/** The row's marker when it is a real one (see isSkillMarkedInvalid). */
+function rowInvalidMarker(
+  row: ISkill | null,
+): ISkill["definitionInvalid"] | undefined {
+  return row && isSkillMarkedInvalid(row) ? row.definitionInvalid : undefined;
+}
+
+/** Assigning `undefined` to a nested path persists `{}`; unset it instead. */
+async function clearSkillInvalid(id: Types.ObjectId): Promise<void> {
+  await Skill.updateOne({ _id: id }, { $unset: { definitionInvalid: 1 } });
+}
+
 async function markSkillInvalid(
   doc: ISkill,
   reason: string,
   path: string,
 ): Promise<void> {
+  // Idempotent: a list call must not rewrite the marker on every read.
+  if (
+    doc.definitionInvalid?.reason === reason &&
+    doc.definitionInvalid?.path === path
+  ) {
+    return;
+  }
   // $set only the invalid stamp. Saving the loaded document re-runs the
   // whole schema (createdBy required, maxlength, …) and 500s GET/list
   // when the last-good row itself cannot save.
   try {
-    await Skill.updateOne(
-      { _id: doc._id },
-      { $set: { definitionInvalid: { reason, at: new Date(), path } } },
-    );
+    const definitionInvalid = { reason, at: new Date(), path };
+    await Skill.updateOne({ _id: doc._id }, { $set: { definitionInvalid } });
+    doc.definitionInvalid = definitionInvalid;
   } catch (error) {
     logger.warn("Failed to mark skill invalid", {
       skillId: doc._id.toString(),
@@ -413,7 +442,7 @@ export async function loadLiveSkillById(
     const defs = await listSkillDefinitionsAtMain(workspaceId);
     const def = defs.find(item => item.name === row.name);
     if (!def) return null;
-    if (row.sourceBlobSha !== def.oid || row.definitionInvalid) {
+    if (row.sourceBlobSha !== def.oid || isSkillMarkedInvalid(row)) {
       try {
         await ensureSkillDerivedCache(row);
       } catch (error) {
@@ -454,13 +483,19 @@ export function liveSkillToPlain(
         createdBy: "git",
         useCount: 0,
         scopeType: "workspace",
+        // Whole shape for a file with no row yet: clients read these.
+        lastUsedAt: null,
+        createdAt: null,
+        updatedAt: null,
+        previousBody: null,
+        previousUpdatedAt: null,
       };
   base._id = live.id;
   base.name = live.def.name;
   base.workspaceId = live.row?.workspaceId ?? new Types.ObjectId(workspaceId);
   const parsed = live.def.parsed;
   if (!parsed) {
-    base.definitionInvalid = live.row?.definitionInvalid ?? {
+    base.definitionInvalid = rowInvalidMarker(live.row) ?? {
       reason: "unparseable skill file",
       at: new Date(),
       path: live.def.path,
@@ -475,7 +510,7 @@ export function liveSkillToPlain(
     applyFailure = error instanceof Error ? error.message : String(error);
   }
   if (applyFailure) {
-    base.definitionInvalid = live.row?.definitionInvalid ?? {
+    base.definitionInvalid = rowInvalidMarker(live.row) ?? {
       reason: applyFailure,
       at: new Date(),
       path: live.def.path,
@@ -486,7 +521,7 @@ export function liveSkillToPlain(
   try {
     applySkillDefinition(base as unknown as ISkill, parsed);
   } catch (error) {
-    base.definitionInvalid = live.row?.definitionInvalid ?? {
+    base.definitionInvalid = rowInvalidMarker(live.row) ?? {
       reason: error instanceof Error ? error.message : String(error),
       at: new Date(),
       path: live.def.path,
@@ -513,16 +548,17 @@ export async function ensureSkillDerivedCache(skill: {
   definitionInvalid?: { reason: string } | null;
 }): Promise<"ok" | "invalid" | "missing" | "resynced"> {
   if (!skill.name) return "ok";
+  const marked = isSkillMarkedInvalid(skill);
   if (!SKILL_NAME_RE.test(skill.name)) {
-    return skill.definitionInvalid ? "invalid" : "ok";
+    return marked ? "invalid" : "ok";
   }
   const workspaceId = skill.workspaceId.toString();
   const repoDir = await boundRepoDirIfExists(workspaceId);
   if (repoDir == null) {
-    return skill.definitionInvalid ? "invalid" : "ok";
+    return marked ? "invalid" : "ok";
   }
   const head = await resolveCommit(repoDir, MAIN);
-  if (!head) return skill.definitionInvalid ? "invalid" : "ok";
+  if (!head) return marked ? "invalid" : "ok";
   const path = skillFilePath(skill.name);
   let contents: string;
   try {
@@ -539,7 +575,7 @@ export async function ensureSkillDerivedCache(skill: {
     return "missing";
   }
   const sha = blobOid(contents);
-  if (skill.sourceBlobSha === sha && !skill.definitionInvalid) return "ok";
+  if (skill.sourceBlobSha === sha && !marked) return "ok";
   const parsed = parseSkillFile(skill.name, contents);
   const row = await Skill.findById(skill._id);
   if (!row) return "missing";
@@ -547,6 +583,18 @@ export async function ensureSkillDerivedCache(skill: {
     await markSkillInvalid(row, "unparseable skill file", path);
     return "invalid";
   }
+  // Same predicate the list and push-sync use; a file the save path would
+  // refuse must not be applied here either.
+  const applyFailure = skillFileApplyFailure(parsed);
+  if (applyFailure) {
+    await markSkillInvalid(row, applyFailure, path);
+    return "invalid";
+  }
+  // Stamping the sha declares the row level with the file. When the trigger
+  // text changed but the embedding could not be computed (service available,
+  // call failed), leave the row unstamped so the next read retries instead
+  // of ranking on the old vector forever.
+  let stamp = true;
   try {
     if (row.body !== parsed.body) {
       row.previousBody = row.body;
@@ -557,6 +605,8 @@ export async function ensureSkillDerivedCache(skill: {
       if (embedding) {
         row.loadWhenEmbedding = embedding;
         row.embeddingModel = model;
+      } else if (isEmbeddingAvailable()) {
+        stamp = false;
       }
     }
     applySkillDefinition(row, parsed);
@@ -566,10 +616,10 @@ export async function ensureSkillDerivedCache(skill: {
     if (fresh) await markSkillInvalid(fresh, reason, path);
     return "invalid";
   }
-  row.definitionInvalid = undefined;
-  row.sourceBlobSha = sha;
+  if (stamp) row.sourceBlobSha = sha;
   try {
     await row.save();
+    if (marked) await clearSkillInvalid(row._id);
   } catch (error) {
     // applySkillDefinition already mutated `row`. Saving that document
     // again (via markSkillInvalid) would re-raise the same ValidationError
@@ -720,79 +770,106 @@ export async function syncSkillsIndexFromRepo(
   if (!(await skillsAdopted(repoDir))) return;
 
   const defs = await listSkillDefinitionsAtMain(workspaceId);
-  let parsedDefs = defs.filter(
-    (def): def is SkillDefinitionAtMain & { parsed: WorkspaceSkillFile } =>
-      def.parsed !== null,
-  );
-  if (parsedDefs.length > MAX_SYNCED_SKILLS) {
+  // Every file at main keeps its row. A file that stopped parsing, or one
+  // past the index cap, is NOT "removed": deleting its row would throw away
+  // useCount, the embedding and the undo slot for a typo in front-matter.
+  const fileNames = new Set(defs.map(def => def.name));
+  let indexable = defs;
+  if (indexable.length > MAX_SYNCED_SKILLS) {
     logger.warn(
       "Workspace has more skill files than the index cap; truncating",
       {
         workspaceId,
-        fileCount: parsedDefs.length,
+        fileCount: indexable.length,
         cap: MAX_SYNCED_SKILLS,
       },
     );
-    parsedDefs = parsedDefs.slice(0, MAX_SYNCED_SKILLS);
+    indexable = indexable.slice(0, MAX_SYNCED_SKILLS);
   }
 
   const wsObjectId = new Types.ObjectId(workspaceId);
   const rows = (await Skill.find({ workspaceId: wsObjectId })) as ISkill[];
   const rowByName = new Map(rows.map(r => [r.name, r]));
-  const fileNames = new Set(parsedDefs.map(def => def.name));
 
-  for (const def of parsedDefs) {
+  for (const def of indexable) {
+    const row = rowByName.get(def.name) ?? null;
+    // One bad file must never abort the loop for the files after it, and
+    // never index a definition the save path would refuse: the same
+    // "applies" check GET/list uses, then a guard around the write.
     const file = def.parsed;
-    const entities = indexEntities(file);
-    const row = rowByName.get(file.name);
-    if (!row) {
-      const { embedding, model } = await embeddingFor(file.loadWhen);
-      await Skill.create({
-        _id: derivedSkillId(workspaceId, file.name),
-        workspaceId: wsObjectId,
-        name: file.name,
-        loadWhen: file.loadWhen,
-        body: file.body,
-        entities,
-        declaredEntities: file.entities,
-        loadWhenEmbedding: embedding,
-        embeddingModel: model,
-        scopeType: "workspace",
-        createdBy: userId && userId.length > 0 ? userId : "agent",
-        suppressed: file.suppressed,
-        useCount: 0,
-        sourceBlobSha: def.oid,
+    const failure = file
+      ? skillFileApplyFailure(file)
+      : "unparseable skill file";
+    if (!file || failure) {
+      logger.warn("skill file does not apply; skipped", {
+        workspaceId,
+        path: def.path,
+        reason: failure,
       });
+      if (row) await markSkillInvalid(row, failure ?? "invalid", def.path);
       continue;
     }
-    const unchanged =
-      row.loadWhen === file.loadWhen &&
-      row.body === file.body &&
-      row.suppressed === file.suppressed &&
-      sameEntities(row.entities ?? [], entities) &&
-      sameEntities(row.declaredEntities ?? [], file.entities) &&
-      row.sourceBlobSha === def.oid &&
-      !row.definitionInvalid;
-    if (unchanged) continue;
-    if (row.body !== file.body) {
-      row.previousBody = row.body;
-      row.previousUpdatedAt = row.updatedAt;
-    }
-    if (row.loadWhen !== file.loadWhen) {
-      const { embedding, model } = await embeddingFor(file.loadWhen);
-      if (embedding) {
-        row.loadWhenEmbedding = embedding;
-        row.embeddingModel = model;
+    try {
+      const entities = indexEntities(file);
+      if (!row) {
+        const { embedding, model } = await embeddingFor(file.loadWhen);
+        await Skill.create({
+          _id: derivedSkillId(workspaceId, file.name),
+          workspaceId: wsObjectId,
+          name: file.name,
+          loadWhen: file.loadWhen,
+          body: file.body,
+          entities,
+          declaredEntities: file.entities,
+          loadWhenEmbedding: embedding,
+          embeddingModel: model,
+          scopeType: "workspace",
+          createdBy: userId && userId.length > 0 ? userId : "agent",
+          suppressed: file.suppressed,
+          useCount: 0,
+          sourceBlobSha: def.oid,
+        });
+        continue;
       }
+      const wasInvalid = isSkillMarkedInvalid(row);
+      const unchanged =
+        row.loadWhen === file.loadWhen &&
+        row.body === file.body &&
+        row.suppressed === file.suppressed &&
+        sameEntities(row.entities ?? [], entities) &&
+        sameEntities(row.declaredEntities ?? [], file.entities) &&
+        row.sourceBlobSha === def.oid &&
+        !wasInvalid;
+      if (unchanged) continue;
+      if (row.body !== file.body) {
+        row.previousBody = row.body;
+        row.previousUpdatedAt = row.updatedAt;
+      }
+      if (row.loadWhen !== file.loadWhen) {
+        const { embedding, model } = await embeddingFor(file.loadWhen);
+        if (embedding) {
+          row.loadWhenEmbedding = embedding;
+          row.embeddingModel = model;
+        }
+      }
+      row.loadWhen = file.loadWhen;
+      row.body = file.body;
+      row.entities = entities;
+      row.declaredEntities = file.entities;
+      row.suppressed = file.suppressed;
+      row.sourceBlobSha = def.oid;
+      await row.save();
+      if (wasInvalid) await clearSkillInvalid(row._id);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn("skill sync failed for one file; skipped", {
+        workspaceId,
+        path: def.path,
+        error: reason,
+      });
+      const fresh = row ? await Skill.findById(row._id) : null;
+      if (fresh) await markSkillInvalid(fresh, reason, def.path);
     }
-    row.loadWhen = file.loadWhen;
-    row.body = file.body;
-    row.entities = entities;
-    row.declaredEntities = file.entities;
-    row.suppressed = file.suppressed;
-    row.sourceBlobSha = def.oid;
-    row.definitionInvalid = undefined;
-    await row.save();
   }
 
   const stale = rows.filter(r => !fileNames.has(r.name));

--- a/api/src/dbt/dbt-config.service.test.ts
+++ b/api/src/dbt/dbt-config.service.test.ts
@@ -20,17 +20,21 @@ import {
   DBT_ENVIRONMENTS_PATH,
   jobFilePath,
   parseJobFile,
+  serializeEnvironmentsFile,
   serializeJobFile,
 } from "./dbt-config-files";
 import {
   adoptDbtConfig,
+  commitDbtEnvironmentsFile,
   commitDbtJobFile,
   deleteDbtJobFile,
   derivedJobId,
+  ensureEnvironmentsDerivedCache,
   loadLiveJobById,
   loadLiveJobs,
   liveJobToPlain,
   reserveJobSlug,
+  resolveLiveJobRow,
   syncDbtConfigFromRepo,
 } from "./dbt-config.service";
 import {
@@ -363,6 +367,107 @@ describe("GET/list from git", () => {
     expect(
       (await DbtJob.findById(job._id))?.definitionInvalid?.reason,
     ).toBeUndefined();
+  });
+});
+
+describe("environments follow dbt/environments.yml; jobs resolve through the overlay", () => {
+  it("a project GET after an external environments edit shows the file, marks a broken one, and clears on revert", async () => {
+    const project = await seedProject();
+    await commitDbtEnvironmentsFile(project);
+    const good = await fileAt(DBT_ENVIRONMENTS_PATH);
+    expect(good).toContain("default_environment: dev");
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      {
+        writes: {
+          [DBT_ENVIRONMENTS_PATH]: serializeEnvironmentsFile({
+            defaultEnvironment: "staging",
+            environments: [
+              {
+                name: "staging",
+                connectionId: CONN.toString(),
+                targetSchema: "dbt_staging",
+                threads: 2,
+              },
+            ],
+          }),
+        },
+      },
+      { message: "laptop: staging only" },
+    );
+    await ensureEnvironmentsDerivedCache(project);
+    expect(project.defaultEnvironment).toBe("staging");
+    expect(project.environments.map(env => env.name)).toEqual(["staging"]);
+    const stored = await DbtProject.findById(project._id);
+    expect(stored?.environments.map(env => env.name)).toEqual(["staging"]);
+    expect(stored?.environmentsInvalid?.reason).toBeUndefined();
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      { writes: { [DBT_ENVIRONMENTS_PATH]: "environments: [broken" } },
+      { message: "break environments" },
+    );
+    await ensureEnvironmentsDerivedCache(project);
+    expect(project.environmentsInvalid?.reason).toBe(
+      "unparseable environments.yml",
+    );
+    // Last-good kept.
+    expect(project.environments.map(env => env.name)).toEqual(["staging"]);
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      { writes: { [DBT_ENVIRONMENTS_PATH]: good! } },
+      { message: "revert" },
+    );
+    await ensureEnvironmentsDerivedCache(project);
+    expect(project.environmentsInvalid?.reason).toBeUndefined();
+    expect(project.defaultEnvironment).toBe("dev");
+    expect(
+      (await DbtProject.findById(project._id))?.environmentsInvalid?.reason,
+    ).toBeUndefined();
+  });
+
+  it("resolves a git-only job as 409, a synced one as ok, a deleted file as 404", async () => {
+    const project = await seedProject();
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      {
+        writes: {
+          [jobFilePath("only-git")]: serializeJobFile({
+            name: "Only git",
+            environment: "prod",
+            commands: ["build"],
+            schedule: null,
+            enabled: true,
+            deferToProduction: false,
+          }),
+        },
+      },
+      { message: "git-only job" },
+    );
+    const id = (await loadLiveJobs(project))[0]!.id.toString();
+    const gitOnly = await resolveLiveJobRow(project, id);
+    expect(gitOnly.ok).toBe(false);
+    if (!gitOnly.ok) expect(gitOnly.status).toBe(409);
+
+    await syncDbtConfigFromRepo(WS.toString());
+    const synced = await resolveLiveJobRow(project, id);
+    expect(synced.ok).toBe(true);
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS.toString()),
+      DEFAULT_BRANCH,
+      { deletes: [jobFilePath("only-git")] },
+      { message: "delete job file" },
+    );
+    const gone = await resolveLiveJobRow(project, id);
+    expect(gone.ok).toBe(false);
+    if (!gone.ok) expect(gone.status).toBe(404);
   });
 });
 

--- a/api/src/dbt/dbt-config.service.ts
+++ b/api/src/dbt/dbt-config.service.ts
@@ -46,6 +46,7 @@ import {
 } from "../apps/repository.service";
 import {
   DBT_ENVIRONMENTS_PATH,
+  type DbtEnvironmentsFile,
   jobFilePath,
   parseEnvironmentsFile,
   parseJobFile,
@@ -282,6 +283,17 @@ function joinLiveJobs(
 export async function loadLiveJobs(project: IDbtProject): Promise<LiveJob[]> {
   const workspaceId = project.workspaceId.toString();
   if ((await boundRepoDirIfExists(workspaceId)) == null) return [];
+  // A job "applies" against the environments the FILE declares, not the
+  // last pushed row — otherwise a job added together with its environment
+  // in one commit reads as invalid until the webhook lands.
+  try {
+    await ensureEnvironmentsDerivedCache(project);
+  } catch (error) {
+    logger.warn("ensureEnvironmentsDerivedCache failed", {
+      workspaceId,
+      error,
+    });
+  }
   const defs = await listJobDefinitionsAtMain(workspaceId);
   const rows = await DbtJob.find({ projectId: project._id });
   const bySlug = new Map(rows.map(row => [row.slug, row]));
@@ -308,6 +320,33 @@ export async function loadLiveJobById(
   if (!Types.ObjectId.isValid(jobId)) return null;
   const live = await loadLiveJobs(project);
   return live.find(job => job.id.toString() === jobId) ?? null;
+}
+
+export type LiveJobRowResolution =
+  | { ok: true; live: LiveJob; row: IDbtJob }
+  | { ok: false; status: 404 | 409; error: string };
+
+/**
+ * Resolve a job id for a mutation or a run: the file must be live at main
+ * AND the scheduler row must exist. A file that only lives in git (the push
+ * has not been reconciled yet) is a 409 with the reason, not a bare 404 —
+ * the list just showed the job. A row whose file was deleted is not live
+ * and resolves to nothing, so it can no longer be triggered.
+ */
+export async function resolveLiveJobRow(
+  project: IDbtProject,
+  jobId: string,
+): Promise<LiveJobRowResolution> {
+  const live = await loadLiveJobById(project, jobId);
+  if (!live) return { ok: false, status: 404, error: "Job not found" };
+  if (!live.row) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Job "${live.def.slug}" exists only in git so far (${live.def.path}); it becomes runnable and editable once the push is synced.`,
+    };
+  }
+  return { ok: true, live, row: live.row };
 }
 
 function rowAsPlain(row: IDbtJob): Record<string, unknown> {
@@ -395,6 +434,84 @@ function environmentsToFile(project: IDbtProject) {
       ownerUserId: env.ownerUserId,
     })),
   };
+}
+
+function isEnvironmentsMarkedInvalid(project: IDbtProject): boolean {
+  return typeof project.environmentsInvalid?.reason === "string";
+}
+
+async function markEnvironmentsInvalid(
+  project: IDbtProject,
+  reason: string,
+): Promise<void> {
+  if (project.environmentsInvalid?.reason === reason) return;
+  const environmentsInvalid = { reason, at: new Date() };
+  await DbtProject.updateOne(
+    { _id: project._id },
+    { $set: { environmentsInvalid } },
+  );
+  project.environmentsInvalid = environmentsInvalid;
+}
+
+/** Project settings follow `dbt/environments.yml`; same mapping for read and push. */
+async function applyEnvironmentsFile(
+  project: IDbtProject,
+  parsed: DbtEnvironmentsFile,
+): Promise<void> {
+  project.environments = parsed.environments.map(env => ({
+    name: env.name,
+    connectionId: new Types.ObjectId(env.connectionId),
+    targetSchema: env.targetSchema,
+    threads: env.threads ?? 4,
+    vars: env.vars,
+    ownerUserId: env.ownerUserId,
+  })) as IDbtProject["environments"];
+  project.defaultEnvironment = parsed.defaultEnvironment;
+  project.prodEnvironment = parsed.prodEnvironment;
+  if (parsed.dbtVersion) project.dbtVersion = parsed.dbtVersion;
+  const clearInvalid = isEnvironmentsMarkedInvalid(project);
+  if (project.isModified()) await project.save();
+  if (clearInvalid) {
+    // Assigning undefined to a nested path persists `{}`; unset it.
+    await DbtProject.updateOne(
+      { _id: project._id },
+      { $unset: { environmentsInvalid: 1 } },
+    );
+    project.environmentsInvalid = undefined;
+  }
+}
+
+/**
+ * `dbt/environments.yml` at main is the read surface for a project's
+ * environments (apps.md §23), the way `dbt/jobs/*.yml` is for jobs. The
+ * project row is resynced in place when the file differs — a project GET
+ * after an external edit shows the file, not the last push. No file at main
+ * (workspace not adopted) leaves the row alone; an unbound workspace too.
+ */
+export async function ensureEnvironmentsDerivedCache(
+  project: IDbtProject,
+): Promise<void> {
+  const workspaceId = project.workspaceId.toString();
+  if (!(await getWorkspaceRepo(workspaceId))) return;
+  const repoDir = await boundRepoDirIfExists(workspaceId);
+  if (repoDir == null || !(await resolveCommit(repoDir, MAIN))) return;
+  let contents: string | null;
+  try {
+    const blob = await readBlob(repoDir, MAIN, DBT_ENVIRONMENTS_PATH);
+    contents = blob.isBinary ? null : blob.contents;
+  } catch {
+    return; // not adopted yet
+  }
+  const parsed = contents == null ? null : parseEnvironmentsFile(contents);
+  if (!parsed) {
+    await markEnvironmentsInvalid(project, "unparseable environments.yml");
+    return;
+  }
+  const level =
+    serializeEnvironmentsFile(environmentsToFile(project)) ===
+    serializeEnvironmentsFile(parsed);
+  if (level && !isEnvironmentsMarkedInvalid(project)) return;
+  await applyEnvironmentsFile(project, parsed);
 }
 
 /**
@@ -577,28 +694,9 @@ async function syncDbtConfigNow(
           "dbt environments.yml is invalid; not overwriting from Mongo",
           { workspaceId },
         );
-        project.environmentsInvalid = {
-          reason: "unparseable environments.yml",
-          at: new Date(),
-        };
-        if (project.isModified()) await project.save();
+        await markEnvironmentsInvalid(project, "unparseable environments.yml");
       } else {
-        project.environments = parsed.environments.map(env => ({
-          name: env.name,
-          connectionId: new Types.ObjectId(env.connectionId),
-          targetSchema: env.targetSchema,
-          threads: env.threads ?? 4,
-          vars: env.vars,
-          ownerUserId: env.ownerUserId,
-        })) as IDbtProject["environments"];
-        project.defaultEnvironment = parsed.defaultEnvironment;
-        project.prodEnvironment = parsed.prodEnvironment;
-        if (parsed.dbtVersion) project.dbtVersion = parsed.dbtVersion;
-        if (project.environmentsInvalid) {
-          project.environmentsInvalid = undefined;
-          project.markModified("environmentsInvalid");
-        }
-        if (project.isModified()) await project.save();
+        await applyEnvironmentsFile(project, parsed);
       }
     } catch (error) {
       logger.warn("dbt environments sync failed", { workspaceId, error });

--- a/api/src/inngest/functions/scheduled-query.ts
+++ b/api/src/inngest/functions/scheduled-query.ts
@@ -16,6 +16,7 @@ import { queryExecutionService } from "../../services/query-execution.service";
 import { loggers } from "../../logging";
 import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
 import { emitScheduledQueryTerminalEvent } from "../../services/flow-run-notification.emit";
+import { liveConsoleCode } from "../../apps/workspace-consoles.service";
 
 const logger = loggers.inngest();
 
@@ -132,6 +133,10 @@ export const scheduledQueryExecutorFunction = inngest.createFunction(
         const savedConsole = savedConsoleDoc.toObject({
           getters: true,
         }) as ISavedConsole;
+        // Git is the definition: run the file at main, not the row's last
+        // pushed copy.
+        const liveCode = await liveConsoleCode(workspaceId, consoleId);
+        if (liveCode) savedConsole.code = liveCode.code;
 
         const connectionMongooseDoc = savedConsole.connectionId
           ? await DatabaseConnection.findById(savedConsole.connectionId)

--- a/api/src/mcp/chatgpt-connector-tools.ts
+++ b/api/src/mcp/chatgpt-connector-tools.ts
@@ -352,6 +352,8 @@ async function fetchSkillDoc(
   const workspaceSkill = await Skill.findOne({
     workspaceId: new Types.ObjectId(workspaceId),
     name,
+    // A skill whose file at main is broken or gone is not servable.
+    "definitionInvalid.reason": { $exists: false },
   })
     .select("name loadWhen body")
     .lean();

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -52,6 +52,8 @@ import {
   savedConsoleStateFromRepo,
   consoleFileVersions,
   consoleHistory,
+  liveConsoleCode,
+  loadLiveConsoleById,
   projectSavedConsole,
   requestConsoleDescription,
   restoreConsoleTo,
@@ -1210,10 +1212,37 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         _id: new Types.ObjectId(pathOrId),
         workspaceId: new Types.ObjectId(workspaceId),
       });
+      // A console that exists only in git (no row yet) is addressed by its
+      // derived id. It still has an owner (its path scope) and a language
+      // (its extension): the ACL check must run against the file, and the
+      // save must replace THAT file — not write a fresh `.sql` beside a
+      // `.js`, which is what the row-less defaults did.
+      const liveOnly =
+        existingById === null
+          ? await loadLiveConsoleById(workspaceId, pathOrId)
+          : null;
+      const liveFile = liveOnly && "live" in liveOnly ? liveOnly.live : null;
+      const aclSubject: ISavedConsole | null =
+        existingById ??
+        (liveFile
+          ? ({
+              _id: liveFile.id,
+              workspaceId: new Types.ObjectId(workspaceId),
+              access:
+                liveFile.location.scope === "private" ? "private" : "workspace",
+              isPrivate: liveFile.location.scope === "private",
+              owner_id:
+                liveFile.location.ownerId || liveFile.row?.owner_id || "git",
+              createdBy:
+                liveFile.location.ownerId || liveFile.row?.createdBy || "git",
+              sharedWith: liveFile.row?.sharedWith,
+              workspaceRole: liveFile.row?.workspaceRole,
+            } as unknown as ISavedConsole)
+          : null);
       if (
-        existingById &&
+        aclSubject &&
         !ConsoleManager.canWrite(
-          existingById,
+          aclSubject,
           user.id,
           isAdminPut,
           memberPut?.role,
@@ -1375,7 +1404,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         const setOnInsertFields: Record<string, any> = {
           createdBy: user.id,
           owner_id: user.id,
-          language: "sql" as const,
+          language: liveFile?.location.language ?? ("sql" as const),
           executionCount: 0,
           createdAt: now,
         };
@@ -1389,6 +1418,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         const projected = await projectSavedConsole({
           workspaceId,
           current: existingById ?? null,
+          previousPath: liveFile?.path ?? null,
           set: setFields,
           onInsert: setOnInsertFields,
           actorUserId: user.id,
@@ -2248,6 +2278,14 @@ consoleRoutes.openapi(
       ) {
         return c.json({ success: false, error: "Console not found" }, 404);
       }
+
+      // Git is the definition: run the file at main, not the row's last
+      // pushed copy (a query edited in git ran stale until the webhook).
+      const liveCode = await liveConsoleCode(
+        access.workspaceId,
+        consoleIdParsed.toString(),
+      );
+      if (liveCode) savedConsole.code = liveCode.code;
 
       // If console has a connection ID, verify it exists and belongs to workspace
       if (savedConsole.connectionId) {

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -49,11 +49,13 @@ import {
   commitDbtEnvironmentsFile,
   commitDbtJobFile,
   deleteDbtJobFile,
+  ensureEnvironmentsDerivedCache,
   jobScheduleFailure,
   loadLiveJobById,
   loadLiveJobs,
   liveJobToPlain,
   reserveJobSlug,
+  resolveLiveJobRow,
 } from "../dbt/dbt-config.service";
 import {
   DBT_PREVIEW_DEFAULT_LIMIT,
@@ -313,11 +315,21 @@ dbtRoutes.get("/projects", async (c: AuthenticatedContext) => {
     if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
       return badRequest(c, "Valid workspace ID is required");
     }
-    const projects = await DbtProject.find({
+    const docs = await DbtProject.find({
       workspaceId: new Types.ObjectId(workspaceId),
-    })
-      .sort({ updatedAt: -1 })
-      .lean();
+    }).sort({ updatedAt: -1 });
+    // Environments follow dbt/environments.yml at main (apps.md §23).
+    for (const doc of docs) {
+      try {
+        await ensureEnvironmentsDerivedCache(doc);
+      } catch (error) {
+        logger.warn("ensureEnvironmentsDerivedCache failed", {
+          projectId: doc._id.toString(),
+          error,
+        });
+      }
+    }
+    const projects = docs.map(doc => doc.toObject());
     const userId = getUserId(c);
     const prefs = await DbtEnvPreference.find({
       projectId: { $in: projects.map(p => p._id) },
@@ -438,6 +450,8 @@ dbtRoutes.get("/projects/:projectId", async (c: AuthenticatedContext) => {
     if (!project) {
       return c.json({ success: false, error: "dbt project not found" }, 404);
     }
+    // Environments follow dbt/environments.yml at main (apps.md §23).
+    await ensureEnvironmentsDerivedCache(project);
     return c.json({ success: true, project });
   } catch (error) {
     return serverError(c, error, "Failed to fetch dbt project");
@@ -949,11 +963,14 @@ dbtRoutes.patch(
       if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
       }
-      const live = await loadLiveJobById(project, jobId);
-      const job = live?.row;
-      if (!live || !job) {
-        return c.json({ success: false, error: "Job not found" }, 404);
+      const resolved = await resolveLiveJobRow(project, jobId);
+      if (!resolved.ok) {
+        return c.json(
+          { success: false, error: resolved.error },
+          resolved.status,
+        );
       }
+      const job = resolved.row;
       const parsed = jobSchema.partial().safeParse(await c.req.json());
       if (!parsed.success) {
         return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid job");
@@ -1006,11 +1023,14 @@ dbtRoutes.delete(
       if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
       }
-      const live = await loadLiveJobById(project, jobId);
-      const doomed = live?.row;
-      if (!live || !doomed) {
-        return c.json({ success: false, error: "Job not found" }, 404);
+      const resolved = await resolveLiveJobRow(project, jobId);
+      if (!resolved.ok) {
+        return c.json(
+          { success: false, error: resolved.error },
+          resolved.status,
+        );
       }
+      const doomed = resolved.row;
       await deleteDbtJobFile(project, doomed.slug, getUserId(c));
       await DbtJob.deleteOne({ _id: doomed._id });
       publishDbtEvent(c, {
@@ -1036,13 +1056,14 @@ dbtRoutes.post(
       if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
       }
-      const job = await DbtJob.findOne({
-        _id: new Types.ObjectId(jobId),
-        projectId: project._id,
-      });
-      if (!job) {
-        return c.json({ success: false, error: "Job not found" }, 404);
+      const resolved = await resolveLiveJobRow(project, jobId);
+      if (!resolved.ok) {
+        return c.json(
+          { success: false, error: resolved.error },
+          resolved.status,
+        );
       }
+      const job = resolved.row;
       const run = await triggerDbtJobRun({
         workspaceId: project.workspaceId.toString(),
         job,

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -35,9 +35,11 @@ import { teardownFlow } from "../sync-cdc/flow-reconcile";
 import { RepoRequiredError, appsRequireConnectedRepo } from "../apps/config";
 import { requireWorkspaceRepo } from "../apps/workspace-repo-required";
 import {
+  listFlowDefinitionsAtMain,
   loadLiveFlowById,
   loadLiveFlows,
   liveFlowToPlain,
+  resolveLiveFlowRow,
 } from "../services/flow-sync.service";
 import { resolveMirrorTarget } from "../apps/cloud-repo.service";
 import { cdcBackfillService } from "../sync-cdc/backfill";
@@ -96,7 +98,13 @@ async function commitFlowFileOrFail(
   const result = await commitFlowFile(flow, actorUserId);
   if (result.ok) {
     if (result.sourceBlobSha) flow.sourceBlobSha = result.sourceBlobSha;
-    flow.definitionInvalid = undefined;
+    // Assigning undefined to a nested path and saving persists `{}`, which
+    // the overlay used to read as "invalid". Unset the marker instead; a
+    // not-yet-saved flow has no row to unset, which is fine.
+    await Flow.updateOne(
+      { _id: flow._id },
+      { $unset: { definitionInvalid: 1 } },
+    );
     return null;
   }
   logger.error("Flow definition did not reach the workspace repo", {
@@ -1160,7 +1168,14 @@ flowRoutes.openapi(
           ? body.name.trim().slice(0, 200)
           : await deriveFlowDisplayName(flowData as unknown as IFlow);
       flowData.name = requestedName;
-      flowData.slug = await reserveFlowSlug(workspaceId, requestedName);
+      // Files at main without a row yet are part of the identity space too.
+      flowData.slug = await reserveFlowSlug(
+        workspaceId,
+        requestedName,
+        new Set(
+          (await listFlowDefinitionsAtMain(workspaceId)).map(def => def.slug),
+        ),
+      );
 
       const flow = new Flow(flowData);
 
@@ -1857,10 +1872,16 @@ flowRoutes.openapi(
       const workspaceId = c.req.param("workspaceId");
       const flowId = c.req.param("flowId");
 
-      const flow = await Flow.findOne({
-        _id: new Types.ObjectId(flowId),
-        workspaceId: new Types.ObjectId(workspaceId),
-      })
+      // Resolve through the git overlay: a flow whose file was deleted on
+      // main is not runnable, and one that exists only in git says so.
+      const resolved = await resolveLiveFlowRow(String(workspaceId), flowId);
+      if (!resolved.ok) {
+        return c.json(
+          { success: false, error: resolved.error },
+          resolved.status,
+        );
+      }
+      const flow = await Flow.findById(resolved.row._id)
         .populate("dataSourceId")
         .populate("destinationDatabaseId");
 

--- a/api/src/services/flow-identity.service.ts
+++ b/api/src/services/flow-identity.service.ts
@@ -110,6 +110,12 @@ export function slugifyFlowName(name: string): string {
 export async function reserveFlowSlug(
   workspaceId: Types.ObjectId | string,
   name: string,
+  /**
+   * Slugs already taken by files at main that have no row yet. Mongo rows
+   * alone are not the identity space: a name that slugifies onto a git-only
+   * `flows/<slug>.yml` would otherwise overwrite that file under a second id.
+   */
+  takenAtMain: ReadonlySet<string> = new Set(),
 ): Promise<string> {
   const wsId =
     typeof workspaceId === "string"
@@ -118,6 +124,7 @@ export async function reserveFlowSlug(
   return reserveSlug(
     slugifyFlowName(name),
     async candidate =>
+      takenAtMain.has(candidate) ||
       Boolean(await Flow.exists({ workspaceId: wsId, slug: candidate })),
     { label: `flow "${name}"` },
   );

--- a/api/src/services/flow-sync.repo.test.ts
+++ b/api/src/services/flow-sync.repo.test.ts
@@ -51,9 +51,12 @@ import {
 } from "../apps/bind-test-workspace-repo";
 import {
   derivedFlowId,
+  ensureFlowDerivedCache,
+  isFlowMarkedInvalid,
   liveFlowToPlain,
   loadLiveFlowById,
   loadLiveFlows,
+  resolveLiveFlowRow,
   syncFlowsFromRepo,
 } from "./flow-sync.service";
 
@@ -124,6 +127,86 @@ beforeEach(async () => {
   await Flow.deleteMany({});
   await initRepo(repoDirFor(WS), { "README.md": "x\n" });
   await bindTestWorkspaceRepo(WS);
+});
+
+describe("markers, reverts, and resolution", () => {
+  it("an unset marker is not 'invalid': an unbound workspace's run is not refused", async () => {
+    await push({ "flows/marker.yml": flowYaml("Marker") });
+    await syncFlowsFromRepo(WS, "user-42");
+    const row = await Flow.findOne({ workspaceId: WS, slug: "marker" });
+    expect(row).not.toBeNull();
+    // Mongoose materialises the unset nested path as `{}` on a hydrated
+    // doc; `if (row.definitionInvalid)` used to read that as invalid.
+    expect(isFlowMarkedInvalid(row!)).toBe(false);
+    const plain = liveFlowToPlain(
+      (await loadLiveFlows(WS)).find(item => item.def.slug === "marker")!,
+      WS,
+    );
+    expect(plain.definitionInvalid).toBeUndefined();
+    await unbindTestWorkspaceRepo(WS);
+    expect(await ensureFlowDerivedCache(row!)).toBe("ok");
+  });
+
+  it("a broken file is marked once; reverting to identical content clears it in push-sync", async () => {
+    const good = flowYaml("Revertable");
+    await push({ "flows/revertable.yml": good });
+    await syncFlowsFromRepo(WS, "user-42");
+    await push({ "flows/revertable.yml": "name: [broken" });
+    await loadLiveFlows(WS);
+    const marked = await Flow.findOne({ workspaceId: WS, slug: "revertable" });
+    expect(marked?.definitionInvalid?.reason).toBe("unparseable flow file");
+    const at = marked?.definitionInvalid?.at;
+    await loadLiveFlows(WS);
+    expect(
+      (await Flow.findOne({ workspaceId: WS, slug: "revertable" }))
+        ?.definitionInvalid?.at,
+    ).toEqual(at);
+    await push({ "flows/revertable.yml": good });
+    const result = await syncFlowsFromRepo(WS, "user-42");
+    expect(result.invalid).toEqual([]);
+    expect(
+      (await Flow.findOne({ workspaceId: WS, slug: "revertable" }))
+        ?.definitionInvalid?.reason,
+    ).toBeUndefined();
+  });
+
+  it("resolves a git-only flow as 409, a synced one as ok, a deleted file as 404; the stub is whole", async () => {
+    await push({ "flows/only-git.yml": flowYaml("Only git") });
+    const live = await loadLiveFlows(WS);
+    const id = live.find(item => item.def.slug === "only-git")!.id.toString();
+    const gitOnly = await resolveLiveFlowRow(WS, id);
+    expect(gitOnly.ok).toBe(false);
+    if (!gitOnly.ok) expect(gitOnly.status).toBe(409);
+
+    await syncFlowsFromRepo(WS, "user-42");
+    const synced = await resolveLiveFlowRow(WS, id);
+    expect(synced.ok).toBe(true);
+
+    await commitBlobsOnBranch(
+      repoDirFor(WS),
+      DEFAULT_BRANCH,
+      { deletes: ["flows/only-git.yml"] },
+      { message: "laptop delete" },
+    );
+    const gone = await resolveLiveFlowRow(WS, id);
+    expect(gone.ok).toBe(false);
+    if (!gone.ok) expect(gone.status).toBe(404);
+
+    await push({ "flows/broken-stub.yml": "name: [broken" });
+    const stub = liveFlowToPlain(
+      (await loadLiveFlows(WS)).find(item => item.def.slug === "broken-stub")!,
+      WS,
+    );
+    expect(stub).toMatchObject({
+      name: "broken-stub",
+      syncMode: "full",
+      enabled: false,
+    });
+    expect(stub.createdAt).toBeInstanceOf(Date);
+    expect(
+      (stub.definitionInvalid as { reason?: string } | undefined)?.reason,
+    ).toBe("unparseable flow file");
+  });
 });
 
 describe("a NEW flow file creates a row", () => {

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -109,15 +109,64 @@ export function mintedWebhookEndpoint(args: {
   return generateWebhookEndpoint(args.workspaceId, args.flowId);
 }
 
+/**
+ * Mongoose materialises an unset nested path as `{}` on a hydrated doc, so
+ * the marker's presence is its `reason`, never the object's truthiness —
+ * `if (row.definitionInvalid)` read every healthy flow as invalid, which is
+ * how a bound workspace's runs came to re-parse their file on every fire and
+ * an unbound one's runs were refused outright.
+ */
+export function isFlowMarkedInvalid(row: {
+  definitionInvalid?: { reason?: string } | null;
+}): boolean {
+  return typeof row.definitionInvalid?.reason === "string";
+}
+
+/** The row's marker when it is a real one (see isFlowMarkedInvalid). */
+function rowInvalidMarker(
+  row: IFlow | null,
+): IFlow["definitionInvalid"] | undefined {
+  return row && isFlowMarkedInvalid(row) ? row.definitionInvalid : undefined;
+}
+
+/** Assigning `undefined` to a nested path persists `{}`; unset it instead. */
+async function clearFlowInvalid(id: Types.ObjectId): Promise<void> {
+  await Flow.updateOne({ _id: id }, { $unset: { definitionInvalid: 1 } });
+}
+
+/**
+ * Stamp the marker (and pause the schedules) with a targeted update, never
+ * a `save()`: a legacy row that no longer passes the schema would throw out
+ * of the push-sync loop and skip every file after it. Idempotent, so a list
+ * call does not rewrite the marker on every read.
+ */
 async function markFlowInvalid(
   doc: IFlow,
   reason: string,
   path: string,
 ): Promise<void> {
-  doc.definitionInvalid = { reason, at: new Date(), path };
-  if (doc.schedule) doc.schedule.enabled = false;
-  if (doc.backfillSchedule) doc.backfillSchedule.enabled = false;
-  await doc.save();
+  if (
+    doc.definitionInvalid?.reason === reason &&
+    doc.definitionInvalid?.path === path
+  ) {
+    return;
+  }
+  const definitionInvalid = { reason, at: new Date(), path };
+  const set: Record<string, unknown> = { definitionInvalid };
+  if (doc.schedule) set["schedule.enabled"] = false;
+  if (doc.backfillSchedule) set["backfillSchedule.enabled"] = false;
+  try {
+    await Flow.updateOne({ _id: doc._id }, { $set: set });
+    doc.definitionInvalid = definitionInvalid;
+    if (doc.schedule) doc.schedule.enabled = false;
+    if (doc.backfillSchedule) doc.backfillSchedule.enabled = false;
+  } catch (error) {
+    logger.warn("Failed to mark flow invalid", {
+      flowId: doc._id.toString(),
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /**
@@ -191,7 +240,7 @@ function flowIndexDrift(defs: FlowDefinitionAtMain[], rows: IFlow[]): boolean {
     const row = bySlug.get(def.slug);
     if (!row) continue;
     if (row.sourceBlobSha !== def.oid) return true;
-    if (row.definitionInvalid && def.parsed) return true;
+    if (isFlowMarkedInvalid(row) && def.parsed) return true;
   }
   return false;
 }
@@ -273,7 +322,7 @@ export async function loadLiveFlowById(
     const defs = await listFlowDefinitionsAtMain(workspaceId);
     const def = defs.find(item => item.slug === row.slug);
     if (!def) return null;
-    if (row.sourceBlobSha !== def.oid || row.definitionInvalid) {
+    if (row.sourceBlobSha !== def.oid || isFlowMarkedInvalid(row)) {
       await ensureFlowDerivedCache(row);
     }
     return { def, row, id: row._id };
@@ -301,6 +350,14 @@ export function liveFlowToPlain(
         createdBy: "git",
         runCount: 0,
         sourceType: "connector",
+        // Whole shape for a file with no row yet: the client's schema
+        // requires these, and one half-defined item used to fail the whole
+        // persisted flow list's validation (every reload cold-started).
+        name: live.def.slug,
+        syncMode: "full",
+        enabled: false,
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
       };
   base._id = live.id;
   base.slug = live.def.slug;
@@ -311,7 +368,7 @@ export function liveFlowToPlain(
       ? live.row.createdBy
       : "git";
   if (!parsed) {
-    base.definitionInvalid = live.row?.definitionInvalid ?? {
+    base.definitionInvalid = rowInvalidMarker(live.row) ?? {
       reason: "unparseable flow file",
       at: new Date(),
       path: live.def.path,
@@ -325,7 +382,7 @@ export function liveFlowToPlain(
     createdBy,
   });
   if (applyFailure) {
-    base.definitionInvalid = live.row?.definitionInvalid ?? {
+    base.definitionInvalid = rowInvalidMarker(live.row) ?? {
       reason: applyFailure,
       at: new Date(),
       path: live.def.path,
@@ -356,10 +413,10 @@ export async function ensureFlowDerivedCache(flow: {
   const workspaceId = flow.workspaceId.toString();
   const repoDir = await boundRepoDirIfExists(workspaceId);
   if (repoDir == null) {
-    return flow.definitionInvalid ? "invalid" : "ok";
+    return isFlowMarkedInvalid(flow) ? "invalid" : "ok";
   }
   const head = await resolveCommit(repoDir, `refs/heads/${DEFAULT_BRANCH}`);
-  if (!head) return flow.definitionInvalid ? "invalid" : "ok";
+  if (!head) return isFlowMarkedInvalid(flow) ? "invalid" : "ok";
   const path = `flows/${flow.slug}.yml`;
   let contents: string;
   try {
@@ -376,7 +433,8 @@ export async function ensureFlowDerivedCache(flow: {
     return "missing";
   }
   const sha = blobOid(contents);
-  if (flow.sourceBlobSha === sha && !flow.definitionInvalid) return "ok";
+  const wasMarked = isFlowMarkedInvalid(flow);
+  if (flow.sourceBlobSha === sha && !wasMarked) return "ok";
   const parsed = parseFlowFile(contents);
   const row = await Flow.findById(flow._id);
   if (!row) return "missing";
@@ -394,7 +452,6 @@ export async function ensureFlowDerivedCache(flow: {
     await markFlowInvalid(row, refusal, path);
     return "invalid";
   }
-  row.definitionInvalid = undefined;
   row.sourceBlobSha = sha;
   try {
     await row.save();
@@ -407,7 +464,35 @@ export async function ensureFlowDerivedCache(flow: {
     if (fresh) await markFlowInvalid(fresh, reason, path);
     return "invalid";
   }
+  if (wasMarked) await clearFlowInvalid(row._id);
   return "resynced";
+}
+
+export type LiveFlowRowResolution =
+  | { ok: true; live: LiveFlow; row: IFlow }
+  | { ok: false; status: 404 | 409; error: string };
+
+/**
+ * Resolve a flow id for a mutation or a run: the file must be live at main
+ * AND the index row must exist. A file that only lives in git (the push has
+ * not been reconciled yet) is a 409 with the reason, not a bare 404 — the
+ * list just showed the flow. A row whose file was deleted is not live and
+ * resolves to nothing, so it can no longer be run from the UI.
+ */
+export async function resolveLiveFlowRow(
+  workspaceId: string,
+  flowId: string,
+): Promise<LiveFlowRowResolution> {
+  const live = await loadLiveFlowById(workspaceId, flowId);
+  if (!live) return { ok: false, status: 404, error: "Flow not found" };
+  if (!live.row) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Flow "${live.def.slug}" exists only in git so far (${live.def.path}); it becomes runnable and editable once the push is synced.`,
+    };
+  }
+  return { ok: true, live, row: live.row };
 }
 
 export interface FlowSyncResult {
@@ -741,7 +826,10 @@ export async function syncFlowsFromRepo(
       });
     }
 
-    if (row && row.sourceBlobSha === sha) {
+    // Level already — unless the row is still flagged from an earlier bad
+    // version and the file was reverted to this exact content, in which
+    // case the marker must clear.
+    if (row && row.sourceBlobSha === sha && !isFlowMarkedInvalid(row)) {
       result.unchanged++;
       continue;
     }
@@ -759,7 +847,27 @@ export async function syncFlowsFromRepo(
       continue;
     }
 
+    // Same "applies" predicate GET/list uses: a file the list flags must
+    // never be indexed here, and one the list shows as valid must not be
+    // what throws below.
+    const applyFailure = flowFileApplyFailure(parsed, {
+      workspaceId,
+      slug,
+      createdBy: row?.createdBy || actorUserId || "sync",
+    });
+    if (applyFailure) {
+      logger.warn("Flow file does not apply; not overwriting from Mongo", {
+        workspaceId,
+        path,
+        reason: applyFailure,
+      });
+      if (row) await markFlowInvalid(row, applyFailure, path);
+      result.invalid.push(slug);
+      continue;
+    }
+
     const isNew = !row;
+    const wasInvalid = row ? isFlowMarkedInvalid(row) : false;
     const doc =
       row ??
       new Flow({
@@ -808,7 +916,6 @@ export async function syncFlowsFromRepo(
       } as IFlow["webhookConfig"];
     }
     (doc as IFlow).sourceBlobSha = sha;
-    (doc as IFlow).definitionInvalid = undefined;
     // One file's failure is that file's problem. `save()` can still throw for
     // a file that parsed and applied — a value outside a schema enum, an id
     // that is not an ObjectId — and letting that escape would skip every file
@@ -827,6 +934,7 @@ export async function syncFlowsFromRepo(
       result.invalid.push(slug);
       continue;
     }
+    if (wasInvalid) await clearFlowInvalid((doc as IFlow)._id);
     if (isNew) {
       result.created++;
       // A row created in this pass has no id until now, so its desired entry

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -40,6 +40,14 @@ import {
 
 const logger = loggers.app();
 
+/**
+ * Agent-facing reads (index injection, search, load) must not serve a skill
+ * whose file at main is broken or gone: the row is kept as last-good for the
+ * admin surface only. The marker's presence is its `reason` — Mongoose
+ * materialises an unset nested path as `{}`, so never test the object.
+ */
+const NOT_INVALID = { "definitionInvalid.reason": { $exists: false } } as const;
+
 const MAX_NAME_LENGTH = 80;
 const MAX_LOAD_WHEN_LENGTH = 500;
 const MAX_BODY_LENGTH = 20000;
@@ -335,8 +343,12 @@ export async function saveSkill(
       body,
     }),
   );
-  existing.definitionInvalid = undefined;
   await existing.save();
+  // Assigning undefined to a nested path persists `{}`; unset the marker.
+  await Skill.updateOne(
+    { _id: existing._id },
+    { $unset: { definitionInvalid: 1 } },
+  );
 
   return {
     success: true,
@@ -413,6 +425,7 @@ export async function loadSkill(
     {
       workspaceId: new Types.ObjectId(workspaceId),
       name: name.trim(),
+      ...NOT_INVALID,
     },
     { $inc: { useCount: 1 }, $set: { lastUsedAt: new Date() } },
     { new: true },
@@ -515,6 +528,7 @@ async function textSearchSkills(
         $text: { $search: query },
         workspaceId: new Types.ObjectId(workspaceId),
         suppressed: { $ne: true },
+        ...NOT_INVALID,
       },
       { score: { $meta: "textScore" } },
     )
@@ -545,6 +559,7 @@ export async function searchSkills(
   const all = await Skill.find({
     workspaceId: new Types.ObjectId(workspaceId),
     suppressed: { $ne: true },
+    ...NOT_INVALID,
   })
     .select("+loadWhenEmbedding")
     .lean();
@@ -629,6 +644,7 @@ export async function retrieveRelevantSkills(
   const indexDocs = await Skill.find({
     workspaceId: wsObjectId,
     suppressed: { $ne: true },
+    ...NOT_INVALID,
   })
     .select("name loadWhen suppressed useCount entities")
     // NOT sorted by useCount: the counter measures auto-injection exposure,

--- a/app/src/components/FlowEditor.tsx
+++ b/app/src/components/FlowEditor.tsx
@@ -64,6 +64,10 @@ export function FlowEditor({
   const flowsError = useFlowStore(s =>
     currentWorkspace ? s.error[currentWorkspace.id] : null,
   );
+  // runFlow records its failure in the store and swallows it; nothing in
+  // this view rendered that field once the flow resolved, so "Run Now" on a
+  // flow the API rejects looked like nothing happened.
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const flows = currentWorkspace ? flowsMap[currentWorkspace.id] || [] : [];
   const currentFlow = currentFlowId
@@ -131,7 +135,14 @@ export function FlowEditor({
 
   const handleRunNow = async () => {
     if (currentWorkspace?.id && currentFlowId) {
-      await runFlow(currentWorkspace.id, currentFlowId);
+      setActionError(null);
+      const workspaceId = currentWorkspace.id;
+      useFlowStore.setState(state => {
+        state.error[workspaceId] = null;
+      });
+      await runFlow(workspaceId, currentFlowId);
+      const failure = useFlowStore.getState().error[workspaceId];
+      if (failure) setActionError(failure);
     }
   };
 
@@ -154,19 +165,51 @@ export function FlowEditor({
   const renderInfoView = () => {
     if (!currentFlowId) return null;
 
+    const invalid = currentFlow?.definitionInvalid;
+    const notices = (
+      <>
+        {invalid && (
+          <Alert severity="warning" sx={{ m: 2, mb: 0 }}>
+            The flow file in git is invalid ({invalid.reason}).
+            {invalid.path ? (
+              <>
+                {" "}
+                Fix <code>{invalid.path}</code> on main;
+              </>
+            ) : null}{" "}
+            until then this shows the last valid version and its schedules are
+            paused.
+          </Alert>
+        )}
+        {actionError && (
+          <Alert
+            severity="error"
+            onClose={() => setActionError(null)}
+            sx={{ m: 2, mb: 0 }}
+          >
+            {actionError}
+          </Alert>
+        )}
+      </>
+    );
+
     if (!isCdcFlow) {
       return (
-        <FlowLogs
-          flowId={currentFlowId}
-          onRunNow={handleRunNow}
-          onEdit={handleEditClick}
-        />
+        <>
+          {notices}
+          <FlowLogs
+            flowId={currentFlowId}
+            onRunNow={handleRunNow}
+            onEdit={handleEditClick}
+          />
+        </>
       );
     }
     if (!currentWorkspace) return null;
     const showRunsTab = hasScheduleTrigger;
     return (
       <>
+        {notices}
         {backfillNotice && (
           <Alert
             severity="success"

--- a/app/src/components/SkillsSection.tsx
+++ b/app/src/components/SkillsSection.tsx
@@ -128,14 +128,21 @@ export function SkillsSection() {
           body: JSON.stringify({ suppressed: nextSuppressed }),
         },
       );
-      if (!res.ok) throw new Error("Request failed");
-    } catch {
-      // Rollback on error
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(data?.error || `Request failed (${res.status})`);
+      }
+    } catch (err) {
+      // Rollback on error — and say why, or a 412 "connect GitHub first"
+      // looks like a switch that will not stay put.
       setSkills(prev =>
         prev.map(s =>
           s.id === skill.id ? { ...s, suppressed: skill.suppressed } : s,
         ),
       );
+      setError(err instanceof Error ? err.message : "Failed to update skill");
     }
   };
 
@@ -156,7 +163,12 @@ export function SkillsSection() {
         `/api/workspaces/${workspaceId}/skills/${skill.id}`,
         { method: "DELETE" },
       );
-      if (!res.ok) throw new Error("Request failed");
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(data?.error || `Request failed (${res.status})`);
+      }
       setSkills(prev => prev.filter(s => s.id !== skill.id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete skill");

--- a/app/src/store/flowStore.ts
+++ b/app/src/store/flowStore.ts
@@ -117,6 +117,18 @@ const flowSchema = z.object({
   createdBy: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  /**
+   * Set when `flows/<slug>.yml` at main does not parse or apply. The rest
+   * of the item is the last valid version (or a stub for a git-only file).
+   */
+  definitionInvalid: z
+    .object({
+      reason: z.string(),
+      at: z.string().optional(),
+      path: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
   // Database-to-database sync fields
   sourceType: z.enum(["connector", "database"]).optional(),
   databaseSource: z

--- a/apps.md
+++ b/apps.md
@@ -3021,3 +3021,73 @@ on.
   pins because they only fail on old code for the trivial reason that the
   route did not exist yet. #912 now enforces the first half of this
   mechanically.
+
+## 26. The overlay audit: four kinds, six bug classes (2026-09-03)
+
+PR #975 put dbt jobs on the GET/list overlay and, browser-tested against
+hostile files on main, found six ways the shape breaks. The other three
+kinds (flows, skills, consoles) were then audited for the same six, and
+every one of them had most of the list. What was fixed, per class:
+
+1. **Read-path resync stamps the sha, push-sync then skips the side effect.**
+   dbt: `ensureJobDerivedCache` now calls `applyJobScheduleChange` when the
+   file changed schedule/enabled. Flows and skills stamp too, but their
+   push-sync side effects (CDC reconcile, endpoint mint on create,
+   re-embed) either run from the row's current definition regardless of the
+   skip or apply to new rows only, so no change there. Consoles have no
+   read-path resync since the storm fix (#971); their file-derived folder
+   placement and schedule wait for the push — documented, not changed.
+2. **"Valid" must mean the same thing in the list and in push-sync, and one
+   bad file must never abort the loop.** dbt: `jobApplyFailure` now also
+   parses the cron and computes its next date (a `99 99 99 99 99` cron and a
+   `Nope/Zone` timezone used to throw inside the loop after creating the
+   row). Flows: `flowFileApplyFailure` runs in the sync loop too, and
+   `markFlowInvalid` is a targeted `updateOne` instead of a `save()` that a
+   legacy row could fail. Skills: the loop is guarded per file; a file that
+   stops parsing keeps its row (marked) instead of being deleted as
+   "removed", and files past the index cap are no longer deleted either.
+   Consoles: the loop is guarded per file so the deletion pass and realtime
+   events always run.
+3. **Git-only ids.** dbt push-sync now creates rows with `derivedJobId`, as
+   flows/skills/consoles already did. Flow slug reservation consults the
+   files at main, so a name that slugifies onto a git-only file no longer
+   overwrites it under a second id.
+4. **Invalid git-only stubs must be whole.** dbt: name/commands/enabled
+   filled, unrunnable. Flows: `name`/`syncMode`/`createdAt`/`updatedAt`
+   filled — one half-defined item used to fail the client's persisted-list
+   validation and cold-start every reload. Skills: null dates added.
+5. **Mongoose materialises an unset nested path as `{}`.** Every
+   `if (row.definitionInvalid)` in flows, skills and dbt read healthy rows as
+   invalid: every list resynced every row, every flow run re-parsed its file,
+   and an unbound workspace's flow runs were refused outright. Presence is
+   now `typeof definitionInvalid?.reason === "string"` everywhere, clearing
+   is `$unset` (assigning `undefined` and saving persists `{}`), and a file
+   reverted to identical content clears its marker in push-sync.
+6. **Silent UI failures.** dbt job view and flow editor render the run/save
+   failure and an invalid-file warning; the skills settings surface the
+   server's reason on toggle/delete.
+
+Execution follows the file, not the row: the console execute route, the
+scheduled-query executor and the agent's console loader run the code at
+main when the console is live there (`liveConsoleCode`), and job/flow
+runs resolve through the overlay — a file that only lives in git is a 409
+with the reason, a row whose file was deleted is not runnable. Saving a
+git-only console by its derived id now ACL-checks against the file's path
+scope, keeps its language, and replaces the file instead of writing a
+`.sql` beside a `.js`. dbt environments follow `dbt/environments.yml` on
+project GET/list, the way jobs follow `dbt/jobs/*.yml`.
+
+**Decided, not changed — schedulers on unbound workspaces.** When a
+workspace has no GitHub binding (or a file is deleted and the push has not
+been reconciled), the list is empty but Inngest keeps running the Mongo
+rows: dbt's due-job poll, the flow scheduler, the CDC consumer, and
+scheduled consoles all select rows without consulting the binding. Gating
+them on the overlay would be a behaviour change for every workspace that
+never connected a repo, and the audit found only one such flow row in
+production. Left as is; the fix for a deleted definition is the push-sync
+that removes the row, which the loop guards above now make reliable.
+
+**Not in this block (D, E, F of the hand-off prompt):** the three
+documented notebook v1 gaps (§24), the skills triage branch on the
+workspace repo, and connectors-as-code. Each is content or a decision, not
+an overlay bug.


### PR DESCRIPTION
### Motivation

PR #975 put dbt jobs on the git GET/list overlay and, browser-tested against hostile files on main, found six ways the shape breaks. The other three overlays (flows, skills, consoles) were built on the same pattern, so this PR audits them for the same six classes and fixes what was found, plus the dbt remainder. Full account in `apps.md` §26.

### What changed

**Mongoose `{}` nested-path trap (flows, skills, dbt).** A hydrated doc reads an unset `definitionInvalid` as a truthy `{}`. Every `if (row.definitionInvalid)` therefore read healthy rows as invalid: every list call resynced every row, every flow run re-parsed its file, and an unbound workspace's flow runs were refused by Inngest. Presence is now `typeof definitionInvalid?.reason === "string"` everywhere, clearing is `$unset` (assigning `undefined` then saving persists `{}`), markers are idempotent, and a file reverted to identical content clears its marker in push-sync.

**One bad file must never abort push-sync.** Flows: `markFlowInvalid` is a targeted `updateOne` (a legacy row that no longer passes the schema used to throw out of the loop), and the sync applies the same `flowFileApplyFailure` the list uses. Skills: the loop is guarded per file; a file that stops parsing keeps its row (marked) instead of being deleted as "removed", and files past the index cap are no longer deleted. Consoles: the loop is guarded per file so the deletion pass and realtime events always run.

**Execution follows the file.** Console execute route, scheduled-query executor and the agent's console loader run the code at main when the console is live there (`liveConsoleCode`). dbt trigger/PATCH/DELETE and the three agent job tools, and the flow run route, resolve through the overlay: a file that only lives in git is a 409 with the reason, a row whose file was deleted is not runnable.

**dbt remainder.** Project GET/list overlay `dbt/environments.yml` (`ensureEnvironmentsDerivedCache`), and jobs validate against the file's environments.

**Ids and stubs.** Flow slug reservation consults files at main so a name can't overwrite a git-only file under a second id. Invalid git-only stubs are whole (flows: `name`/`syncMode`/`createdAt`; one half-defined item used to fail the client's persisted flow-list validation and cold-start every reload). Saving a git-only console by its derived id now ACL-checks against the path scope, keeps its language, and replaces the file instead of writing a `.sql` beside a `.js`.

**Skills agent reads.** Index injection, search, load and the ChatGPT fetch exclude rows whose file is broken or gone. A `loadWhen` edit whose embedding failed is left unstamped so the next read retries instead of ranking on the old vector forever.

**UI.** Flow editor shows the invalid-file warning and run failures; skills settings show the server's reason on toggle/delete.

**Decided, not changed.** Schedulers on unbound workspaces keep running Mongo rows; reasoning in §26. Blocks D/E/F of the hand-off (notebook v1 gaps, skills triage branch, connectors-as-code) are content or decisions, not overlay bugs, and are out of scope here.

### Testing

- New Vitest cases in all four service suites: markers vs `{}`, identical reverts, loop guards with a hostile batch, derived ids, 409/404 resolution, environments overlay, stub shape. Suites: dbt 18/18, skills + consoles + flows 64/64.
- API and app typecheck, lint (0 errors), Prettier, OpenAPI drift check, the tsx contract tests (`*-git-list`, `*-repo-required`, `no-silent-repo-skip`, `repo-backed-resources`, `flow-sync`, `flow-identity`, write-through honesty, test-coverage guard), app store tests.
- Browser pass on an isolated stack (scratch mirror, pushes denied) with a broken flow file and a broken skill file committed to main: the flows explorer lists the broken flow by slug, the editor shows the invalid warning, and Run now surfaces the 409 reason; the skills list loads with 95 skills.
- Flows census against production: 23 rows, 23 files, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUW2yMykUQDPxLzciseCV2
