### PR TITLE
docs(transforms): fix stale dbt storage model (workspace DB → git) and RBAC GitHub refs

### DIFF
--- a/docs/src/content/docs/transforms.md
+++ b/docs/src/content/docs/transforms.md
@@ -3,7 +3,7 @@ title: Transforms (dbt)
 description: Build, run, and schedule dbt Core projects inside Mako — a dbt Cloud replica with a file IDE, jobs, run history, lineage, and an AI Transform Agent.
 ---
 
-The **Transforms** section runs [dbt Core](https://docs.getdbt.com) projects directly inside your Mako workspace — a self-hosted dbt Cloud replica. Project files live in the workspace database (one document per file) and execute as `dbt` subprocesses against your existing [database connections](/databases/connect-databases/).
+The **Transforms** section runs [dbt Core](https://docs.getdbt.com) projects directly inside your Mako workspace — a self-hosted dbt Cloud replica. Project files live in the workspace's git repo (a `dbt/` folder, same repo as consoles, notebooks, and apps) and execute as `dbt` subprocesses against your existing [database connections](/databases/connect-databases/). Job definitions (`dbt/jobs/*.yml`) and environments (`dbt/environments.yml`) are authoritative in git; Mongo holds only a derived, SHA-checked index for fast reads.
 
 You get a file IDE, saved jobs with cron schedules, run history with artifacts, a DAG lineage view, and the AI agent's [Transforms mode](/ai-agent/#expertise-modes) that writes and verifies models for you.
 
@@ -44,16 +44,7 @@ snapshots/             # SCD2 snapshots
 tests/                 # singular SQL tests
 ```
 
-Files are unique per path (`{projectId, path}`), deletes are soft (`is_deleted`) so history is preserved, and every write is also captured in the shared [version history](/version-history/).
-
-## GitHub integration
-
-Projects can be **imported from GitHub** and kept in sync via Mako's multi-tenant GitHub App.
-
-- **Install flow** is HMAC-state protected — the signed `state` pins the initiating workspace + user, and binding an installation requires that same user with **admin** access (prevents install IDOR/CSRF).
-- **Browse & import** — list repos, check a repo's dbt layout, and import a project.
-- **Continuous branch sync** — pushes to the tracked branch flow back into the in-app project.
-- **Slim CI on PRs** (opt-in per project, off by default) — `state:modified+` builds with prod-manifest `defer`, posting commit statuses back to the PR.
+Reads come from the workspace repo at your session branch (git `listTree`/`readBlob`); writes are commits on that branch, and every write is also captured in the shared [version history](/version-history/). There's one dbt project per workspace, scaffolded into `dbt/` on first use — or imported by pointing at an existing `dbt/dbt_project.yml` in the repo.
 
 ## Studio-style editor
 
@@ -100,9 +91,9 @@ Every execution produces a **run** record with per-node status, timing, and logs
 
 Transforms access is enforced by a pure policy (`api/src/dbt/rbac.ts`):
 
-- **Reads (GET)** — open to any member, including viewers (GitHub repo discovery is member+).
-- **File/run mutations** (edit files, trigger runs, repo sync) — require **member** or above (viewers excluded).
-- **Deployment-config changes** (GitHub connect/import, repo writes, job create/edit/delete, project create/delete) — require **admin** or **owner**.
+- **Reads (GET)** — open to any member, including viewers.
+- **File/run mutations** (edit files, trigger runs, ad-hoc compile/run) — require **member** or above (viewers excluded).
+- **Deployment-config changes** (job create/edit/delete, project create/delete, PR merges) — require **admin** or **owner**. Connecting the workspace's GitHub repo is workspace-level infrastructure now (`/workspaces/:workspaceId/github/*`), not a dbt-specific route.
 
 ## Runner security
 
@@ -138,8 +129,6 @@ dbt routes are mounted under `/api/workspaces/:workspaceId/dbt`. Highlights (ful
 | `POST` | `/projects/:projectId/preview` | `dbt show --select` — bounded read-only row preview |
 | `POST` | `/projects/:projectId/command` | Run an allow-listed free-form command |
 | `GET` | `/projects/:projectId/lineage` | DAG nodes + edges from the latest manifest |
-
-GitHub connect/import and in-IDE git operations (status, diff, commit, branch, pull request) are exposed under the same `/dbt` prefix.
 
 ## Project rules (`.makorules.md`)
 


### PR DESCRIPTION
## What
`transforms.md` described dbt project files as living **in the workspace database (one document per file)**, with a per-project GitHub import/sync/CI/PR-status pipeline. Both are gone.

## Why (P0 doc bug)
- Block D3 (commit `2cc9df5`, "dbt lives in the workspace repo") moved dbt project files into the workspace's git repo (`dbt/` folder, same repo as consoles/notebooks/apps).
- The git-first read overlay (commit `e6f5ca2`, "Serve dbt job definitions from git") made `dbt/jobs/*.yml` and `dbt/environments.yml` authoritative in git, with Mongo as a derived SHA-checked index only.
- The old per-project GitHub import/sync/CI section no longer matches any route -- GitHub connect/import now lives at the workspace level (`api/src/routes/workspace-repo.ts`, mounted under `/workspaces/:workspaceId/github/*`), not under `/dbt`.

## Changes
- Storage model paragraph: workspace database → workspace git repo, with the Mongo-as-derived-index detail.
- Removed stale "## GitHub integration" section (per-project import/sync/CI/PR-status -- deleted feature).
- File section: reads come from git `listTree`/`readBlob` on the session branch; one dbt project per workspace, scaffolded or imported by pointing at an existing `dbt_project.yml`.
- RBAC bullets: dropped "GitHub connect/import" from dbt-specific RBAC (matches `api/src/dbt/rbac.ts` -- `DBT_ADMIN_ONLY` has no import-github pattern); added a note that GitHub connect is workspace infra now.
- API table: removed the line claiming GitHub connect/import + git ops are exposed under `/dbt`.

Verified against `api/src/dbt/dbt-config.service.ts`, `dbt-config-files.ts`, `api/src/dbt/rbac.ts`, and `api/src/routes/workspace-repo.ts` at HEAD 80853e1/e6f5ca2.