### PR TITLE
ci: name the API test job for what fails in it; pre-push runs both vitest configs

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -1,10 +1,14 @@
 name: API Contract
 
-# Verifies the OpenAPI contract stays honest:
-#  - runs the API + frontend-client test suites
-#  - regenerates the OpenAPI spec and the generated frontend types, then fails
-#    if either differs from what's committed (so a route change can't ship
-#    without updating the spec + client types).
+# Two jobs, named for what actually fails in them:
+#  - "OpenAPI contract + drift check": regenerates the OpenAPI spec and the
+#    generated frontend types, then fails if either differs from what's
+#    committed (so a route change can't ship without updating the spec +
+#    client types); also runs the frontend typed client's own tests.
+#  - "API tests (tsx + vitest)": every API suite — the tsx chain, the three
+#    vitest configs, agent-tools, destinations, the edge worker. This used to
+#    hide inside the contract job, so a unit-test failure read as "OpenAPI
+#    drift" and got triaged as such twice (PRs #976, #979).
 
 on:
   push:
@@ -59,24 +63,6 @@ jobs:
           pnpm --filter @mako/schemas run build
           pnpm --filter @mako/agent-tools run build
 
-      - name: API contract tests
-        run: pnpm --filter api run test
-
-      - name: Agent tools tests
-        run: pnpm --filter @mako/agent-tools run test
-
-      - name: API destination tests
-        # Offline destination connector suite (driver dialect/write SQL, CDC
-        # MERGE builder, DestinationWriter orchestration). Real-DB integration
-        # specs self-skip without RUN_DB_INTEGRATION (see destination-integration.yml).
-        run: pnpm --filter api run test:destinations
-
-      - name: API dbt tests
-        # vitest.config.ts — src/dbt/**, src/integrations/github/**, the dbt
-        # route integration spec and the dbt-* agent tools. The real-dbt engine
-        # contract self-skips without RUN_DBT_ENGINE_CONTRACT.
-        run: pnpm --filter api run test:dbt
-
       - name: Frontend typed-client tests
         # Deliberately just the typed client, not the whole app suite: this
         # workflow exists to keep the OpenAPI contract honest, and the client
@@ -85,11 +71,6 @@ jobs:
         # would double up on PRs touching both, and running ONLY it here would
         # leave api-only PRs with no client check at all.
         run: pnpm --filter app exec vitest run src/api/client.test.ts
-
-      - name: Cloudflare app-router tests
-        # Maintenance-mode edge worker: raw webhook body forwarding, operator
-        # bypass, redirect rewriting, response streaming.
-        run: pnpm run cf:app:test
 
       - name: Regenerate OpenAPI spec + frontend types
         run: pnpm run openapi:sync
@@ -101,3 +82,67 @@ jobs:
               "Run 'pnpm run openapi:sync' and commit the result."
             exit 1
           fi
+
+  api-tests:
+    name: API tests (tsx + vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          # 22, not 20, because of ONE suite: the workspace-connector specs
+          # execute a real connector, and a connector is TypeScript imported
+          # without a build step. Node strips types from a `.ts` import from
+          # 22.6 (with a flag) and 22.18 (without one); on 20 it cannot, and
+          # every one of those specs fails with `Unknown file extension
+          # ".ts"`. The sandbox that runs connectors in production is on 22 for
+          # the same reason, so this is CI matching the runtime rather than a
+          # preference. The API image itself is still node:20-slim — it never
+          # imports a connector, it ships the code to a box that does.
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Workspace packages the API imports at runtime must be built first so
+      # `tsx` can resolve `@mako/schemas` / `@mako/agent-tools`.
+      - name: Build workspace packages
+        run: |
+          pnpm --filter @mako/schemas run build
+          pnpm --filter @mako/agent-tools run build
+
+      - name: API tsx suites + apps vitest config
+        # api/package.json "test": the hand-rolled tsx + node:assert chain,
+        # then `vitest run --config vitest.apps.config.ts` (apps, consoles,
+        # skills, flows, notebooks).
+        run: pnpm --filter api run test
+
+      - name: API dbt vitest config
+        # vitest.config.ts — src/dbt/**, src/integrations/github/**, the dbt
+        # route integration spec, the dbt-* agent tools, and anything else
+        # that happens to live under src/dbt. The real-dbt engine contract
+        # self-skips without RUN_DBT_ENGINE_CONTRACT.
+        run: pnpm --filter api run test:dbt
+
+      - name: API destination tests
+        # Offline destination connector suite (driver dialect/write SQL, CDC
+        # MERGE builder, DestinationWriter orchestration). Real-DB integration
+        # specs self-skip without RUN_DB_INTEGRATION (see destination-integration.yml).
+        run: pnpm --filter api run test:destinations
+
+      - name: Agent tools tests
+        run: pnpm --filter @mako/agent-tools run test
+
+      - name: Cloudflare app-router tests
+        # Maintenance-mode edge worker: raw webhook body forwarding, operator
+        # bypass, redirect rewriting, response streaming.
+        run: pnpm run cf:app:test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,18 @@
+# Both API vitest configs before anything leaves this machine. The tsx chain
+# and the lint/prettier/openapi checks already run per commit (lint-staged);
+# these two are the suites that were being run file-by-file and then failing
+# in CI under a job named "OpenAPI contract" (PRs #976, #979).
+#
+# Skip deliberately with: SKIP_PREPUSH_TESTS=1 git push
+if [ -n "$SKIP_PREPUSH_TESTS" ]; then
+  echo "pre-push: SKIP_PREPUSH_TESTS set, skipping vitest configs"
+  exit 0
+fi
+# git runs hooks with GIT_DIR (and friends) exported. The repo-backed suites
+# spawn `git` against temporary bare repos; with GIT_DIR inherited they all
+# silently operate on THIS repo instead and five dbt specs fail with
+# "expected null not to be null". Unset before anything runs.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
+echo "pre-push: api vitest configs (dbt + apps) — SKIP_PREPUSH_TESTS=1 to bypass"
+pnpm --filter api run test:dbt --reporter=dot || exit 1
+pnpm --filter api run test:apps --reporter=dot || exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,16 @@ pnpm api:build             # Build backend only (TypeScript compilation)
 pnpm lint:all              # Lint all packages
 pnpm lint:fix:all          # Auto-fix linting issues across workspace
 pnpm openapi:sync          # Regenerate OpenAPI spec + typed client (~3s) — REQUIRED after any api route/schema change; commit the outputs
-
+pnpm --filter api run test:dbt   # vitest.config.ts: src/dbt/**, github integration, dbt tools (whole config, not single files)
+pnpm --filter api run test:apps  # vitest.apps.config.ts: apps, consoles, skills, flows, notebooks
 ```
+
+Hooks: `pre-commit` runs lint-staged (eslint, prettier, the test-coverage
+guard, `openapi:sync` on route changes). `pre-push` runs BOTH API vitest
+configs above (~2 min); bypass deliberately with `SKIP_PREPUSH_TESTS=1`.
+Run the whole config, never a single file: a test's location decides which
+config runs it, and CI's "API tests (tsx + vitest)" job runs all of them.
+
 
 ### Data Operations
 


### PR DESCRIPTION
### Motivation

Twice in two days (#976, #979) a unit test failed inside the CI job named **OpenAPI contract + drift check**, was read as OpenAPI drift, and had not been caught locally because the Vitest suites were run file by file. The lint-staged hooks were fine: they regenerate the spec on every route change and the drift step passed both times.

### What changed

- `api-contract.yml` is split: **OpenAPI contract + drift check** does only the contract (regen, drift, frontend typed-client test); **API tests (tsx + vitest)** runs every API suite (tsx chain + apps config, dbt config, destinations, agent-tools, edge worker).
- New `.husky/pre-push` runs both API Vitest configs before a push (~2 min locally). Bypass deliberately with `SKIP_PREPUSH_TESTS=1 git push`. It unsets `GIT_DIR` and friends first: git exports them to hooks, and the repo-backed suites spawn `git` against temporary bare repos, which then silently operated on the Mako repo and failed five dbt specs on the first try.
- `CLAUDE.md` lists the two config commands and says to run whole configs, never single files, because a test's location decides which config runs it.

### Testing

The branch was pushed through the new hook: 272 + 322 tests green in about two minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUW2yMykUQDPxLzciseCV2