### PR TITLE
fix(auth): persist CLI/MCP sign-ins and improve authentication screens

### DIFF
--- a/AUTH_README.md
+++ b/AUTH_README.md
@@ -493,8 +493,10 @@ would fall through to the SPA fallback and poison client discovery.
 ### Token model
 
 - Opaque tokens, stored as SHA-256 hashes: access `mcpat_*` (8 h TTL),
-  refresh `mcprt_*` (30 d TTL, rotated on every refresh). Auth codes live
-  10 minutes and are consumed atomically.
+  refresh `mcprt_*` (no expiry for CLI / external MCP grants, rotated on every
+  refresh). Sign-ins last until revoked, including after long periods of
+  inactivity. Access tokens renew silently; auth codes live 10 minutes and
+  are consumed atomically. Session-minted Desktop ACP grants remain expiring.
 - `unifiedAuthMiddleware` recognizes the `mcpat_` Bearer prefix and sets
   `authType: "mcpOAuth"` with the grant's workspace binding and scopes.
 - Scopes default to the read-only set (`mcp`, `query:read`). OAuth clients may

--- a/api/src/auth/mcp-oauth.service.test.ts
+++ b/api/src/auth/mcp-oauth.service.test.ts
@@ -1,0 +1,249 @@
+import { createHash } from "node:crypto";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import {
+  McpOAuthClient,
+  McpOAuthCode,
+  McpOAuthToken,
+} from "../database/mcp-oauth-schema";
+import {
+  ACP_MCP_CLIENT_ID,
+  createAuthorizationCode,
+  exchangeAuthorizationCode,
+  listMcpConnections,
+  mintMcpAccessTokenForUser,
+  refreshAccessToken,
+  registerOAuthClient,
+  revokeMcpConnection,
+  validateMcpAccessToken,
+} from "./mcp-oauth.service";
+import { up } from "../migrations/2026-09-06-230000_persistent_mcp_oauth_grants";
+
+let mongo: MongoMemoryServer;
+const hash = (value: string) =>
+  createHash("sha256").update(value).digest("hex");
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create({
+    instance: { args: ["--setParameter", "ttlMonitorEnabled=false"] },
+  });
+  await mongoose.connect(mongo.getUri());
+  await Promise.all([
+    McpOAuthClient.init(),
+    McpOAuthCode.init(),
+    McpOAuthToken.init(),
+  ]);
+});
+beforeEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  await Promise.all([
+    McpOAuthClient.deleteMany({}),
+    McpOAuthCode.deleteMany({}),
+    McpOAuthToken.deleteMany({}),
+  ]);
+});
+afterAll(async () => {
+  vi.useRealTimers();
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+async function authorize(clientName = "Mako CLI") {
+  const redirectUri = "http://127.0.0.1/callback";
+  const { clientId } = await registerOAuthClient({
+    clientName,
+    redirectUris: [redirectUri],
+  });
+  const verifier = "a".repeat(43);
+  const code = await createAuthorizationCode({
+    clientId,
+    userId: "user",
+    workspaceId: "workspace",
+    redirectUri,
+    codeChallenge: createHash("sha256").update(verifier).digest("base64url"),
+    scopes: ["mcp", "query:read"],
+  });
+  const tokens = await exchangeAuthorizationCode({
+    code,
+    clientId,
+    redirectUri,
+    codeVerifier: verifier,
+  });
+  return { clientId, ...tokens };
+}
+
+it.each(["Mako CLI", "External MCP client"])(
+  "%s stays renewable after years of inactivity and remains revocable",
+  async clientName => {
+    const grant = await authorize(clientName);
+    const original = await McpOAuthToken.findOne({
+      clientId: grant.clientId,
+    }).lean();
+    expect(original?.refreshExpiresAt).toBeUndefined();
+    expect(grant.expiresInSeconds).toBe(8 * 60 * 60);
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2040-01-01T00:00:00Z"));
+    expect(await validateMcpAccessToken(grant.accessToken)).toBeNull();
+    expect(await listMcpConnections("workspace")).toHaveLength(1);
+    const renewed = await refreshAccessToken({
+      clientId: grant.clientId,
+      refreshToken: grant.refreshToken,
+    });
+    expect(await validateMcpAccessToken(renewed.accessToken)).toMatchObject({
+      userId: "user",
+      workspaceId: "workspace",
+      scopes: ["mcp", "query:read"],
+    });
+    const stored = await McpOAuthToken.findOne({
+      clientId: grant.clientId,
+    }).lean();
+    expect(stored?.refreshExpiresAt).toBeUndefined();
+    expect(stored?._id).toEqual(original?._id);
+    expect(stored?.createdAt).toEqual(original?.createdAt);
+    await expect(
+      refreshAccessToken({
+        clientId: grant.clientId,
+        refreshToken: grant.refreshToken,
+      }),
+    ).rejects.toThrow("invalid_grant");
+    expect(
+      await revokeMcpConnection({
+        workspaceId: "workspace",
+        clientId: grant.clientId,
+        userId: "user",
+      }),
+    ).toBe(1);
+    expect(await validateMcpAccessToken(renewed.accessToken)).toBeNull();
+    await expect(
+      refreshAccessToken({
+        clientId: grant.clientId,
+        refreshToken: renewed.refreshToken,
+      }),
+    ).rejects.toThrow("invalid_grant");
+    expect(await listMcpConnections("workspace")).toHaveLength(0);
+  },
+);
+
+it("a wrong client or failed rotation leaves the original grant usable", async () => {
+  const grant = await authorize();
+  await expect(
+    refreshAccessToken({ clientId: "wrong", refreshToken: grant.refreshToken }),
+  ).rejects.toThrow("invalid_grant");
+  expect(await validateMcpAccessToken(grant.accessToken)).not.toBeNull();
+  const write = vi
+    .spyOn(McpOAuthToken, "findOneAndUpdate")
+    .mockRejectedValueOnce(new Error("database unavailable"));
+  await expect(
+    refreshAccessToken({
+      clientId: grant.clientId,
+      refreshToken: grant.refreshToken,
+    }),
+  ).rejects.toThrow("database unavailable");
+  write.mockRestore();
+  expect(await validateMcpAccessToken(grant.accessToken)).not.toBeNull();
+  await expect(
+    refreshAccessToken({
+      clientId: grant.clientId,
+      refreshToken: grant.refreshToken,
+    }),
+  ).resolves.toHaveProperty("accessToken");
+});
+
+it("only one concurrent caller may consume a refresh token", async () => {
+  const grant = await authorize();
+  const attempts = await Promise.allSettled(
+    Array.from({ length: 2 }, () =>
+      refreshAccessToken({
+        clientId: grant.clientId,
+        refreshToken: grant.refreshToken,
+      }),
+    ),
+  );
+  expect(attempts.filter(result => result.status === "fulfilled")).toHaveLength(
+    1,
+  );
+  expect(attempts.filter(result => result.status === "rejected")).toHaveLength(
+    1,
+  );
+  expect(await McpOAuthToken.countDocuments()).toBe(1);
+});
+
+it("migration preserves live logins without reviving expired grants or extending ACP", async () => {
+  const active = await authorize();
+  const expired = await authorize();
+  const acp = await mintMcpAccessTokenForUser({
+    userId: "user",
+    workspaceId: "workspace",
+  });
+  const future = new Date(Date.now() + 86_400_000);
+  const past = new Date(Date.now() - 86_400_000);
+  await McpOAuthToken.updateOne(
+    { clientId: active.clientId },
+    { $set: { refreshExpiresAt: future } },
+  );
+  await McpOAuthToken.updateOne(
+    { clientId: expired.clientId },
+    { $set: { refreshExpiresAt: past } },
+  );
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("Test database missing");
+  await up(db);
+  await up(db);
+  expect(
+    (await McpOAuthToken.findOne({ clientId: active.clientId }).lean())
+      ?.refreshExpiresAt,
+  ).toBeUndefined();
+  expect(await validateMcpAccessToken(active.accessToken)).not.toBeNull();
+  expect(
+    (await McpOAuthToken.findOne({ clientId: expired.clientId }).lean())
+      ?.refreshExpiresAt,
+  ).toEqual(past);
+  expect(
+    (await McpOAuthToken.findOne({ clientId: ACP_MCP_CLIENT_ID }).lean())
+      ?.refreshExpiresAt,
+  ).toBeInstanceOf(Date);
+  expect(
+    (await listMcpConnections("workspace")).map(
+      connection => connection.clientId,
+    ),
+  ).not.toContain(expired.clientId);
+  await expect(
+    refreshAccessToken({
+      clientId: expired.clientId,
+      refreshToken: expired.refreshToken,
+    }),
+  ).rejects.toThrow("invalid_grant");
+  await expect(
+    refreshAccessToken({
+      clientId: ACP_MCP_CLIENT_ID,
+      refreshToken: acp.refreshToken,
+    }),
+  ).rejects.toThrow("session-minted");
+  // The existing TTL index ignores persistent grants because they have no date.
+  expect(
+    (await McpOAuthToken.collection.indexes()).find(
+      index => index.key.refreshExpiresAt === 1,
+    )?.expireAfterSeconds,
+  ).toBe(0);
+});
+
+it("refreshing a live legacy grant upgrades it without requiring migration first", async () => {
+  const grant = await authorize();
+  await McpOAuthToken.updateOne(
+    { refreshTokenHash: hash(grant.refreshToken) },
+    { $set: { refreshExpiresAt: new Date(Date.now() + 86_400_000) } },
+  );
+  const renewed = await refreshAccessToken({
+    clientId: grant.clientId,
+    refreshToken: grant.refreshToken,
+  });
+  expect(
+    (
+      await McpOAuthToken.findOne({
+        refreshTokenHash: hash(renewed.refreshToken),
+      }).lean()
+    )?.refreshExpiresAt,
+  ).toBeUndefined();
+});

--- a/api/src/auth/mcp-oauth.service.ts
+++ b/api/src/auth/mcp-oauth.service.ts
@@ -27,7 +27,9 @@ const CLIENT_ID_PREFIX = "mcpc_";
 
 const AUTH_CODE_TTL_MS = 10 * 60 * 1000;
 const ACCESS_TOKEN_TTL_MS = 8 * 60 * 60 * 1000;
-const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// Only session-minted Desktop ACP grants expire; browser-authorized grants
+// remain renewable until explicitly revoked.
+const ACP_GRANT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 /** Avoid a write per MCP request: bump lastUsedAt at most once a minute. */
 const LAST_USED_WRITE_INTERVAL_MS = 60 * 1000;
 
@@ -188,7 +190,9 @@ async function issueTokens(grant: {
     agentSessionId: grant.agentSessionId,
     scopes: grant.scopes,
     accessExpiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
-    refreshExpiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+    ...(grant.clientId === ACP_MCP_CLIENT_ID
+      ? { refreshExpiresAt: new Date(Date.now() + ACP_GRANT_TTL_MS) }
+      : {}),
   });
   return {
     accessToken,
@@ -296,28 +300,46 @@ export async function refreshAccessToken(input: {
   refreshToken: string;
   clientId: string;
 }): Promise<IssuedTokens> {
-  // Rotation: the old grant is deleted and a fresh pair is issued.
-  const record = await McpOAuthToken.findOneAndDelete({
-    refreshTokenHash: sha256(input.refreshToken),
-    refreshExpiresAt: { $gt: new Date() },
-  });
-  if (!record) throw new Error("invalid_grant: unknown or expired token");
-  if (record.clientId !== input.clientId) {
-    throw new Error("invalid_grant: token was issued to a different client");
+  if (input.clientId === ACP_MCP_CLIENT_ID) {
+    throw new Error("invalid_grant: session-minted tokens cannot be refreshed");
   }
-  return issueTokens({
-    clientId: record.clientId,
-    userId: record.userId,
-    workspaceId: record.workspaceId,
+  const accessToken = randomToken(MCP_ACCESS_TOKEN_PREFIX);
+  const refreshToken = randomToken(MCP_REFRESH_TOKEN_PREFIX);
+  // Rotate atomically in place: a failed write or wrong client must not
+  // destroy a valid grant. Only one caller may consume each refresh token.
+  const record = await McpOAuthToken.findOneAndUpdate(
+    {
+      refreshTokenHash: sha256(input.refreshToken),
+      clientId: input.clientId,
+      $or: [
+        { refreshExpiresAt: { $exists: false } },
+        { refreshExpiresAt: { $gt: new Date() } },
+      ],
+    },
+    {
+      $set: {
+        accessTokenHash: sha256(accessToken),
+        refreshTokenHash: sha256(refreshToken),
+        accessExpiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
+      },
+      $unset: { refreshExpiresAt: "" },
+    },
+    { new: true },
+  );
+  if (!record) throw new Error("invalid_grant: unknown or expired token");
+  return {
+    accessToken,
+    refreshToken,
+    expiresInSeconds: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
     scopes: record.scopes,
     agentSessionId: record.agentSessionId,
-  });
+  };
 }
 
 /**
  * One row per connected agent: a (client × user) pair that holds at least one
- * live grant in the workspace. Grants are token documents; refresh rotation
- * replaces them, so `connectedAt` is the oldest surviving grant's creation.
+ * live grant in the workspace. Rotation preserves the grant, so connectedAt
+ * remains the original authorization time.
  */
 export interface McpConnectionSummary {
   clientId: string;
@@ -337,7 +359,15 @@ export async function listMcpConnections(
     lastUsedAt?: Date;
     accessExpiresAt: Date;
   }>([
-    { $match: { workspaceId, refreshExpiresAt: { $gt: new Date() } } },
+    {
+      $match: {
+        workspaceId,
+        $or: [
+          { refreshExpiresAt: { $exists: false } },
+          { refreshExpiresAt: { $gt: new Date() } },
+        ],
+      },
+    },
     {
       $group: {
         _id: { clientId: "$clientId", userId: "$userId" },

--- a/api/src/database/mcp-oauth-schema.ts
+++ b/api/src/database/mcp-oauth-schema.ts
@@ -67,7 +67,8 @@ export interface IMcpOAuthToken extends Document {
   agentSessionId?: string;
   scopes: string[];
   accessExpiresAt: Date;
-  refreshExpiresAt: Date;
+  /** Absent for CLI / external MCP grants, which last until revoked. */
+  refreshExpiresAt?: Date;
   createdAt: Date;
   lastUsedAt?: Date;
 }
@@ -81,11 +82,11 @@ const McpOAuthTokenSchema = new Schema<IMcpOAuthToken>({
   agentSessionId: { type: String, index: true },
   scopes: { type: [String], required: true },
   accessExpiresAt: { type: Date, required: true },
-  refreshExpiresAt: { type: Date, required: true },
+  refreshExpiresAt: { type: Date },
   createdAt: { type: Date, default: Date.now },
   lastUsedAt: { type: Date },
 });
-// Mongo reaps the whole grant once the refresh token can no longer be used.
+// TTL skips grants without a date; only expiring legacy / ACP grants are reaped.
 McpOAuthTokenSchema.index({ refreshExpiresAt: 1 }, { expireAfterSeconds: 0 });
 
 export const McpOAuthClient = mongoose.model<IMcpOAuthClient>(

--- a/api/src/migrations/2026-09-06-230000_persistent_mcp_oauth_grants.ts
+++ b/api/src/migrations/2026-09-06-230000_persistent_mcp_oauth_grants.ts
@@ -1,0 +1,16 @@
+import { Db } from "mongodb";
+
+export const description =
+  "Keep active CLI and external MCP OAuth grants renewable until revoked";
+
+export async function up(db: Db): Promise<void> {
+  // Never revive expired grants or extend session-minted Desktop ACP access.
+  // Unsetting the date also excludes these grants from the existing TTL index.
+  await db.collection("mcpoauthtokens").updateMany(
+    {
+      clientId: { $ne: "mako-acp-local" },
+      refreshExpiresAt: { $gt: new Date() },
+    },
+    { $unset: { refreshExpiresAt: "" } },
+  );
+}

--- a/api/src/routes/mcp-oauth.routes.ts
+++ b/api/src/routes/mcp-oauth.routes.ts
@@ -311,40 +311,84 @@ function consentPage(input: {
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Connect ${escapeHtml(clientName)} — Mako</title>
+<script>
+  // Match the app's explicit preference before paint; otherwise CSS follows the OS.
+  (function () {
+    function syncTheme() {
+      try {
+        var mode = localStorage.getItem("themeMode");
+        if (mode === "light" || mode === "dark") {
+          document.documentElement.dataset.theme = mode;
+        } else {
+          delete document.documentElement.dataset.theme;
+        }
+      } catch (_) { /* System theme still works when storage is unavailable. */ }
+    }
+    syncTheme();
+    window.addEventListener("storage", syncTheme);
+  })();
+</script>
 <style>
+  :root { color-scheme: light; --page: #f6f5f1; --surface: #fff;
+          --ink: #1a1a1a; --muted: #555; --border: #d8d5cc;
+          --shadow: #e3e0d7; --accent: #6c4fd8; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) { color-scheme: dark; --page: #161513;
+      --surface: #201e1a; --ink: #edeae3; --muted: #b8b3a9;
+      --border: #55504a; --shadow: #302c26; --accent: #b7a5ff; }
+  }
+  :root[data-theme="dark"] { color-scheme: dark; --page: #161513;
+    --surface: #201e1a; --ink: #edeae3; --muted: #b8b3a9;
+    --border: #55504a; --shadow: #302c26; --accent: #b7a5ff; }
+  * { box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-         background: #f6f5f1; color: #1a1a1a; display: flex; min-height: 100vh;
+         background: var(--page); color: var(--ink); display: flex;
+         min-height: 100vh; min-height: 100svh; padding: 32px 24px;
          align-items: center; justify-content: center; margin: 0; }
-  .card { background: #fff; border: 1px solid #d8d5cc; padding: 32px;
-          max-width: 420px; width: calc(100% - 48px);
-          box-shadow: 6px 6px 0 0 #e3e0d7; }
-  h1 { font-size: 20px; margin: 0 0 4px; }
-  p { color: #555; font-size: 14px; line-height: 1.5; }
-  .ws { display: flex; align-items: center; gap: 10px; padding: 10px 12px;
-        border: 1px solid #d8d5cc; margin-bottom: 8px; cursor: pointer;
+  .card { background: var(--surface); border: 1px solid var(--border); padding: 32px;
+          max-width: 486px; width: 100%; overflow-wrap: anywhere;
+          box-shadow: 6px 6px 0 0 var(--shadow); }
+  .brand { font: 600 12px ui-monospace, monospace; letter-spacing: 0.14em;
+           margin-bottom: 28px; }
+  h1 { font-size: 22px; letter-spacing: -0.025em; margin: 0 0 4px; }
+  p { color: var(--muted); font-size: 14px; line-height: 1.6; }
+  fieldset { border: 0; padding: 0; margin: 24px 0 0; min-width: 0; }
+  legend { font-size: 14px; font-weight: 600; padding: 0; margin-bottom: 8px; }
+  .ws { display: flex; align-items: center; gap: 10px; padding: 12px;
+        border: 1px solid var(--border); margin-bottom: 8px; cursor: pointer;
         font-size: 14px; }
-  .ws em { margin-left: auto; color: #888; font-style: normal;
+  .ws:has(input:checked) { border-color: var(--accent); background: var(--page); }
+  .ws:hover { background: var(--page); }
+  .ws span { min-width: 0; }
+  .ws em { margin-left: auto; color: var(--muted); font-style: normal;
            font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
-  .scopes { background: #f6f5f1; border: 1px solid #e3e0d7; padding: 10px 12px;
-            font-size: 13px; color: #444; margin: 16px 0; }
+  input { accent-color: var(--accent); flex-shrink: 0; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+  .scopes { background: var(--page); border: 1px solid var(--border); padding: 12px;
+            font-size: 13px; line-height: 1.6; color: var(--muted); margin: 16px 0; }
+  .scopes strong { color: var(--ink); }
   .scope-option { display: flex; align-items: flex-start; gap: 8px; margin-top: 12px;
-                  color: #1a1a1a; cursor: pointer; }
-  .scope-option input { margin-top: 3px; }
-  .actions { display: flex; gap: 8px; margin-top: 20px; }
-  button { flex: 1; padding: 10px 16px; font-size: 14px; cursor: pointer;
-           border: 1px solid #1a1a1a; display: inline-flex;
-           align-items: center; justify-content: center; gap: 8px; }
-  .allow { background: #1a1a1a; color: #fff; }
-  .deny { background: #fff; color: #1a1a1a; }
+                  cursor: pointer; }
+  .scope-option input { margin-top: 4px; }
+  .actions { display: flex; gap: 8px; margin-top: 24px; }
+  button { flex: 1; padding: 12px 16px; font: inherit; font-size: 14px;
+           font-weight: 500; cursor: pointer; border: 1px solid var(--ink);
+           display: inline-flex; align-items: center; justify-content: center; gap: 8px; }
+  .allow { background: var(--ink); color: var(--surface); }
+  .deny { background: var(--surface); color: var(--ink); }
+  button:hover { opacity: 0.8; }
   button[disabled] { cursor: default; opacity: 0.65; }
   .spinner { width: 14px; height: 14px; border-radius: 50%; flex: none;
              border: 2px solid currentColor; border-top-color: transparent;
              animation: spin 0.7s linear infinite; }
   @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+  @media (max-width: 480px) { .card { padding: 24px; } }
 </style>
 </head>
 <body>
 <main class="card">
+  <div class="brand">MAKO / CONNECT</div>
   <h1>Connect ${escapeHtml(clientName)}</h1>
   <p><strong>${escapeHtml(clientName)}</strong> wants to access a Mako workspace over MCP.</p>
   <form method="post" action="${AUTHORIZE_PATH}">
@@ -353,8 +397,10 @@ function consentPage(input: {
     ${hidden("state", params.state)}
     ${hidden("code_challenge", params.codeChallenge)}
     ${hidden("scope", params.scopes.join(" "))}
-    <p style="margin-bottom:6px;font-weight:600;color:#1a1a1a">Choose a workspace</p>
-    ${options}
+    <fieldset>
+      <legend>Choose a workspace</legend>
+      ${options}
+    </fieldset>
     <div class="scopes">
       <strong>Workspace authoring:</strong> explore schemas, run read-only
       queries, and create or edit Mako apps and dbt files.

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "src/dbt/**/*.test.ts",
+      "src/auth/mcp-oauth.service.test.ts",
       "src/integrations/github/**/*.test.ts",
       "src/routes/dbt.routes.integration.test.ts",
       "src/routes/connector-reveal-secret.test.ts",

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -52,6 +52,11 @@ url = "https://your-mako-host/api/mcp"
 
 Verify the connection (Claude Code): `claude mcp list` should show `mako … ✓ Connected`.
 
+CLI and external MCP sign-ins stay connected until you revoke them, even after
+long periods of inactivity. Access tokens last 8 hours and clients renew them
+automatically with a rotating refresh token that has no expiry. You can revoke
+a connection from your workspace settings.
+
 Under the hood this is standard OAuth 2.1 for MCP: RFC 9728 protected-resource discovery, dynamic client registration, PKCE, and rotating refresh tokens. Grants default to `mcp query:read`; `warehouse:write` is the only OAuth write scope and must be requested and approved explicitly.
 
 ## Headless / CI: API keys
@@ -192,7 +197,7 @@ systems must not be mixed on one app.
 | Symptom                                                                  | Cause / fix                                                                                                                                                                            |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Client never opens the sign-in browser                                   | The client predates MCP OAuth support — update it, or fall back to an API key header.                                                                                                  |
-| `401 Invalid or expired MCP access token`                                | The OAuth grant was revoked or fully expired — reconnect the server in your client (it re-runs the sign-in).                                                                           |
+| `401 Invalid or expired MCP access token`                                | The access token expired or the connection was revoked. The client should refresh automatically; reconnect if the grant was revoked or the client lost its saved credentials.                                                                           |
 | `403 … created before MCP scopes existed`                                | Legacy key. Sign in via OAuth or create a new key under Workspace Settings → API Keys.                                                                                                 |
 | `403 … does not include the mcp scope`                                   | Key was created without the `mcp` scope — create a new key.                                                                                                                            |
 | `Mako MCP access is read-only: the query was rejected…`                  | The agent attempted a write (`UPDATE`/`INSERT`/DDL). Expected — run writes with your own database tooling.                                                                             |

--- a/packages/app-sdk/credentials.test.mjs
+++ b/packages/app-sdk/credentials.test.mjs
@@ -46,3 +46,20 @@ test("getAccessToken refreshes an expiring token and persists the rotation", asy
   assert.equal(calls.length, 1);
   assert.equal(await getAccessToken("https://nobody.test", null, { file: f }), null);
 });
+
+test("a CLI credential unused for years renews without another browser login", async () => {
+  const f = file();
+  saveCredential("https://api.test", null, {
+    clientId: "cid", accessToken: "old", refreshToken: "persistent-grant",
+    expiresAt: "2000-01-01T00:00:00.000Z",
+  }, f);
+  const fetchImpl = async (_url, init) => {
+    assert.equal(new URLSearchParams(init.body).get("refresh_token"), "persistent-grant");
+    return new Response(JSON.stringify({
+      access_token: "renewed", refresh_token: "rotated-grant", expires_in: 28800,
+    }));
+  };
+  assert.equal(await getAccessToken("https://api.test", "ws1", { file: f, fetch: fetchImpl }), "renewed");
+  assert.equal(findCredential("https://api.test", "ws1", readCredentialStore(f)).refreshToken, "rotated-grant");
+  fs.rmSync(path.dirname(f), { recursive: true });
+});

--- a/packages/cli/src/login-page.js
+++ b/packages/cli/src/login-page.js
@@ -1,0 +1,77 @@
+/** Self-contained: the loopback callback must render without network access. */
+export function loginPage(status, error = "") {
+  const approved = status === "approved";
+  const denied = status === "denied";
+  const title = approved ? "Connection approved" : denied ? "Connection declined" : "Unable to connect";
+  const description = approved
+    ? "Your browser step is complete. Return to your terminal to finish signing in to Mako."
+    : denied
+      ? "You declined this connection. If you change your mind, start again from your terminal."
+      : "We couldn’t complete this sign-in. Return to your terminal and try again.";
+  const detail = String(error).replace(/[&<>"']/g, char => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  })[char]);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>${title} — Mako</title>
+  <style>
+    :root { color-scheme: light; --page: #f6f5f1; --surface: #fff;
+      --ink: #1a1a1a; --muted: #555; --border: #d8d5cc;
+      --shadow: #e3e0d7; --accent: #6c4fd8; --tint: #f0ecfc; }
+    @media (prefers-color-scheme: dark) {
+      :root { color-scheme: dark; --page: #161513; --surface: #201e1a;
+        --ink: #edeae3; --muted: #b8b3a9; --border: #55504a;
+        --shadow: #302c26; --accent: #b7a5ff; --tint: #30283e; }
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; min-height: 100svh; padding: 32px 24px;
+      display: flex; align-items: center; justify-content: center;
+      background: var(--page); color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .card { width: 100%; max-width: 486px; padding: 32px;
+      background: var(--surface); border: 1px solid var(--border);
+      box-shadow: 6px 6px 0 var(--shadow); overflow-wrap: anywhere; }
+    .brand { font: 600 12px ui-monospace, monospace; letter-spacing: 0.14em;
+      margin-bottom: 36px; }
+    .status { width: 48px; height: 48px; display: grid; place-items: center;
+      margin-bottom: 24px; color: var(--accent); background: var(--tint);
+      border: 1px solid var(--accent); }
+    .status svg { width: 24px; height: 24px; }
+    h1 { margin: 0 0 12px; font-size: 28px; letter-spacing: -0.035em;
+      line-height: 1.2; font-weight: 600; }
+    p { margin: 0; font-size: 14px; line-height: 1.7; color: var(--muted); }
+    .next { margin-top: 28px; padding: 16px; background: var(--page);
+      border: 1px solid var(--border); }
+    .next strong { display: block; font-size: 13px; margin-bottom: 4px; }
+    code { font: 13px ui-monospace, monospace; color: var(--ink); }
+    .detail { margin-top: 16px; }
+    footer { border-top: 1px solid var(--border); padding-top: 20px;
+      margin-top: 28px; font-size: 12px; color: var(--muted); }
+    @media (max-width: 480px) { .card { padding: 24px; } h1 { font-size: 24px; } }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <div class="brand">MAKO / CLI</div>
+    <div class="status" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+        ${approved ? '<path d="m5 12 4 4L19 6" />' : denied ? '<path d="m6 6 12 12M18 6 6 18" />' : '<path d="M12 5v9m0 4h.01" />'}
+      </svg>
+    </div>
+    <h1>${title}</h1>
+    <p>${description}</p>
+    <div class="next">
+      <strong>${approved ? "Continue in your terminal" : "Start a new sign-in"}</strong>
+      <p>${approved ? "Your CLI will confirm when you’re signed in." : "Run <code>mako login</code> to reconnect."}</p>
+    </div>
+    ${detail ? `<p class="detail">Error: <code>${detail}</code></p>` : ""}
+    <footer>You can safely close this tab.</footer>
+  </main>
+</body>
+</html>`;
+}

--- a/packages/cli/src/login-page.test.mjs
+++ b/packages/cli/src/login-page.test.mjs
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loginPage } from "./login-page.js";
+
+test("OAuth error parameters render as text, never executable HTML", () => {
+  const html = loginPage("error", '<script>alert("token")</script>&\'');
+  assert.ok(!html.includes("<script>"));
+  assert.ok(html.includes("&lt;script&gt;alert(&quot;token&quot;)&lt;/script&gt;&amp;&#39;"));
+});

--- a/packages/cli/src/login.js
+++ b/packages/cli/src/login.js
@@ -6,6 +6,7 @@ import crypto from "node:crypto";
 import http from "node:http";
 import { saveCredential, normalizeApiUrl } from "@makoai/app-sdk/credentials";
 import { openInBrowser } from "./browser.js";
+import { loginPage } from "./login-page.js";
 
 const CLIENT_NAME = "Mako CLI";
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
@@ -72,15 +73,15 @@ function awaitCallback(server, expectedState, timeoutMs) {
       const code = url.searchParams.get("code");
       const error = url.searchParams.get("error");
       res.setHeader("content-type", "text/html; charset=utf-8");
+      res.setHeader("cache-control", "no-store");
+      res.setHeader("referrer-policy", "no-referrer");
       if (state !== expectedState || (!code && !error)) {
         res.statusCode = 400;
-        res.end("<p>Unexpected callback. Return to the terminal and run <code>mako login</code> again.</p>");
+        res.end(loginPage("error"));
         return;
       }
       res.end(
-        error
-          ? `<p>Sign-in failed: ${error}. You can close this tab.</p>`
-          : "<p>Signed in to Mako. You can close this tab and return to the terminal.</p>",
+        loginPage(error === "access_denied" ? "denied" : error ? "error" : "approved", error === "access_denied" ? "" : error ?? ""),
       );
       clearTimeout(timer);
       server.close();


### PR DESCRIPTION
CLI and external MCP sign-ins could require a new browser login after 30 days without a token refresh. Their refresh grants now have no expiry and remain renewable until revoked. Access tokens retain their 8-hour lifetime and refresh automatically. An idempotent migration upgrades existing active grants; expired grants are not revived, and session-minted Desktop ACP grants retain their current expiry.

Refresh rotation now updates the grant atomically in place, preventing a wrong client or failed database write from deleting a valid sign-in. Connected-agent listings include persistent grants and preserve the original connection date.

The authorization screen also follows light/dark mode and the app’s saved theme preference. The CLI callback replaces its unstyled paragraph with a matching responsive card for approved, declined, and error states, follows the system theme, and escapes OAuth error text.

Validation:
- Real Mongo tests for renewal after years of inactivity, revocation, client binding, concurrent rotation, failed writes, and migration idempotency / exclusions.
- SDK tests cover renewal of a long-unused CLI credential; CLI tests cover callback error escaping.
- Browser previews checked at desktop/mobile widths in light/dark mode.
- API lint/build and test-coverage registration guard passed; OpenAPI sync produced no contract changes.
- Full pre-push suites passed: 282 dbt/auth tests (2 gated tests skipped) and 334 app tests. An initial dbt subprocess-cancellation timing failure passed on the full rerun.
