### PR TITLE
Workspaces: domain auto-join — a trusted-domain sign-in becomes a member on first contact, with a default job role and country

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -128,6 +128,13 @@ export interface IWorkspace extends Document {
      * workspace. Clamped to [1, DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE_MAX].
      */
     dashboardRefreshConcurrency?: number;
+    /**
+     * Domain auto-join (apps.md §27): a signed-in person whose email domain
+     * is listed becomes a member on first contact with the workspace — no
+     * invitation — with this access role, job role and country. How a rep
+     * clicks the app link, signs in with Google, and lands on their view.
+     */
+    autoJoin?: IWorkspaceAutoJoin;
   };
   billing: IWorkspaceBilling;
   apiKeys?: IWorkspaceApiKey[];
@@ -176,6 +183,14 @@ export interface IWorkspaceApiKey {
   createdAt: Date;
   lastUsedAt?: Date;
   createdBy: string;
+}
+
+export interface IWorkspaceAutoJoin {
+  /** Lowercase email domains, exact match (no sub-domains). */
+  domains: string[];
+  role: "member" | "viewer";
+  jobRole?: JobRole;
+  country?: string;
 }
 
 /**
@@ -1303,6 +1318,27 @@ const WorkspaceSchema = new Schema<IWorkspace>(
         type: Number,
         default: 2,
         min: 1,
+      },
+      autoJoin: {
+        type: new Schema(
+          {
+            domains: [{ type: String, lowercase: true, trim: true }],
+            role: {
+              type: String,
+              enum: ["member", "viewer"],
+              default: "viewer",
+            },
+            jobRole: { type: String, enum: JOB_ROLES },
+            country: {
+              type: String,
+              uppercase: true,
+              trim: true,
+              match: /^[A-Z]{2}$/,
+            },
+          },
+          { _id: false },
+        ),
+        required: false,
       },
     },
     billing: {

--- a/api/src/middleware/workspace.middleware.ts
+++ b/api/src/middleware/workspace.middleware.ts
@@ -1,6 +1,7 @@
 import { Context, Next } from "hono";
 import { ValidatedSession, ValidatedUser } from "../auth/session";
 import { workspaceService } from "../services/workspace.service";
+import { ensureAutoJoin } from "../services/auto-join.service";
 import { Types } from "mongoose";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 
@@ -112,8 +113,11 @@ export async function requireWorkspace(c: Context, next: Next) {
         return c.json({ error: "Invalid workspace ID format" }, 400);
       }
 
-      // Verify user has access to workspace
-      const member = await workspaceService.getMember(workspaceId, user.id);
+      // Verify user has access to workspace — or admit them now, when the
+      // workspace auto-joins their email domain (auto-join.service).
+      const member =
+        (await workspaceService.getMember(workspaceId, user.id)) ??
+        (await ensureAutoJoin(workspaceId, user));
 
       if (!member) {
         return c.json({ error: "Access denied to workspace" }, 403);

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -146,6 +146,7 @@ import {
   rowFilterFor,
 } from "../apps/viewers.service";
 import { resolveViewerFor } from "../apps/viewer-resolution.service";
+import { ensureAutoJoin } from "../services/auto-join.service";
 import {
   filterArtifactToTempFile,
   streamTempParquet,
@@ -191,7 +192,11 @@ appsRoutes.use("*", async (c: AuthenticatedContext, next) => {
         );
       }
     } else if (user) {
-      const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+      // A stranger from a trusted domain joins here — this is the request a
+      // rep's first click on the app link makes (apps.md §27).
+      const hasAccess =
+        (await ensureAutoJoin(workspaceId, user)) !== null ||
+        (await workspaceService.hasAccess(workspaceId, user.id));
       if (!hasAccess) {
         return c.json(
           { success: false, error: "Access denied to workspace" },

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { JOB_ROLES } from "@mako/schemas";
+import { normalizeAutoJoin } from "../services/auto-join.service";
 import {
   isSessionAuth,
   unifiedAuthMiddleware,
@@ -31,7 +32,10 @@ import {
   optionalWorkspace,
 } from "../middleware/workspace.middleware";
 import { Types } from "mongoose";
-import { Workspace } from "../database/workspace-schema";
+import {
+  Workspace,
+  type IWorkspaceAutoJoin,
+} from "../database/workspace-schema";
 import { User } from "../database/schema";
 import { normalizeEmail } from "../utils/email.utils";
 import { loggers } from "../logging";
@@ -98,6 +102,14 @@ const AddMemberBody = jsonBody(
 const UpdateMemberBody = jsonBody(
   z.object({
     role: MemberRole.optional(),
+    jobRole: JobRoleField.nullable().optional(),
+    country: CountryField.nullable().optional(),
+  }),
+);
+const AutoJoinBody = jsonBody(
+  z.object({
+    domains: z.array(z.string()).max(20),
+    role: z.enum(["member", "viewer"]).default("viewer"),
     jobRole: JobRoleField.nullable().optional(),
     country: CountryField.nullable().optional(),
   }),
@@ -174,6 +186,16 @@ type WorkspaceMemberResponseSource = {
   country?: string;
   joinedAt: unknown;
 };
+
+function serializeAutoJoin(autoJoin: IWorkspaceAutoJoin | null | undefined) {
+  if (!autoJoin || autoJoin.domains.length === 0) return null;
+  return {
+    domains: autoJoin.domains,
+    role: autoJoin.role,
+    jobRole: autoJoin.jobRole ?? null,
+    country: autoJoin.country ?? null,
+  };
+}
 
 function serializeWorkspaceMember(member: WorkspaceMemberResponseSource) {
   const populatedUser =
@@ -1333,6 +1355,104 @@ workspaceRoutes.openapi(
           success: false,
           error:
             error instanceof Error ? error.message : "Failed to remove member",
+        },
+        500,
+      );
+    }
+  },
+);
+
+// Domain auto-join — read
+workspaceRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/auto-join",
+    tags: ["Workspaces"],
+    summary: "Domain auto-join settings",
+    description:
+      "Email domains whose signed-in users become members on first contact " +
+      "(no invitation), and the access role, job role and country they get. " +
+      "`null` when off. How a rep opens a published app link, signs in with " +
+      "Google and lands on their own view (apps.md §27).",
+    security: AUTH_SECURITY,
+    middleware: [
+      unifiedAuthMiddleware,
+      requireWorkspace,
+      requireWorkspaceRole(["owner", "admin"]),
+    ] as const,
+    request: { params: IdParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    const workspace = c.get("workspace");
+    if (c.req.param("id") !== workspace._id.toString()) {
+      return c.json({ success: false, error: "Workspace ID mismatch" }, 400);
+    }
+    const fresh = await workspaceService.getWorkspaceById(
+      workspace._id.toString(),
+    );
+    return c.json({
+      success: true,
+      data: serializeAutoJoin(fresh?.settings?.autoJoin),
+    });
+  },
+);
+
+// Domain auto-join — write (an empty domain list turns it off)
+workspaceRoutes.openapi(
+  createRoute({
+    method: "put",
+    path: "/{id}/auto-join",
+    tags: ["Workspaces"],
+    summary: "Set domain auto-join",
+    security: AUTH_SECURITY,
+    middleware: [
+      unifiedAuthMiddleware,
+      requireWorkspace,
+      requireWorkspaceRole(["owner", "admin"]),
+    ] as const,
+    request: { params: IdParam, body: AutoJoinBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspace = c.get("workspace");
+      const workspaceId = c.req.param("id");
+      if (workspaceId !== workspace._id.toString()) {
+        return c.json({ success: false, error: "Workspace ID mismatch" }, 400);
+      }
+      const body = c.req.valid("json");
+      const normalized = normalizeAutoJoin(body);
+      const rejected = body.domains
+        .filter(
+          d =>
+            !normalized?.domains.includes(
+              d.trim().toLowerCase().replace(/^@/, ""),
+            ),
+        )
+        .filter(d => d.trim() !== "");
+      if (rejected.length > 0) {
+        return c.json(
+          { success: false, error: `Not a domain: ${rejected.join(", ")}` },
+          400,
+        );
+      }
+      await workspaceService.setAutoJoin(workspaceId, normalized);
+      logger.info("Workspace auto-join updated", {
+        workspaceId,
+        by: c.get("user")?.id,
+        domains: normalized?.domains ?? [],
+      });
+      return c.json({ success: true, data: serializeAutoJoin(normalized) });
+    } catch (error) {
+      logger.error("Error updating auto-join", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to update auto-join",
         },
         500,
       );

--- a/api/src/services/auto-join.service.test.ts
+++ b/api/src/services/auto-join.service.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Domain auto-join: a signed-in person whose email domain a workspace lists
+ * becomes a member on first contact — with the access role, job role and
+ * country the workspace chose — so a rep who clicks the app link, signs in
+ * with Google, and lands on their own view, without an invitation.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { Workspace, WorkspaceMember } from "../database/workspace-schema";
+import { ensureAutoJoin, normalizeAutoJoin } from "./auto-join.service";
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId();
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+beforeEach(async () => {
+  await Workspace.deleteMany({});
+  await WorkspaceMember.deleteMany({});
+  await Workspace.create({
+    _id: WS,
+    name: "RealAdvisor",
+    slug: "realadvisor",
+    createdBy: "u-owner",
+    settings: {
+      autoJoin: {
+        domains: ["realadvisor.com"],
+        role: "viewer",
+        jobRole: "bdr",
+        country: "FR",
+      },
+    },
+    billing: {},
+  });
+});
+
+describe("ensureAutoJoin", () => {
+  it("makes a matching-domain stranger a member with the workspace's defaults", async () => {
+    const member = await ensureAutoJoin(WS.toString(), {
+      id: "u-sam",
+      email: "Sam@RealAdvisor.com",
+    });
+    expect(member).toMatchObject({
+      userId: "u-sam",
+      role: "viewer",
+      jobRole: "bdr",
+      country: "FR",
+    });
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(1);
+  });
+
+  it("is idempotent and never touches an existing membership", async () => {
+    await WorkspaceMember.create({
+      workspaceId: WS,
+      userId: "u-lead",
+      role: "admin",
+      jobRole: "team_leader",
+    });
+    const member = await ensureAutoJoin(WS.toString(), {
+      id: "u-lead",
+      email: "lead@realadvisor.com",
+    });
+    expect(member?.role).toBe("admin");
+    expect(member?.jobRole).toBe("team_leader");
+    await ensureAutoJoin(WS.toString(), {
+      id: "u-sam",
+      email: "sam@realadvisor.com",
+    });
+    await ensureAutoJoin(WS.toString(), {
+      id: "u-sam",
+      email: "sam@realadvisor.com",
+    });
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(2);
+  });
+
+  it("refuses other domains, sub-domains, and a workspace with no auto-join", async () => {
+    expect(
+      await ensureAutoJoin(WS.toString(), { id: "u-x", email: "x@gmail.com" }),
+    ).toBeNull();
+    expect(
+      await ensureAutoJoin(WS.toString(), {
+        id: "u-y",
+        email: "y@evil.realadvisor.com",
+      }),
+    ).toBeNull();
+    await Workspace.updateOne(
+      { _id: WS },
+      { $unset: { "settings.autoJoin": 1 } },
+    );
+    expect(
+      await ensureAutoJoin(WS.toString(), {
+        id: "u-z",
+        email: "z@realadvisor.com",
+      }),
+    ).toBeNull();
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(0);
+  });
+});
+
+describe("normalizeAutoJoin", () => {
+  it("lowercases and dedupes domains, rejects junk, and drops the block when no domain is left", () => {
+    expect(
+      normalizeAutoJoin({
+        domains: [
+          " RealAdvisor.com",
+          "realadvisor.com",
+          "@ra.ch",
+          "",
+          "not a domain",
+        ],
+        role: "viewer",
+        jobRole: "bdr",
+        country: "fr",
+      }),
+    ).toEqual({
+      domains: ["realadvisor.com", "ra.ch"],
+      role: "viewer",
+      jobRole: "bdr",
+      country: "FR",
+    });
+    expect(
+      normalizeAutoJoin({ domains: ["", "x"], role: "viewer" }),
+    ).toBeNull();
+    expect(normalizeAutoJoin(null)).toBeNull();
+  });
+});

--- a/api/src/services/auto-join.service.ts
+++ b/api/src/services/auto-join.service.ts
@@ -1,0 +1,123 @@
+/**
+ * Domain auto-join (apps.md §27).
+ *
+ * The flow it exists for: a rep gets the published app's link, clicks, signs
+ * in with Google, and lands on their own view — no invitation, no admin
+ * action per person. A workspace lists the email domains it trusts and the
+ * membership every newcomer from those domains gets (access role, job role,
+ * country); the first request that would otherwise be refused for "not a
+ * member" creates the membership instead. Exact domain match only: a
+ * sub-domain is somebody else's.
+ */
+import { Types } from "mongoose";
+import { isCountryCode, isJobRole } from "@mako/schemas";
+import {
+  Workspace,
+  WorkspaceMember,
+  type IWorkspaceAutoJoin,
+  type IWorkspaceMember,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+
+const logger = loggers.workspace();
+
+const DOMAIN_RE =
+  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+/**
+ * Clean a submitted auto-join block: domains lowercased, de-duplicated,
+ * a leading `@` tolerated, junk dropped. Null when nothing valid is left —
+ * which also means "turn auto-join off".
+ */
+export function normalizeAutoJoin(
+  input: {
+    domains?: unknown;
+    role?: unknown;
+    jobRole?: unknown;
+    country?: unknown;
+  } | null,
+): IWorkspaceAutoJoin | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = Array.isArray(input.domains) ? input.domains : [];
+  const domains: string[] = [];
+  for (const d of raw) {
+    if (typeof d !== "string") continue;
+    const clean = d.trim().toLowerCase().replace(/^@/, "");
+    if (DOMAIN_RE.test(clean) && !domains.includes(clean)) domains.push(clean);
+  }
+  if (domains.length === 0) return null;
+  const out: IWorkspaceAutoJoin = {
+    domains,
+    role: input.role === "member" ? "member" : "viewer",
+  };
+  if (isJobRole(input.jobRole)) out.jobRole = input.jobRole;
+  if (typeof input.country === "string") {
+    const c = input.country.trim().toUpperCase();
+    if (isCountryCode(c)) out.country = c;
+  }
+  return out;
+}
+
+export function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at === -1) return null;
+  return (
+    email
+      .slice(at + 1)
+      .trim()
+      .toLowerCase() || null
+  );
+}
+
+/**
+ * The person's membership in `workspaceId`, creating it when the workspace
+ * auto-joins their email domain. Null when they are not a member and the
+ * domain is not trusted. Safe to call on every request: one read for a
+ * member, and the (workspaceId, userId) unique index makes a concurrent
+ * first contact create exactly one row.
+ */
+export async function ensureAutoJoin(
+  workspaceId: string,
+  user: { id: string; email?: string | null },
+): Promise<IWorkspaceMember | null> {
+  if (!Types.ObjectId.isValid(workspaceId)) return null;
+  const wsId = new Types.ObjectId(workspaceId);
+  const existing = await WorkspaceMember.findOne({
+    workspaceId: wsId,
+    userId: user.id,
+  });
+  if (existing) return existing;
+
+  const domain = user.email ? emailDomain(user.email) : null;
+  if (!domain) return null;
+  const workspace = await Workspace.findById(wsId)
+    .select("settings.autoJoin")
+    .lean<{ settings?: { autoJoin?: IWorkspaceAutoJoin } }>();
+  const autoJoin = workspace?.settings?.autoJoin;
+  if (!autoJoin || !autoJoin.domains?.includes(domain)) return null;
+
+  try {
+    const member = await WorkspaceMember.create({
+      workspaceId: wsId,
+      userId: user.id,
+      role: autoJoin.role ?? "viewer",
+      ...(autoJoin.jobRole ? { jobRole: autoJoin.jobRole } : {}),
+      ...(autoJoin.country ? { country: autoJoin.country } : {}),
+      joinedAt: new Date(),
+    });
+    logger.info("Auto-joined a member by email domain", {
+      workspaceId,
+      userId: user.id,
+      domain,
+      role: member.role,
+      jobRole: member.jobRole ?? null,
+    });
+    return member;
+  } catch (error) {
+    // Lost a race with another first request: the row now exists.
+    if ((error as { code?: number }).code === 11000) {
+      return WorkspaceMember.findOne({ workspaceId: wsId, userId: user.id });
+    }
+    throw error;
+  }
+}

--- a/api/src/services/workspace.service.ts
+++ b/api/src/services/workspace.service.ts
@@ -7,6 +7,7 @@ import {
   IWorkspace,
   IWorkspaceMember,
   IWorkspaceInvite,
+  type IWorkspaceAutoJoin,
 } from "../database/workspace-schema";
 import { Session, User } from "../database/schema";
 import { v4 as uuidv4 } from "uuid";
@@ -184,6 +185,20 @@ export class WorkspaceService {
     updates: Partial<IWorkspace>,
   ): Promise<IWorkspace | null> {
     return Workspace.findByIdAndUpdate(workspaceId, updates, { new: true });
+  }
+
+  /** Domain auto-join settings; null turns it off. */
+  async setAutoJoin(
+    workspaceId: string,
+    autoJoin: IWorkspaceAutoJoin | null,
+  ): Promise<void> {
+    await Workspace.updateOne(
+      { _id: new Types.ObjectId(workspaceId) },
+      autoJoin
+        ? { $set: { "settings.autoJoin": autoJoin } }
+        : { $unset: { "settings.autoJoin": 1 } },
+      { runValidators: true },
+    );
   }
 
   /**

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       "src/apps/viewers.service.test.ts",
       "src/apps/filtered-parquet.service.test.ts",
       "src/apps/deployment.viewers.test.ts",
+      "src/services/auto-join.service.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",
       // These two were written as vitest suites but listed in no vitest
       // config, so neither runner could execute them: tsx dies on them

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -541,6 +541,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{id}/auto-join": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Domain auto-join settings
+         * @description Email domains whose signed-in users become members on first contact (no invitation), and the access role, job role and country they get. `null` when off. How a rep opens a published app link, signs in with Google and lands on their own view (apps.md §27).
+         */
+        get: operations["get_api_workspaces_id_auto_join"];
+        /** Set domain auto-join */
+        put: operations["put_api_workspaces_id_auto_join"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{id}/invites": {
         parameters: {
             query?: never;
@@ -7757,6 +7778,100 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_id_auto_join: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    put_api_workspaces_id_auto_join: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    domains: string[];
+                    /**
+                     * @default viewer
+                     * @enum {string}
+                     */
+                    role?: "member" | "viewer";
+                    /** @enum {string|null} */
+                    jobRole?: "sdr" | "bdr" | "csm" | "head_of_csm" | "team_leader" | "developer" | "admin" | null;
+                    country?: string | null;
+                };
+            };
+        };
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Box,
   Typography,
@@ -40,6 +40,7 @@ import {
   type JobRole,
 } from "@mako/schemas";
 import { useWorkspace } from "../contexts/workspace-context";
+import { workspaceClient } from "../lib/workspace-client";
 import { useAuth } from "../contexts/auth-context";
 import { trackEvent } from "../lib/analytics";
 import { useConfirm } from "./ConfirmDialog";
@@ -293,6 +294,8 @@ export function WorkspaceMembers() {
           {successMessage}
         </Alert>
       )}
+
+      {canManageMembers && <AutoJoinCard workspaceId={currentWorkspace.id} />}
 
       <TableContainer
         component={Paper}
@@ -618,5 +621,181 @@ export function WorkspaceMembers() {
         </DialogActions>
       </Dialog>
     </Box>
+  );
+}
+
+/**
+ * Domain auto-join: anyone signing in with an email on these domains joins
+ * the workspace on first contact — no invitation — with these defaults. The
+ * way a rep clicks a published app's link, signs in with Google, and lands
+ * on their own view.
+ */
+function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
+  const [loaded, setLoaded] = useState(false);
+  const [domains, setDomains] = useState("");
+  const [role, setRole] = useState<"member" | "viewer">("viewer");
+  const [jobRole, setJobRole] = useState<JobRole | "">("");
+  const [country, setCountry] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    workspaceClient
+      .getAutoJoin(workspaceId)
+      .then(current => {
+        if (cancelled) return;
+        setDomains(current?.domains.join(", ") ?? "");
+        setRole(current?.role ?? "viewer");
+        setJobRole(current?.jobRole ?? "");
+        setCountry(current?.country ?? "");
+      })
+      .catch((e: any) => setError(e.message || "Failed to load auto-join"))
+      .finally(() => !cancelled && setLoaded(true));
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const list = domains
+        .split(/[,\s]+/)
+        .map(d => d.trim())
+        .filter(Boolean);
+      const saved = await workspaceClient.setAutoJoin(workspaceId, {
+        domains: list,
+        role,
+        jobRole: jobRole || null,
+        country: country || null,
+      });
+      setMessage(
+        saved
+          ? `Anyone with an email on ${saved.domains.join(", ")} now joins as ${saved.role}` +
+              (saved.jobRole ? ` · ${JOB_ROLE_LABELS[saved.jobRole]}` : "") +
+              (saved.country ? ` · ${saved.country}` : "") +
+              " the first time they open the workspace or one of its apps."
+          : "Auto-join is off.",
+      );
+      setTimeout(() => setMessage(null), 6000);
+    } catch (e: any) {
+      setError(e.message || "Failed to save auto-join");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        mb: 2,
+        boxShadow: "none",
+        border: "1px solid rgba(224, 224, 224, 1)",
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        Auto-join by email domain
+      </Typography>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mb: 1.5 }}
+      >
+        People who sign in with an email on these domains become members the
+        first time they open the workspace or one of its apps — no invitation
+        needed — with the access role, job role and country below. Leave the
+        domains empty to turn it off.
+      </Typography>
+      {error && (
+        <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {message && (
+        <Alert
+          severity="success"
+          sx={{ mb: 1.5 }}
+          onClose={() => setMessage(null)}
+        >
+          {message}
+        </Alert>
+      )}
+      <Box
+        sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}
+      >
+        <TextField
+          size="small"
+          label="Domains"
+          placeholder="acme.com, acme.ch"
+          value={domains}
+          onChange={e => setDomains(e.target.value)}
+          disabled={!loaded || saving}
+          sx={{ minWidth: 260, flex: 1 }}
+        />
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel>Access</InputLabel>
+          <Select
+            value={role}
+            label="Access"
+            onChange={e => setRole(e.target.value as "member" | "viewer")}
+            disabled={!loaded || saving}
+          >
+            <MenuItem value="viewer">Viewer</MenuItem>
+            <MenuItem value="member">Member</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel>Job role</InputLabel>
+          <Select
+            value={jobRole}
+            label="Job role"
+            onChange={e => setJobRole(e.target.value as JobRole | "")}
+            disabled={!loaded || saving}
+          >
+            <MenuItem value="">
+              <em>Not set</em>
+            </MenuItem>
+            {JOB_ROLES.map(r => (
+              <MenuItem key={r} value={r}>
+                {JOB_ROLE_LABELS[r]}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 110 }}>
+          <InputLabel>Country</InputLabel>
+          <Select
+            value={country}
+            label="Country"
+            onChange={e => setCountry(e.target.value)}
+            disabled={!loaded || saving}
+            MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+          >
+            <MenuItem value="">
+              <em>Not set</em>
+            </MenuItem>
+            {COUNTRY_CODES.map(code => (
+              <MenuItem key={code} value={code}>
+                {code} · {countryName(code)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          size="small"
+          onClick={save}
+          disabled={!loaded || saving}
+        >
+          {saving ? <CircularProgress size={18} /> : "Save"}
+        </Button>
+      </Box>
+    </Paper>
   );
 }

--- a/app/src/lib/workspace-client.ts
+++ b/app/src/lib/workspace-client.ts
@@ -96,6 +96,14 @@ export interface InviteMemberData {
   country?: string;
 }
 
+/** Domain auto-join: who joins by email domain, and as what. null = off. */
+export interface WorkspaceAutoJoin {
+  domains: string[];
+  role: "member" | "viewer";
+  jobRole: JobRole | null;
+  country: string | null;
+}
+
 /** Any subset; null clears a profile field. */
 export interface UpdateMemberData {
   role?: "admin" | "member" | "viewer";
@@ -231,6 +239,35 @@ class WorkspaceClient {
       }),
     );
     return body.data as WorkspaceMember;
+  }
+
+  /** Domain auto-join settings (owner/admin). */
+  async getAutoJoin(workspaceId: string): Promise<WorkspaceAutoJoin | null> {
+    const body = unwrap(
+      await api.GET("/api/workspaces/{id}/auto-join", {
+        params: { path: { id: workspaceId } },
+      }),
+    );
+    return (body.data ?? null) as WorkspaceAutoJoin | null;
+  }
+
+  /** An empty domain list turns auto-join off. */
+  async setAutoJoin(
+    workspaceId: string,
+    data: {
+      domains: string[];
+      role: "member" | "viewer";
+      jobRole?: JobRole | null;
+      country?: string | null;
+    },
+  ): Promise<WorkspaceAutoJoin | null> {
+    const body = unwrap(
+      await api.PUT("/api/workspaces/{id}/auto-join", {
+        params: { path: { id: workspaceId } },
+        body: data,
+      }),
+    );
+    return (body.data ?? null) as WorkspaceAutoJoin | null;
   }
 
   /**

--- a/apps.md
+++ b/apps.md
@@ -3161,7 +3161,17 @@ skills — the posture every other kind already had.
 > que moi, jonas et joan devont avoir un role d'admin et que les admin
 > doivent tout voir"* — so the `admin` job role bypasses every `roles` list
 > and every row filter (`rowFilterFor`), and a workspace owner/admin with no
-> job role IS an admin viewer (`viewerFromMember`). The trade Théo accepted: someone
+> job role IS an admin viewer (`viewerFromMember`). And, later the same day:
+> *"un bdr reçoit le lien généraliste du dashboard, il clique, il passe par
+> gauth mako, et pouf il est sur sa vue personnelle et c'est tout"* — no
+> invitation, no per-rep admin action. Hence **domain auto-join**
+> (`settings.autoJoin`, Members page): a signed-in stranger whose email
+> domain the workspace lists becomes a member at the first request that
+> would have refused them (the apps router's access check, and
+> `requireWorkspace`), with the workspace's default access role, job role
+> and country — RealAdvisor: `realadvisor.com` → viewer / bdr / FR. The
+> published app's live URL already gates on login with `returnTo`, so the
+> chain is link → Google → auto-join → served as `bdr`. The trade Théo accepted: someone
 > edits the member list when a rep joins or moves, instead of the CRM roster
 > doing it. What follows is the history of how the enforcement path (which
 > stands) was arrived at; read "role" below as "job role from the membership"

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -4276,6 +4276,195 @@
         "operationId": "delete_api_workspaces_id_members_userId"
       }
     },
+    "/api/workspaces/{id}/auto-join": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Domain auto-join settings",
+        "description": "Email domains whose signed-in users become members on first contact (no invitation), and the access role, job role and country they get. `null` when off. How a rep opens a published app link, signs in with Google and lands on their own view (apps.md §27).",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_id_auto_join"
+      },
+      "put": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Set domain auto-join",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "domains": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 20
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "member",
+                      "viewer"
+                    ],
+                    "default": "viewer"
+                  },
+                  "jobRole": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "sdr",
+                      "bdr",
+                      "csm",
+                      "head_of_csm",
+                      "team_leader",
+                      "developer",
+                      "admin",
+                      null
+                    ]
+                  },
+                  "country": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "domains"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "put_api_workspaces_id_auto_join"
+      }
+    },
     "/api/workspaces/{id}/invites": {
       "post": {
         "tags": [


### PR DESCRIPTION
## What

A person who signs in with an email on a domain the workspace trusts becomes a member the first time they open the workspace or one of its apps — no invitation — with the access role, job role and country the workspace chose.

The flow it exists for (apps.md §27): a rep gets a published app's link, clicks, signs in with Google, and lands on their own view. The live URL already gates on login with `returnTo`; this adds the missing step between "signed in" and "member".

- `Workspace.settings.autoJoin { domains, role: member|viewer, jobRole?, country? }`
- `GET` / `PUT /workspaces/{id}/auto-join` (owner/admin); an empty domain list turns it off
- "Auto-join by email domain" card on the Members page
- `ensureAutoJoin(workspaceId, user)`: exact domain match (no sub-domains), idempotent, race-safe on the `(workspaceId, userId)` unique index; wired in the apps router's access check and in `requireWorkspace`

## Tests

`auto-join.service.test.ts` (mongo-memory): defaults applied, existing membership untouched, other/sub-domains and no-config refused, normalization (lowercase, dedupe, `@` tolerated, junk rejected). Both API suites green locally on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXchWya6usKHaWsRfL7pH5