### PR TITLE
Revert #985 — pending-profile gate crashed the IDE (useWorkspace outside WorkspaceProvider)

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -189,11 +189,8 @@ export interface IWorkspaceAutoJoin {
   /** Lowercase email domains, exact match (no sub-domains). */
   domains: string[];
   role: "member" | "viewer";
-  /** Set = newcomers get it at once. Unset = they wait for an admin (profilePending). */
   jobRole?: JobRole;
   country?: string;
-  /** Slack incoming webhook (encrypted) told about each newcomer waiting for a role. */
-  slackWebhookUrlEncrypted?: string;
 }
 
 /**
@@ -212,13 +209,6 @@ export interface IWorkspaceMember extends Document {
   jobRole?: JobRole;
   /** ISO 3166-1 alpha-2; the viewer's `country` claim. */
   country?: string;
-  /**
-   * Auto-joined without a job role: waiting for an admin to set one. Until
-   * then the person sees a "please wait" page instead of apps or the IDE.
-   */
-  profilePending?: boolean;
-  /** Where they were going when they joined — what the "you're in" email links to. */
-  pendingReturnTo?: string;
   joinedAt: Date;
   /** True only for the first workspace auto-created during user onboarding */
   isDefaultMembership?: boolean;
@@ -1345,7 +1335,6 @@ const WorkspaceSchema = new Schema<IWorkspace>(
               trim: true,
               match: /^[A-Z]{2}$/,
             },
-            slackWebhookUrlEncrypted: { type: String },
           },
           { _id: false },
         ),
@@ -1481,8 +1470,6 @@ const WorkspaceMemberSchema = new Schema<IWorkspaceMember>({
   },
   jobRole: { type: String, enum: JOB_ROLES },
   country: { type: String, uppercase: true, trim: true, match: /^[A-Z]{2}$/ },
-  profilePending: { type: Boolean },
-  pendingReturnTo: { type: String },
   joinedAt: {
     type: Date,
     default: Date.now,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -146,10 +146,7 @@ import {
   rowFilterFor,
 } from "../apps/viewers.service";
 import { resolveViewerFor } from "../apps/viewer-resolution.service";
-import {
-  ensureAutoJoin,
-  pendingProfileHtml,
-} from "../services/auto-join.service";
+import { ensureAutoJoin } from "../services/auto-join.service";
 import {
   filterArtifactToTempFile,
   streamTempParquet,
@@ -198,8 +195,8 @@ appsRoutes.use("*", async (c: AuthenticatedContext, next) => {
       // A stranger from a trusted domain joins here — this is the request a
       // rep's first click on the app link makes (apps.md §27).
       const hasAccess =
-        (await ensureAutoJoin(workspaceId, user, { returnTo: c.req.path })) !==
-          null || (await workspaceService.hasAccess(workspaceId, user.id));
+        (await ensureAutoJoin(workspaceId, user)) !== null ||
+        (await workspaceService.hasAccess(workspaceId, user.id));
       if (!hasAccess) {
         return c.json(
           { success: false, error: "Access denied to workspace" },
@@ -2523,46 +2520,12 @@ async function serveLive(c: AuthenticatedContext): Promise<Response> {
   const marker = `/apps/${ref}/live`;
   const at = c.req.path.indexOf(marker);
   const rest = at === -1 ? "" : c.req.path.slice(at + marker.length);
-  const assetPath = rest.replace(/^\/+/, "");
-
-  // A member still waiting for an admin to set their job role (domain
-  // auto-join, apps.md §27) gets the waiting page instead of the app.
-  const self = viewerOf(c);
-  if (self) {
-    const member = await workspaceService.getMember(
-      project.workspaceId.toString(),
-      self.id,
-    );
-    if (member?.profilePending) {
-      if (assetPath === "" || assetPath === "index.html") {
-        const workspace = await workspaceService.getWorkspaceById(
-          project.workspaceId.toString(),
-        );
-        return c.html(
-          pendingProfileHtml({
-            email: self.email,
-            workspaceName: workspace?.name ?? "Mako",
-          }),
-          403,
-          { "Cache-Control": "no-store" },
-        );
-      }
-      return c.json(
-        {
-          success: false,
-          error:
-            "Your signup is waiting for an administrator to set your role.",
-        },
-        403,
-      );
-    }
-  }
 
   const response = await serveDeploymentFile({
     projectId,
     sha,
-    assetPath,
-    viewer: self,
+    assetPath: rest.replace(/^\/+/, ""),
+    viewer: viewerOf(c),
   });
   return response ?? c.json({ success: false, error: "Not found" }, 404);
 }

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -35,7 +35,6 @@ import { Types } from "mongoose";
 import {
   Workspace,
   type IWorkspaceAutoJoin,
-  encrypt,
 } from "../database/workspace-schema";
 import { User } from "../database/schema";
 import { normalizeEmail } from "../utils/email.utils";
@@ -113,8 +112,6 @@ const AutoJoinBody = jsonBody(
     role: z.enum(["member", "viewer"]).default("viewer"),
     jobRole: JobRoleField.nullable().optional(),
     country: CountryField.nullable().optional(),
-    /** Slack incoming webhook for "please assign role to …"; null clears, absent keeps. */
-    slackWebhookUrl: z.string().url().max(500).nullable().optional(),
   }),
 );
 const CreateInviteBody = jsonBody(
@@ -187,7 +184,6 @@ type WorkspaceMemberResponseSource = {
   role: string;
   jobRole?: string;
   country?: string;
-  profilePending?: boolean;
   joinedAt: unknown;
 };
 
@@ -198,7 +194,6 @@ function serializeAutoJoin(autoJoin: IWorkspaceAutoJoin | null | undefined) {
     role: autoJoin.role,
     jobRole: autoJoin.jobRole ?? null,
     country: autoJoin.country ?? null,
-    slackWebhookConfigured: !!autoJoin.slackWebhookUrlEncrypted,
   };
 }
 
@@ -215,7 +210,6 @@ function serializeWorkspaceMember(member: WorkspaceMemberResponseSource) {
     role: member.role,
     jobRole: member.jobRole ?? null,
     country: member.country ?? null,
-    profilePending: member.profilePending === true,
     joinedAt: member.joinedAt,
   };
 }
@@ -313,13 +307,11 @@ workspaceRoutes.openapi(
       const workspaces = await workspaceService.getWorkspacesForUser(user.id);
       return c.json({
         success: true,
-        data: workspaces.map(({ workspace, role, profilePending }) => ({
+        data: workspaces.map(({ workspace, role }) => ({
           id: workspace._id,
           name: workspace.name,
           slug: workspace.slug,
           role,
-          // Waiting for an admin to set a job role (domain auto-join).
-          profilePending: profilePending === true,
           createdAt: workspace.createdAt,
           updatedAt: workspace.updatedAt,
           settings: workspace.settings,
@@ -1284,7 +1276,7 @@ workspaceRoutes.openapi(
       const updatedMember = await workspaceService.updateMember(
         workspaceId,
         userId,
-        { role, jobRole, country, actor: c.get("user")?.email },
+        { role, jobRole, country },
       );
 
       if (!updatedMember) {
@@ -1431,28 +1423,6 @@ workspaceRoutes.openapi(
       }
       const body = c.req.valid("json");
       const normalized = normalizeAutoJoin(body);
-      if (normalized) {
-        const current = (await workspaceService.getWorkspaceById(workspaceId))
-          ?.settings?.autoJoin;
-        if (body.slackWebhookUrl === undefined) {
-          if (current?.slackWebhookUrlEncrypted) {
-            normalized.slackWebhookUrlEncrypted =
-              current.slackWebhookUrlEncrypted;
-          }
-        } else if (body.slackWebhookUrl) {
-          if (!/^https:\/\/hooks\.slack\.com\//.test(body.slackWebhookUrl)) {
-            return c.json(
-              {
-                success: false,
-                error:
-                  "The Slack webhook must start with https://hooks.slack.com/",
-              },
-              400,
-            );
-          }
-          normalized.slackWebhookUrlEncrypted = encrypt(body.slackWebhookUrl);
-        }
-      }
       const rejected = body.domains
         .filter(
           d =>

--- a/api/src/services/auto-join.service.test.ts
+++ b/api/src/services/auto-join.service.test.ts
@@ -8,12 +8,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import mongoose, { Types } from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { Workspace, WorkspaceMember } from "../database/workspace-schema";
-import {
-  completePendingProfile,
-  ensureAutoJoin,
-  normalizeAutoJoin,
-  pendingProfileHtml,
-} from "./auto-join.service";
+import { ensureAutoJoin, normalizeAutoJoin } from "./auto-join.service";
 
 let mongo: MongoMemoryServer;
 const WS = new Types.ObjectId();
@@ -134,121 +129,5 @@ describe("normalizeAutoJoin", () => {
       normalizeAutoJoin({ domains: ["", "x"], role: "viewer" }),
     ).toBeNull();
     expect(normalizeAutoJoin(null)).toBeNull();
-  });
-});
-
-describe("pending profile — the general case: no default job role", () => {
-  const notifications: string[] = [];
-  const hooks = {
-    slack: async (text: string) => {
-      notifications.push("slack:" + text);
-    },
-    email: async (to: string, subject: string) => {
-      notifications.push(`email:${to}:${subject}`);
-    },
-  };
-  beforeEach(async () => {
-    notifications.length = 0;
-    await Workspace.updateOne(
-      { _id: WS },
-      {
-        $set: {
-          "settings.autoJoin": {
-            domains: ["realadvisor.com"],
-            role: "viewer",
-            slackWebhookUrlEncrypted: "enc",
-          },
-        },
-      },
-    );
-  });
-
-  it("joins as pending, and tells the admins' Slack channel who needs a role", async () => {
-    const member = await ensureAutoJoin(
-      WS.toString(),
-      { id: "u-new", email: "new.rep@realadvisor.com" },
-      { returnTo: "/api/workspaces/x/apps/fr-sales-dashboard/live/", hooks },
-    );
-    expect(member).toMatchObject({ role: "viewer", profilePending: true });
-    expect(member?.jobRole).toBeUndefined();
-    expect(member?.pendingReturnTo).toBe(
-      "/api/workspaces/x/apps/fr-sales-dashboard/live/",
-    );
-    expect(notifications).toHaveLength(1);
-    expect(notifications[0]).toMatch(/^slack:.*new\.rep@realadvisor\.com/);
-    expect(notifications[0]).toMatch(/settings\/members/);
-    // A second contact does not nag the channel again.
-    await ensureAutoJoin(
-      WS.toString(),
-      { id: "u-new", email: "new.rep@realadvisor.com" },
-      { hooks },
-    );
-    expect(notifications).toHaveLength(1);
-  });
-
-  it("a default job role skips the queue entirely", async () => {
-    await Workspace.updateOne(
-      { _id: WS },
-      { $set: { "settings.autoJoin.jobRole": "bdr" } },
-    );
-    const member = await ensureAutoJoin(
-      WS.toString(),
-      { id: "u-sam", email: "sam@realadvisor.com" },
-      { hooks },
-    );
-    expect(member?.profilePending).toBeFalsy();
-    expect(member?.jobRole).toBe("bdr");
-    expect(notifications).toHaveLength(0);
-  });
-
-  it("completing the profile clears the wait, emails the person, and closes the loop on Slack", async () => {
-    await ensureAutoJoin(
-      WS.toString(),
-      { id: "u-new", email: "new.rep@realadvisor.com" },
-      { returnTo: "/apps/fr-sales-dashboard", hooks },
-    );
-    notifications.length = 0;
-    const done = await completePendingProfile(
-      WS.toString(),
-      "u-new",
-      {
-        email: "new.rep@realadvisor.com",
-        jobRole: "bdr",
-        country: "FR",
-        actor: "theo@realadvisor.com",
-      },
-      hooks,
-    );
-    expect(done).toBe(true);
-    const member = await WorkspaceMember.findOne({
-      workspaceId: WS,
-      userId: "u-new",
-    });
-    expect(member?.profilePending).toBeFalsy();
-    expect(member?.pendingReturnTo).toBeUndefined();
-    expect(
-      notifications.some(n => n.startsWith("email:new.rep@realadvisor.com:")),
-    ).toBe(true);
-    expect(
-      notifications.some(n => n.startsWith("slack:") && /BDR/i.test(n)),
-    ).toBe(true);
-    // Not pending any more: a second completion is a no-op.
-    expect(
-      await completePendingProfile(
-        WS.toString(),
-        "u-new",
-        { email: "new.rep@realadvisor.com", jobRole: "bdr" },
-        hooks,
-      ),
-    ).toBe(false);
-  });
-
-  it("renders a waiting page that reloads itself", () => {
-    const html = pendingProfileHtml({
-      email: "new.rep@realadvisor.com",
-      workspaceName: "RealAdvisor",
-    });
-    expect(html).toMatch(/administrat/i);
-    expect(html).toMatch(/http-equiv="refresh"/);
   });
 });

--- a/api/src/services/auto-join.service.ts
+++ b/api/src/services/auto-join.service.ts
@@ -2,30 +2,21 @@
  * Domain auto-join (apps.md §27).
  *
  * The flow it exists for: a rep gets the published app's link, clicks, signs
- * in with Google, and is in — no invitation. A workspace lists the email
- * domains it trusts and the access role newcomers get. Then, the general
- * case Théo wants: the newcomer WAITS ("veuillez attendre qu'un
- * administrateur finalise votre inscription"), the admins' Slack channel is
- * told "please assign role and country to <email>", and once an admin sets
- * the job role on the Members page the person gets an email and the page
- * lets them through. A workspace that sets a default job role skips the
- * queue. Exact domain match only: a sub-domain is somebody else's.
+ * in with Google, and lands on their own view — no invitation, no admin
+ * action per person. A workspace lists the email domains it trusts and the
+ * membership every newcomer from those domains gets (access role, job role,
+ * country); the first request that would otherwise be refused for "not a
+ * member" creates the membership instead. Exact domain match only: a
+ * sub-domain is somebody else's.
  */
 import { Types } from "mongoose";
-import {
-  isCountryCode,
-  isJobRole,
-  JOB_ROLE_LABELS,
-  type JobRole,
-} from "@mako/schemas";
+import { isCountryCode, isJobRole } from "@mako/schemas";
 import {
   Workspace,
   WorkspaceMember,
-  decrypt,
   type IWorkspaceAutoJoin,
   type IWorkspaceMember,
 } from "../database/workspace-schema";
-import { emailService } from "./email.service";
 import { loggers } from "../logging";
 
 const logger = loggers.workspace();
@@ -33,41 +24,10 @@ const logger = loggers.workspace();
 const DOMAIN_RE =
   /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
 
-/** How the outside world is told — injectable so tests see the messages. */
-export interface AutoJoinHooks {
-  slack: (text: string, webhookUrl: string) => Promise<void>;
-  email: (
-    to: string,
-    subject: string,
-    body: { html: string; text: string },
-  ) => Promise<void>;
-}
-
-async function postSlack(text: string, webhookUrl: string): Promise<void> {
-  const response = await fetch(webhookUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      text,
-      blocks: [{ type: "section", text: { type: "mrkdwn", text } }],
-    }),
-  });
-  if (!response.ok) {
-    throw new Error(`Slack webhook HTTP ${response.status}`);
-  }
-}
-
-const defaultHooks: AutoJoinHooks = {
-  slack: postSlack,
-  email: (to, subject, body) =>
-    emailService.sendFlowRunNotificationEmails([to], { subject, ...body }),
-};
-
 /**
  * Clean a submitted auto-join block: domains lowercased, de-duplicated,
  * a leading `@` tolerated, junk dropped. Null when nothing valid is left —
- * which also means "turn auto-join off". The Slack webhook is handled by
- * the route (it is stored encrypted).
+ * which also means "turn auto-join off".
  */
 export function normalizeAutoJoin(
   input: {
@@ -109,22 +69,6 @@ export function emailDomain(email: string): string | null {
   );
 }
 
-function clientUrl(): string {
-  return (process.env.CLIENT_URL || "https://app.mako.ai").replace(/\/+$/, "");
-}
-
-function safeReturnTo(value: string | undefined): string | undefined {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return undefined;
-  }
-  return value.slice(0, 500);
-}
-
-type AutoJoinWorkspace = {
-  name?: string;
-  settings?: { autoJoin?: IWorkspaceAutoJoin };
-};
-
 /**
  * The person's membership in `workspaceId`, creating it when the workspace
  * auto-joins their email domain. Null when they are not a member and the
@@ -135,7 +79,6 @@ type AutoJoinWorkspace = {
 export async function ensureAutoJoin(
   workspaceId: string,
   user: { id: string; email?: string | null },
-  opts: { returnTo?: string; hooks?: AutoJoinHooks } = {},
 ): Promise<IWorkspaceMember | null> {
   if (!Types.ObjectId.isValid(workspaceId)) return null;
   const wsId = new Types.ObjectId(workspaceId);
@@ -148,25 +91,28 @@ export async function ensureAutoJoin(
   const domain = user.email ? emailDomain(user.email) : null;
   if (!domain) return null;
   const workspace = await Workspace.findById(wsId)
-    .select("name settings.autoJoin")
-    .lean<AutoJoinWorkspace>();
+    .select("settings.autoJoin")
+    .lean<{ settings?: { autoJoin?: IWorkspaceAutoJoin } }>();
   const autoJoin = workspace?.settings?.autoJoin;
   if (!autoJoin || !autoJoin.domains?.includes(domain)) return null;
 
-  const pending = !autoJoin.jobRole;
-  const returnTo = pending ? safeReturnTo(opts.returnTo) : undefined;
-  let member: IWorkspaceMember;
   try {
-    member = await WorkspaceMember.create({
+    const member = await WorkspaceMember.create({
       workspaceId: wsId,
       userId: user.id,
       role: autoJoin.role ?? "viewer",
       ...(autoJoin.jobRole ? { jobRole: autoJoin.jobRole } : {}),
       ...(autoJoin.country ? { country: autoJoin.country } : {}),
-      ...(pending ? { profilePending: true } : {}),
-      ...(returnTo ? { pendingReturnTo: returnTo } : {}),
       joinedAt: new Date(),
     });
+    logger.info("Auto-joined a member by email domain", {
+      workspaceId,
+      userId: user.id,
+      domain,
+      role: member.role,
+      jobRole: member.jobRole ?? null,
+    });
+    return member;
   } catch (error) {
     // Lost a race with another first request: the row now exists.
     if ((error as { code?: number }).code === 11000) {
@@ -174,132 +120,4 @@ export async function ensureAutoJoin(
     }
     throw error;
   }
-  logger.info("Auto-joined a member by email domain", {
-    workspaceId,
-    userId: user.id,
-    domain,
-    role: member.role,
-    jobRole: member.jobRole ?? null,
-    pending,
-  });
-
-  if (pending && autoJoin.slackWebhookUrlEncrypted) {
-    const hooks = opts.hooks ?? defaultHooks;
-    const membersUrl = `${clientUrl()}/settings/members`;
-    const text =
-      `:new: *${user.email}* vient de rejoindre *${workspace?.name ?? "Mako"}* et attend son rôle.\n` +
-      `Please assign role and country to ${user.email} — <${membersUrl}|Members page>.`;
-    try {
-      await hooks.slack(
-        text,
-        hooks === defaultHooks
-          ? decrypt(autoJoin.slackWebhookUrlEncrypted)
-          : "test",
-      );
-    } catch (error) {
-      logger.warn("Auto-join Slack notification failed", {
-        workspaceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-  return member;
-}
-
-/**
- * An admin set the job role of a member who was waiting: clear the wait,
- * email the person ("c'est bon, tu peux y aller" with the link they wanted),
- * and close the loop in the admins' Slack channel. True when there was
- * something to complete.
- */
-export async function completePendingProfile(
-  workspaceId: string,
-  userId: string,
-  done: {
-    email: string;
-    jobRole: JobRole | string;
-    country?: string | null;
-    actor?: string;
-  },
-  hooks: AutoJoinHooks = defaultHooks,
-): Promise<boolean> {
-  const wsId = new Types.ObjectId(workspaceId);
-  const member = await WorkspaceMember.findOneAndUpdate(
-    { workspaceId: wsId, userId, profilePending: true },
-    { $unset: { profilePending: 1, pendingReturnTo: 1 } },
-    { new: false },
-  );
-  if (!member) return false;
-  const workspace = await Workspace.findById(wsId)
-    .select("name settings.autoJoin")
-    .lean<AutoJoinWorkspace>();
-  const name = workspace?.name ?? "Mako";
-  const link = `${clientUrl()}${member.pendingReturnTo ?? "/"}`;
-  const label = isJobRole(done.jobRole)
-    ? JOB_ROLE_LABELS[done.jobRole]
-    : String(done.jobRole);
-  const country = done.country ? ` · ${done.country}` : "";
-  try {
-    await hooks.email(done.email, `Votre accès ${name} est prêt`, {
-      text:
-        `Bonjour,\n\nUn administrateur a finalisé votre inscription sur ${name} : rôle ${label}` +
-        (done.country ? `, pays ${done.country}` : "") +
-        `.\n\nVous pouvez y aller : ${link}\n`,
-      html:
-        `<p>Bonjour,</p><p>Un administrateur a finalisé votre inscription sur <b>${name}</b> : rôle <b>${label}</b>` +
-        (done.country ? `, pays <b>${done.country}</b>` : "") +
-        `.</p><p><a href="${link}">Vous pouvez y aller →</a></p>`,
-    });
-  } catch (error) {
-    logger.warn("Profile-complete email failed", {
-      workspaceId,
-      userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-  const webhook = workspace?.settings?.autoJoin?.slackWebhookUrlEncrypted;
-  if (webhook) {
-    try {
-      await hooks.slack(
-        `:white_check_mark: ${done.email} → ${label}${country}` +
-          (done.actor ? ` (par ${done.actor})` : "") +
-          ". La personne a été prévenue par email.",
-        hooks === defaultHooks ? decrypt(webhook) : "test",
-      );
-    } catch (error) {
-      logger.warn("Profile-complete Slack notification failed", {
-        workspaceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-  return true;
-}
-
-/** The page a waiting member sees instead of an app. Reloads itself. */
-export function pendingProfileHtml(input: {
-  email: string;
-  workspaceName: string;
-}): string {
-  const esc = (s: string) =>
-    s.replace(
-      /[&<>"]/g,
-      c =>
-        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[
-          c
-        ] as string,
-    );
-  return `<!doctype html>
-<html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<meta http-equiv="refresh" content="20">
-<title>Inscription en attente — ${esc(input.workspaceName)}</title>
-<style>body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f6f7f9;color:#1a1a1a;display:flex;min-height:100vh;align-items:center;justify-content:center}
-.card{background:#fff;border:1px solid #e3e6ea;border-radius:12px;padding:32px 36px;max-width:520px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
-h1{font-size:20px;margin:0 0 12px}p{margin:8px 0;line-height:1.5;color:#3c3c3c}.muted{color:#7a7a7a;font-size:13px}</style></head>
-<body><div class="card">
-<h1>Veuillez attendre qu'un administrateur finalise votre inscription</h1>
-<p>Vous êtes connecté à <b>${esc(input.workspaceName)}</b> en tant que <b>${esc(input.email)}</b>. Un administrateur doit encore vous attribuer un rôle et un pays.</p>
-<p>Les administrateurs ont été prévenus. Vous recevrez un email dès que c'est fait — cette page se rafraîchit toute seule.</p>
-<p class="muted">Please wait for an administrator to finish your signup. This page refreshes itself.</p>
-</div></body></html>`;
 }

--- a/api/src/services/workspace.service.ts
+++ b/api/src/services/workspace.service.ts
@@ -1,6 +1,5 @@
 import { Types } from "mongoose";
 import type { JobRole } from "@mako/schemas";
-import { completePendingProfile } from "./auto-join.service";
 import {
   Workspace,
   WorkspaceMember,
@@ -29,8 +28,6 @@ export interface MemberProfile {
 
 export interface MemberPatch extends MemberProfile {
   role?: "admin" | "member" | "viewer";
-  /** Who is making the change (for the "done" Slack line). */
-  actor?: string;
 }
 
 export class WorkspaceService {
@@ -108,7 +105,6 @@ export class WorkspaceService {
     Array<{
       workspace: IWorkspace;
       role: string;
-      profilePending?: boolean;
     }>
   > {
     const members = await WorkspaceMember.aggregate([
@@ -126,7 +122,6 @@ export class WorkspaceService {
         $project: {
           workspace: 1,
           role: 1,
-          profilePending: 1,
         },
       },
     ]);
@@ -292,7 +287,7 @@ export class WorkspaceService {
     const update: Record<string, unknown> = {};
     if (Object.keys($set).length) update.$set = $set;
     if (Object.keys($unset).length) update.$unset = $unset;
-    const updated = await WorkspaceMember.findOneAndUpdate(
+    return WorkspaceMember.findOneAndUpdate(
       {
         workspaceId: new Types.ObjectId(workspaceId),
         userId: userId,
@@ -300,28 +295,6 @@ export class WorkspaceService {
       update,
       { new: true, runValidators: true },
     ).populate("userId", "email");
-    // A waiting newcomer just got their role: let them in, tell them.
-    if (updated?.profilePending && updated.jobRole) {
-      const populated = updated.userId as unknown as
-        | { email?: string }
-        | string;
-      const email =
-        typeof populated === "object" &&
-        populated &&
-        typeof populated.email === "string"
-          ? populated.email
-          : null;
-      if (email) {
-        await completePendingProfile(workspaceId, userId, {
-          email,
-          jobRole: updated.jobRole,
-          country: updated.country ?? null,
-          actor: patch.actor,
-        });
-        updated.profilePending = undefined;
-      }
-    }
-    return updated;
   }
 
   /** @deprecated use updateMember */

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,7 +16,6 @@ import {
   BottomNavigation,
   BottomNavigationAction,
   Paper,
-  Typography,
 } from "@mui/material";
 import {
   MessageCircleMore as AskTabIcon,
@@ -79,7 +78,7 @@ const loadDbtExplorer = () => import("./components/DbtExplorer");
 const DbtExplorer = lazy(loadDbtExplorer);
 import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
-import { WorkspaceProvider, useWorkspace } from "./contexts/workspace-context";
+import { WorkspaceProvider } from "./contexts/workspace-context";
 import { OnboardingProvider } from "./contexts/onboarding-context";
 import type { DbFlowFormRef } from "./components/DbFlowForm";
 import { generateObjectId } from "./utils/objectId";
@@ -149,7 +148,6 @@ function clamp(value: number, min: number, max: number): number {
 
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
-  const pendingGate = usePendingProfileGate();
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
   const activeTabId = useConsoleStore(state => state.activeTabId);
   const requestReveal = useExplorerRevealStore(state => state.requestReveal);
@@ -737,10 +735,6 @@ function MainApp() {
     );
   }
 
-  // Domain auto-join: waiting for an admin to set the job role. Nothing
-  // else is useful until then — show the waiting screen and poll.
-  if (pendingGate) return pendingGate;
-
   return (
     <AuthWrapper>
       <UrlSync />
@@ -1105,61 +1099,3 @@ function App() {
 }
 
 export default App;
-
-/**
- * The "veuillez attendre qu'un administrateur finalise votre inscription"
- * screen for a member who auto-joined by email domain and has no job role
- * yet (apps.md §27). Re-reads the workspace list every 20 s and lets them
- * through the moment an admin sets it.
- */
-function usePendingProfileGate(): React.ReactElement | null {
-  const { currentWorkspace, refreshWorkspaces } = useWorkspace();
-  const { user } = useAuth();
-  const pending = !!currentWorkspace?.profilePending;
-  useEffect(() => {
-    if (!pending) return;
-    const id = window.setInterval(() => void refreshWorkspaces(), 20_000);
-    return () => window.clearInterval(id);
-  }, [pending, refreshWorkspaces]);
-  if (!pending) return null;
-  return (
-    <Box
-      sx={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        bgcolor: "background.default",
-        p: 3,
-      }}
-    >
-      <Box
-        sx={{
-          maxWidth: 520,
-          p: 4,
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 3,
-          bgcolor: "background.paper",
-        }}
-      >
-        <Typography variant="h6" sx={{ mb: 1.5 }}>
-          Veuillez attendre qu&apos;un administrateur finalise votre inscription
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 1 }}>
-          Vous êtes connecté à <b>{currentWorkspace?.name}</b> en tant que{" "}
-          <b>{user?.email}</b>. Un administrateur doit encore vous attribuer un
-          rôle et un pays.
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 2 }}>
-          Les administrateurs ont été prévenus. Vous recevrez un email dès que
-          c&apos;est fait — cette page se met à jour toute seule.
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          Please wait for an administrator to finish your signup. This page
-          updates itself.
-        </Typography>
-      </Box>
-    </Box>
-  );
-}

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -7869,8 +7869,6 @@ export interface operations {
                     /** @enum {string|null} */
                     jobRole?: "sdr" | "bdr" | "csm" | "head_of_csm" | "team_leader" | "developer" | "admin" | null;
                     country?: string | null;
-                    /** Format: uri */
-                    slackWebhookUrl?: string | null;
                 };
             };
         };

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -52,8 +52,6 @@ interface MemberRow {
   /** Job role + country: what published apps scope their data by. */
   jobRole: JobRole | null;
   country: string | null;
-  /** Auto-joined, waiting for an admin to set the job role. */
-  profilePending?: boolean;
   status: "active" | "pending";
   joinedAt?: string;
   expiresAt?: string;
@@ -234,7 +232,6 @@ export function WorkspaceMembers() {
       role: member.role,
       jobRole: member.jobRole ?? null,
       country: member.country ?? null,
-      profilePending: member.profilePending === true,
       status: "active" as const,
       joinedAt: member.joinedAt,
       userId: member.userId,
@@ -446,18 +443,10 @@ export function WorkspaceMembers() {
                   </TableCell>
                   <TableCell>
                     <Chip
-                      label={
-                        row.profilePending ? "waiting for role" : row.status
-                      }
+                      label={row.status}
                       size="small"
                       variant="outlined"
-                      color={
-                        row.profilePending
-                          ? "warning"
-                          : row.status === "active"
-                            ? "success"
-                            : "warning"
-                      }
+                      color={row.status === "active" ? "success" : "warning"}
                     />
                   </TableCell>
                   <TableCell>
@@ -647,8 +636,6 @@ function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
   const [role, setRole] = useState<"member" | "viewer">("viewer");
   const [jobRole, setJobRole] = useState<JobRole | "">("");
   const [country, setCountry] = useState("");
-  const [slackWebhook, setSlackWebhook] = useState("");
-  const [slackConfigured, setSlackConfigured] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -663,7 +650,6 @@ function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
         setRole(current?.role ?? "viewer");
         setJobRole(current?.jobRole ?? "");
         setCountry(current?.country ?? "");
-        setSlackConfigured(!!current?.slackWebhookConfigured);
       })
       .catch((e: any) => setError(e.message || "Failed to load auto-join"))
       .finally(() => !cancelled && setLoaded(true));
@@ -686,23 +672,13 @@ function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
         role,
         jobRole: jobRole || null,
         country: country || null,
-        ...(slackWebhook.trim()
-          ? { slackWebhookUrl: slackWebhook.trim() }
-          : {}),
       });
-      setSlackConfigured(!!saved?.slackWebhookConfigured);
-      setSlackWebhook("");
       setMessage(
         saved
           ? `Anyone with an email on ${saved.domains.join(", ")} now joins as ${saved.role}` +
-              (saved.jobRole
-                ? ` · ${JOB_ROLE_LABELS[saved.jobRole]}` +
-                  (saved.country ? ` · ${saved.country}` : "") +
-                  " the first time they open the workspace or one of its apps."
-                : " and WAITS until an admin sets their job role here" +
-                  (saved.slackWebhookConfigured
-                    ? " — Slack is told each time."
-                    : " — add a Slack webhook to be told each time."))
+              (saved.jobRole ? ` · ${JOB_ROLE_LABELS[saved.jobRole]}` : "") +
+              (saved.country ? ` · ${saved.country}` : "") +
+              " the first time they open the workspace or one of its apps."
           : "Auto-join is off.",
       );
       setTimeout(() => setMessage(null), 6000);
@@ -733,10 +709,8 @@ function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
       >
         People who sign in with an email on these domains become members the
         first time they open the workspace or one of its apps — no invitation
-        needed. With a job role below they are in at once; with none they see a
-        &quot;please wait for an administrator&quot; page, the Slack channel is
-        told to assign their role and country, and they get an email once you
-        do. Leave the domains empty to turn it off.
+        needed — with the access role, job role and country below. Leave the
+        domains empty to turn it off.
       </Typography>
       {error && (
         <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
@@ -822,20 +796,6 @@ function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
           {saving ? <CircularProgress size={18} /> : "Save"}
         </Button>
       </Box>
-      <TextField
-        size="small"
-        fullWidth
-        sx={{ mt: 1.5 }}
-        label={
-          slackConfigured
-            ? "Slack incoming webhook (configured — paste a new one to replace)"
-            : "Slack incoming webhook (optional) — #mako-internal-signup"
-        }
-        placeholder="https://hooks.slack.com/services/…"
-        value={slackWebhook}
-        onChange={e => setSlackWebhook(e.target.value)}
-        disabled={!loaded || saving}
-      />
     </Paper>
   );
 }

--- a/app/src/lib/workspace-client.ts
+++ b/app/src/lib/workspace-client.ts
@@ -34,8 +34,6 @@ export interface Workspace {
   name: string;
   slug: string;
   role: string;
-  /** Domain auto-join: waiting for an admin to set the job role. */
-  profilePending?: boolean;
   createdAt: string;
   updatedAt: string;
   settings: {
@@ -56,8 +54,6 @@ export interface WorkspaceMember {
   jobRole: JobRole | null;
   /** ISO 3166-1 alpha-2, or null. */
   country: string | null;
-  /** Auto-joined, waiting for an admin to set the job role. */
-  profilePending?: boolean;
   joinedAt: string;
 }
 
@@ -106,7 +102,6 @@ export interface WorkspaceAutoJoin {
   role: "member" | "viewer";
   jobRole: JobRole | null;
   country: string | null;
-  slackWebhookConfigured?: boolean;
 }
 
 /** Any subset; null clears a profile field. */
@@ -264,8 +259,6 @@ class WorkspaceClient {
       role: "member" | "viewer";
       jobRole?: JobRole | null;
       country?: string | null;
-      /** null clears, absent keeps */
-      slackWebhookUrl?: string | null;
     },
   ): Promise<WorkspaceAutoJoin | null> {
     const body = unwrap(

--- a/apps.md
+++ b/apps.md
@@ -3171,20 +3171,7 @@ skills — the posture every other kind already had.
 > `requireWorkspace`), with the workspace's default access role, job role
 > and country — RealAdvisor: `realadvisor.com` → viewer / bdr / FR. The
 > published app's live URL already gates on login with `returnTo`, so the
-> chain is link → Google → auto-join → served as `bdr`. Then Théo, on
-> seeing that: *"j'aime pas ça. je préfère que dans le cas général: l'IC
-> se connecte à mako. il y a un blocker genre veuillez attendre qu'un
-> administrateur finalise votre inscription. slack dans un channel
-> #mako-internal-signup please assign role and country to blablabla. and
-> then slack notif or email once done."* So the default job role is
-> optional: without one the newcomer joins with `profilePending` (and
-> `pendingReturnTo` = the URL they came for), the live route and the IDE
-> show a waiting page (`pendingProfileHtml`, `usePendingProfileGate`),
-> the workspace's Slack incoming webhook (`autoJoin.slackWebhookUrlEncrypted`,
-> Members page) gets "please assign role and country to <email>", and
-> when an admin sets the job role (`updateMember` →
-> `completePendingProfile`) the person is emailed the link they wanted
-> and the channel gets a ✅. The trade Théo accepted: someone
+> chain is link → Google → auto-join → served as `bdr`. The trade Théo accepted: someone
 > edits the member list when a rep joins or moves, instead of the CRM roster
 > doing it. What follows is the history of how the enforcement path (which
 > stands) was arrived at; read "role" below as "job role from the membership"

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -4411,14 +4411,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "slackWebhookUrl": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "maxLength": 500,
-                    "format": "uri"
                   }
                 },
                 "required": [


### PR DESCRIPTION
Production hotfix: reverts #985 (pending profile). The waiting-screen hook was called from MainApp, which renders above WorkspaceProvider, so every page of the IDE showed "Mako hit a display error". The feature comes back in a follow-up with the gate rendered inside the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXchWya6usKHaWsRfL7pH5