### PR TITLE
Identity is a primitive, permissions are the app's: useViewer() + domain auto-join (apps.md §28)

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -190,6 +190,24 @@ serves the data). Public share links refuse it unless the owner enabled
 live queries for the link. Prefer this over a cron for "what is it now?"
 buttons; keep `-- schedule:` for data that must be fresh before anyone asks.
 
+## Who is looking: `useViewer()` (SDK ≥ 2.4)
+
+`const { viewer, loading } = useViewer()` — `null` on an anonymous share
+link, else `{ id, email, workspace: { id, name, role }, app: { id, slug,
+role } }`. `workspace.role` is the person's ACCESS role
+(owner/admin/member/viewer); `app.role` is owner/editor/viewer. Mako
+resolves it server-side (session or signed token); the page cannot forge it.
+
+That is ALL the platform knows about a person, by design. Team, territory,
+seniority, quota — anything an app needs to shape its view — is data:
+write a roster binding (`bindings/viewers.sql`: `email` plus only the
+columns the logic needs), join it on `lower(viewer.email)` in `useDuckDB`,
+and branch the UI on the result. Never propose adding such fields to Mako
+users or members. Every binding the app can read is downloaded whole into
+the browser, so this shapes the UI; it is not access control — say so
+when the user asks for "hiding" data. `MAKO_VIEWER_AS=<email>` in the
+repo's `.env` previews the app as another member during `npm run dev`.
+
 ## The SDK's name
 
 New apps depend on `@makoai/app-sdk` (npm) — vendored at `packages/app-sdk`.

--- a/api/src/apps/app-viewer.service.test.ts
+++ b/api/src/apps/app-viewer.service.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Who an app is talking to (apps.md §28): the platform reports identity,
+ * workspace access role and the person's role on the app — and nothing
+ * about what they do for a living.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  AppProject,
+  Workspace,
+  WorkspaceMember,
+  type IAppProject,
+} from "../database/workspace-schema";
+import { User } from "../database/schema";
+import {
+  resolveAppViewer,
+  resolveAppViewerByEmail,
+} from "./app-viewer.service";
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId();
+const OWNER = { id: "u-owner", email: "owner@acme.com" };
+const ADMIN = { id: "u-admin", email: "admin@acme.com" };
+const VIEWER = { id: "u-viewer", email: "Sam@Acme.com" };
+const OUTSIDER = { id: "u-out", email: "out@elsewhere.com" };
+let sharedApp: IAppProject;
+let privateApp: IAppProject;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  await Workspace.create({
+    _id: WS,
+    name: "Acme",
+    slug: "acme",
+    createdBy: OWNER.id,
+    settings: {},
+    billing: {},
+  });
+  await WorkspaceMember.create([
+    { workspaceId: WS, userId: OWNER.id, role: "owner" },
+    { workspaceId: WS, userId: ADMIN.id, role: "admin" },
+    { workspaceId: WS, userId: VIEWER.id, role: "viewer" },
+  ]);
+  await User.create({
+    _id: VIEWER.id,
+    email: "sam@acme.com",
+    emailVerified: true,
+  });
+  sharedApp = await AppProject.create({
+    workspaceId: WS,
+    title: "Sales",
+    slug: "sales",
+    access: "workspace",
+    workspaceRole: "editor",
+    createdBy: OWNER.id,
+    owner_id: OWNER.id,
+  });
+  privateApp = await AppProject.create({
+    workspaceId: WS,
+    title: "Secret",
+    slug: "secret",
+    access: "private",
+    createdBy: ADMIN.id,
+    owner_id: ADMIN.id,
+    sharedWith: [{ userId: VIEWER.id, role: "viewer" }],
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe("resolveAppViewer", () => {
+  it("is null for nobody (anonymous share)", async () => {
+    expect(await resolveAppViewer(sharedApp, null)).toBeNull();
+    expect(await resolveAppViewer(sharedApp, undefined)).toBeNull();
+  });
+
+  it("reports identity, the workspace and the access role, and the app role — nothing else", async () => {
+    const viewer = await resolveAppViewer(sharedApp, VIEWER);
+    expect(viewer).toEqual({
+      id: VIEWER.id,
+      email: "sam@acme.com",
+      workspace: { id: WS.toString(), name: "Acme", role: "viewer" },
+      app: { id: sharedApp._id.toString(), slug: "sales", role: "viewer" },
+    });
+    expect(Object.keys(viewer!).sort()).toEqual([
+      "app",
+      "email",
+      "id",
+      "workspace",
+    ]);
+  });
+
+  it("derives the app role from the ACL: owner, editor for admins, share entries", async () => {
+    expect((await resolveAppViewer(sharedApp, OWNER))!.app.role).toBe("owner");
+    expect((await resolveAppViewer(sharedApp, ADMIN))!.app.role).toBe("editor");
+    expect((await resolveAppViewer(privateApp, VIEWER))!.app.role).toBe(
+      "viewer",
+    );
+    expect((await resolveAppViewer(privateApp, OWNER))!.app.role).toBeNull();
+  });
+
+  it("describes a non-member honestly: known identity, no roles", async () => {
+    const viewer = await resolveAppViewer(sharedApp, OUTSIDER);
+    expect(viewer!.workspace.role).toBeNull();
+    expect(viewer!.app.role).toBeNull();
+  });
+});
+
+describe("resolveAppViewerByEmail (preview as)", () => {
+  it("resolves a member by email, case-insensitively, and null for a stranger", async () => {
+    const viewer = await resolveAppViewerByEmail(sharedApp, "SAM@acme.com");
+    expect(viewer?.id).toBe(VIEWER.id);
+    expect(viewer?.workspace.role).toBe("viewer");
+    expect(
+      await resolveAppViewerByEmail(sharedApp, "nobody@acme.com"),
+    ).toBeNull();
+  });
+});

--- a/api/src/apps/app-viewer.service.ts
+++ b/api/src/apps/app-viewer.service.ts
@@ -1,0 +1,126 @@
+/**
+ * Who is looking at a published app (apps.md §28).
+ *
+ * The platform tells an app exactly what it knows about the person behind
+ * a request and nothing more: who they are (id, email), where they are
+ * (the workspace and their ACCESS role in it), and what they may do to this
+ * app (their share role). Everything else — team, territory, seniority,
+ * whatever an app needs to shape its view — is data the app looks up in
+ * the warehouse by email. Mako carries no org chart.
+ *
+ * Identity comes from the session or from the HMAC-signed `pub.` token,
+ * never from anything the browser can edit. An anonymous share resolves to
+ * `null`: there is nobody to describe.
+ */
+import { Types } from "mongoose";
+import {
+  AppProject,
+  Workspace,
+  WorkspaceMember,
+  type IAppProject,
+} from "../database/workspace-schema";
+import { User } from "../database/schema";
+import { normalizeEmail } from "../utils/email.utils";
+import {
+  getResourceOwnerId,
+  resolveResourceRole,
+  type EffectiveResourceRole,
+  type WorkspaceMemberRole,
+} from "../utils/resource-acl";
+import type { ViewerIdentity } from "./preview.service";
+
+export type { ViewerIdentity };
+
+/** The viewer as the app sees it — `__data/viewer.json`, `useViewer()`. */
+export interface AppViewer {
+  id: string;
+  email: string;
+  workspace: {
+    id: string;
+    name: string;
+    /** Access role in the workspace; null when not (or no longer) a member. */
+    role: WorkspaceMemberRole | null;
+  };
+  app: {
+    id: string;
+    slug: string | null;
+    /** What they may do to this app; null when the ACL admits them no more. */
+    role: EffectiveResourceRole;
+  };
+}
+
+/**
+ * Resolve the viewer for `project`. One workspace read and one membership
+ * read; callers keep it off the per-asset path (document + `__data/` only).
+ */
+export async function resolveAppViewer(
+  project: Pick<IAppProject, "_id" | "workspaceId" | "slug"> &
+    Parameters<typeof resolveResourceRole>[0],
+  identity: ViewerIdentity | null | undefined,
+): Promise<AppViewer | null> {
+  if (!identity) return null;
+  const workspaceId = project.workspaceId.toString();
+  const [workspace, member] = await Promise.all([
+    Workspace.findById(workspaceId).select("name").lean<{ name?: string }>(),
+    WorkspaceMember.findOne({
+      workspaceId: new Types.ObjectId(workspaceId),
+      userId: identity.id,
+    })
+      .select("role")
+      .lean<{ role?: WorkspaceMemberRole }>(),
+  ]);
+  const memberRole = member?.role ?? null;
+  // The ACL's workspace-scope fallback assumes the caller already passed the
+  // membership check. Someone who is no longer a member (a token minted
+  // before they were removed) keeps only what names them explicitly.
+  const namedExplicitly =
+    getResourceOwnerId(project) === identity.id ||
+    (project.sharedWith ?? []).some(s => s.userId === identity.id);
+  const appRole =
+    memberRole || namedExplicitly
+      ? resolveResourceRole(project, identity.id, memberRole ?? undefined)
+      : null;
+  return {
+    id: identity.id,
+    email: normalizeEmail(identity.email),
+    workspace: {
+      id: workspaceId,
+      name: workspace?.name ?? "",
+      role: memberRole,
+    },
+    app: {
+      id: project._id.toString(),
+      slug: project.slug ?? null,
+      role: appRole,
+    },
+  };
+}
+
+/**
+ * The viewer a given EMAIL would resolve to — the builder's "preview as"
+ * (`GET /apps/{id}/viewer?as=`, `MAKO_VIEWER_AS` in a laptop `vite dev`).
+ * Null when no Mako user has that email.
+ */
+export async function resolveAppViewerByEmail(
+  project: Parameters<typeof resolveAppViewer>[0],
+  email: string,
+): Promise<AppViewer | null> {
+  const user = await User.findOne({ email: normalizeEmail(email) })
+    .select("_id email")
+    .lean<{ _id: string; email: string }>();
+  if (!user) return null;
+  return resolveAppViewer(project, {
+    id: user._id.toString(),
+    email: user.email,
+  });
+}
+
+/** Convenience for routes that only hold a project id. */
+export async function resolveAppViewerById(
+  projectId: string,
+  identity: ViewerIdentity | null | undefined,
+): Promise<AppViewer | null> {
+  if (!identity) return null;
+  const project = await AppProject.findById(projectId);
+  return project ? resolveAppViewer(project, identity) : null;
+}

--- a/api/src/apps/deployment.service.test.ts
+++ b/api/src/apps/deployment.service.test.ts
@@ -46,6 +46,17 @@ vi.mock("../database/workspace-schema", () => ({
   },
 }));
 
+vi.mock("./app-viewer.service", () => ({
+  resolveAppViewer: vi.fn(
+    async (_project: unknown, identity: { id: string; email: string }) => ({
+      id: identity.id,
+      email: identity.email,
+      workspace: { id: "ws", name: "Acme", role: "viewer" },
+      app: { id: "project", slug: "sales", role: "viewer" },
+    }),
+  ),
+}));
+
 vi.mock("../services/artifact-delivery.service", () => ({
   serveParquetArtifact: vi.fn(
     async (store, key) =>
@@ -139,6 +150,35 @@ describe("published deployment artifact source", () => {
     expect(await response?.text()).toBe(`true:${bindingKey}`);
     expect(stores.primary.exists).toHaveBeenCalledWith(bindingKey);
     expect(stores.source.exists).toHaveBeenCalledWith(bindingKey);
+  });
+
+  it("answers __data/viewer.json for the signed-in viewer, and null when nobody is known", async () => {
+    const known = await serveDeploymentFile({
+      projectId,
+      sha,
+      assetPath: "__data/viewer.json",
+      viewer: { id: "u1", email: "sam@acme.com" },
+    });
+    expect(known?.status).toBe(200);
+    expect(known?.headers.get("cache-control")).toBe("no-store");
+    expect(await known?.json()).toMatchObject({
+      email: "sam@acme.com",
+      workspace: { role: "viewer" },
+      app: { role: "viewer" },
+    });
+
+    const anonymous = await serveDeploymentFile({
+      projectId,
+      sha,
+      assetPath: "__data/viewer.json",
+      private: true,
+      viewer: null,
+    });
+    expect(anonymous?.status).toBe(200);
+    expect(anonymous?.headers.get("cache-control")).toBe("private, no-store");
+    expect(await anonymous?.json()).toBeNull();
+    // Never a store read: identity is not an artifact.
+    expect(stores.primary.exists).not.toHaveBeenCalled();
   });
 });
 

--- a/api/src/apps/deployment.service.ts
+++ b/api/src/apps/deployment.service.ts
@@ -34,6 +34,7 @@ import {
   readBindingsTolerant,
 } from "./bindings.service";
 import { AppProject, type IAppProject } from "../database/workspace-schema";
+import { resolveAppViewer, type ViewerIdentity } from "./app-viewer.service";
 import { loggers } from "../logging";
 import {
   PUBLISH_ACTOR,
@@ -505,10 +506,12 @@ export async function deployBuild(
  * binding at `__data/<name>.parquet`.
  *
  * The only difference between the signed-in viewer and an anonymous share is
- * WHO is allowed to call it; what gets served is identical. Keeping that in
- * one place is what stops the two drifting into serving different things —
- * which is exactly how the viewer ended up returning index.html for every
- * asset while the share route did not.
+ * WHO is allowed to call it; what gets served is identical — except
+ * `__data/viewer.json`, which tells the app who that is (apps.md §28) and
+ * is `null` for an anonymous share. Keeping that in one place is what stops
+ * the routes drifting into serving different things — which is exactly how
+ * the viewer once ended up returning index.html for every asset while the
+ * share route did not.
  */
 export async function serveDeploymentFile(input: {
   projectId: string;
@@ -516,9 +519,30 @@ export async function serveDeploymentFile(input: {
   assetPath: string;
   /** Anonymous shares must not be cached by anything in between. */
   private?: boolean;
+  /**
+   * Who is asking, from the session or the signed token. Absent/null =
+   * nobody known (anonymous share, a token minted before viewers existed).
+   */
+  viewer?: ViewerIdentity | null;
 }): Promise<Response | null> {
   const { projectId, sha, assetPath } = input;
   const cache = input.private ? "private, no-cache" : "no-cache";
+
+  // Who the app is talking to — the SDK's useViewer(). Two small reads
+  // (workspace, membership), only on this one request, never per asset.
+  if (assetPath === "__data/viewer.json") {
+    const project = input.viewer ? await AppProject.findById(projectId) : null;
+    const viewer = project
+      ? await resolveAppViewer(project, input.viewer)
+      : null;
+    return new Response(JSON.stringify(viewer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": input.private ? "private, no-store" : "no-store",
+      },
+    });
+  }
 
   // The staged-binding list the SDK's useDuckDB registers tables from. The
   // dev server writes this file next to its staged parquet; published serving

--- a/api/src/apps/preview.service.test.ts
+++ b/api/src/apps/preview.service.test.ts
@@ -93,3 +93,61 @@ describe("published preview grants are stateless", () => {
     expect(resolvePreviewGrant("nope")).toBeNull();
   });
 });
+
+describe("grants carry the viewer they were minted for (apps.md §28)", () => {
+  beforeEach(() => {
+    process.env.SESSION_SECRET = "test-secret-0123456789abcdef";
+  });
+  afterEach(() => {
+    delete process.env.SESSION_SECRET;
+  });
+
+  it("round-trips the viewer through the signed token, and stays viewer-less when minted without one", () => {
+    const viewer = { id: "u1", email: "lead@acme.com" };
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+      viewer,
+    });
+    expect(grant.viewer).toEqual(viewer);
+    expect(resolvePreviewGrant(grant.token)?.viewer).toEqual(viewer);
+
+    const anonymous = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+    });
+    expect(anonymous.viewer).toBeUndefined();
+    expect(resolvePreviewGrant(anonymous.token)?.viewer).toBeUndefined();
+  });
+
+  it("rejects a token whose viewer email was swapped", () => {
+    const grant = mintPublishedGrant({
+      workspaceId: ws,
+      projectId: project,
+      sha,
+      viewer: { id: "u1", email: "rep@acme.com" },
+    });
+    const [prefix, body, sig] = grant.token.split(".");
+    const forged = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+    forged.e = "lead@acme.com";
+    const forgedBody = Buffer.from(JSON.stringify(forged)).toString(
+      "base64url",
+    );
+    expect(resolvePreviewGrant(`${prefix}.${forgedBody}.${sig}`)).toBeNull();
+  });
+
+  it("keeps the builder's identity on a static preview grant", () => {
+    const grant = mintPreviewGrant({
+      workspaceId: ws,
+      projectId: project,
+      rootDir: "/tmp/preview-viewer-test",
+      viewer: { id: "u1", email: "dev@acme.com" },
+    });
+    expect(resolvePreviewGrant(grant.token)?.viewer).toEqual({
+      id: "u1",
+      email: "dev@acme.com",
+    });
+  });
+});

--- a/api/src/apps/preview.service.ts
+++ b/api/src/apps/preview.service.ts
@@ -47,7 +47,21 @@ export interface PreviewGrant {
    * nothing.
    */
   publishedSha?: string;
+  /**
+   * Who the grant was minted for (apps.md §28). The serving route has no
+   * cookie (opaque-origin iframe), so the token is the only place the
+   * viewer's identity can ride; `__data/viewer.json` — the SDK's
+   * `useViewer()` — is answered from it. Absent on an anonymous share and
+   * on tokens minted before viewers existed.
+   */
+  viewer?: ViewerIdentity;
   expiresAt: number;
+}
+
+/** The signed-in person behind a request, as the session knows them. */
+export interface ViewerIdentity {
+  id: string;
+  email: string;
 }
 
 const PREVIEW_TTL_MS = 30 * 60 * 1000;
@@ -61,7 +75,12 @@ function sweep(): void {
 }
 
 function mint(
-  input: { workspaceId: string; projectId: string; token?: string },
+  input: {
+    workspaceId: string;
+    projectId: string;
+    token?: string;
+    viewer?: ViewerIdentity;
+  },
   scope: Pick<PreviewGrant, "rootDir">,
   dedupe: (grant: PreviewGrant) => boolean,
 ): PreviewGrant {
@@ -79,6 +98,7 @@ function mint(
     workspaceId: input.workspaceId,
     projectId: input.projectId,
     ...scope,
+    ...(input.viewer ? { viewer: { ...input.viewer } } : {}),
     expiresAt: Date.now() + PREVIEW_TTL_MS,
   };
   grants.set(grant.token, grant);
@@ -90,6 +110,8 @@ export function mintPreviewGrant(input: {
   workspaceId: string;
   projectId: string;
   rootDir: string;
+  /** The builder previewing their own build — what `useViewer()` sees. */
+  viewer?: ViewerIdentity;
 }): PreviewGrant {
   return mint(
     input,
@@ -113,6 +135,9 @@ interface PublishedTokenPayload {
   w: string;
   p: string;
   s: string;
+  /** Viewer user id + email (apps.md §28). Absent on tokens minted before. */
+  u?: string;
+  e?: string;
   /** Epoch milliseconds. */
   exp: number;
 }
@@ -135,12 +160,15 @@ export function mintPublishedGrant(input: {
   workspaceId: string;
   projectId: string;
   sha: string;
+  /** Binds the token to this person; a tampered email fails the HMAC. */
+  viewer?: ViewerIdentity;
 }): PreviewGrant {
   const payload: PublishedTokenPayload = {
     v: 1,
     w: input.workspaceId,
     p: input.projectId,
     s: input.sha,
+    ...(input.viewer ? { u: input.viewer.id, e: input.viewer.email } : {}),
     exp: Date.now() + PREVIEW_TTL_MS,
   };
   const body = Buffer.from(JSON.stringify(payload), "utf8").toString(
@@ -152,6 +180,7 @@ export function mintPublishedGrant(input: {
     workspaceId: input.workspaceId,
     projectId: input.projectId,
     publishedSha: input.sha,
+    ...(input.viewer ? { viewer: { ...input.viewer } } : {}),
     expiresAt: payload.exp,
   };
 }
@@ -192,11 +221,20 @@ function resolvePublishedGrant(token: string): PreviewGrant | null {
   ) {
     return null;
   }
+  let viewer: ViewerIdentity | undefined;
+  if (payload.u !== undefined || payload.e !== undefined) {
+    // Half a viewer is a malformed token, not an anonymous one.
+    if (typeof payload.u !== "string" || typeof payload.e !== "string") {
+      return null;
+    }
+    viewer = { id: payload.u, email: payload.e };
+  }
   return {
     token,
     workspaceId: payload.w,
     projectId: payload.p,
     publishedSha: payload.s,
+    ...(viewer ? { viewer } : {}),
     expiresAt: payload.exp,
   };
 }

--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 11, fingerprint: "72fddf18ebde3cf5" };
+const PINNED = { version: 12, fingerprint: "6807799526ab90df" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.ts
+++ b/api/src/apps/workspace-template.ts
@@ -31,7 +31,7 @@ import { fetchFromCloud, queueMirrorPush } from "./cloud-repo.service";
 
 const logger = loggers.app();
 
-export const WORKSPACE_TEMPLATE_VERSION = 11;
+export const WORKSPACE_TEMPLATE_VERSION = 12;
 
 /** Where `.mcp.json` points when MAKO_API_URL is not exported. */
 export const HOSTED_MAKO_URL = "https://app.mako.ai";
@@ -159,6 +159,16 @@ SELECT …
 \`useQuery("<name>")\` in the app reads it. Materialize on demand with the
 \`app_materialize\` tool (safe from a checkout: it builds from the committed
 binding, keyed by content) or let the dev server do it on first load.
+
+## Who is looking
+
+\`useViewer()\` gives the signed-in person: \`{ id, email, workspace: { id,
+name, role }, app: { id, slug, role } }\`, or \`null\` on an anonymous share.
+Mako knows nothing else about people on purpose — team, country, seniority
+are YOUR data: put a roster in a binding (\`email\` + the columns the app's
+logic needs) and join it on the email in \`useDuckDB\`. \`MAKO_VIEWER_AS=<email>\`
+in \`.env\` previews the app as another member during \`npm run dev\`. See
+\`packages/app-sdk/README.md\`.
 
 ## Shipping
 

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -127,6 +127,13 @@ export interface IWorkspace extends Document {
      * workspace. Clamped to [1, DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE_MAX].
      */
     dashboardRefreshConcurrency?: number;
+    /**
+     * Domain auto-join (apps.md §28): a signed-in person whose email domain
+     * is listed becomes a member on first contact with the workspace — no
+     * invitation — with this access role. How someone clicks a published
+     * app's link, signs in, and is simply in.
+     */
+    autoJoin?: IWorkspaceAutoJoin;
   };
   billing: IWorkspaceBilling;
   apiKeys?: IWorkspaceApiKey[];
@@ -166,6 +173,13 @@ export type IAppsRepoBinding = IWorkspaceRepoBinding;
 /**
  * API Key interface for workspace authentication
  */
+export interface IWorkspaceAutoJoin {
+  /** Lowercase email domains, exact match (no sub-domains). */
+  domains: string[];
+  /** The ACCESS role newcomers get. Never owner/admin. */
+  role: "member" | "viewer";
+}
+
 export interface IWorkspaceApiKey {
   _id?: Types.ObjectId;
   name: string;
@@ -1291,6 +1305,20 @@ const WorkspaceSchema = new Schema<IWorkspace>(
         type: Number,
         default: 2,
         min: 1,
+      },
+      autoJoin: {
+        type: new Schema(
+          {
+            domains: [{ type: String, lowercase: true, trim: true }],
+            role: {
+              type: String,
+              enum: ["member", "viewer"],
+              default: "viewer",
+            },
+          },
+          { _id: false },
+        ),
+        required: false,
       },
     },
     billing: {

--- a/api/src/middleware/workspace.middleware.ts
+++ b/api/src/middleware/workspace.middleware.ts
@@ -1,6 +1,7 @@
 import { Context, Next } from "hono";
 import { ValidatedSession, ValidatedUser } from "../auth/session";
 import { workspaceService } from "../services/workspace.service";
+import { ensureAutoJoin } from "../services/auto-join.service";
 import { Types } from "mongoose";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 
@@ -112,8 +113,11 @@ export async function requireWorkspace(c: Context, next: Next) {
         return c.json({ error: "Invalid workspace ID format" }, 400);
       }
 
-      // Verify user has access to workspace
-      const member = await workspaceService.getMember(workspaceId, user.id);
+      // Verify user has access to workspace — or admit them now, when the
+      // workspace auto-joins their email domain (auto-join.service).
+      const member =
+        (await workspaceService.getMember(workspaceId, user.id)) ??
+        (await ensureAutoJoin(workspaceId, user));
 
       if (!member) {
         return c.json({ error: "Access denied to workspace" }, 403);

--- a/api/src/routes/apps-preview.ts
+++ b/api/src/routes/apps-preview.ts
@@ -18,6 +18,7 @@ import {
 } from "../apps/binding-refresh";
 import { AppProject } from "../database/workspace-schema";
 import { serveDeploymentFile } from "../apps/deployment.service";
+import { resolveAppViewerById } from "../apps/app-viewer.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 import { serveParquetArtifact } from "../services/artifact-delivery.service";
 import { readPreviewAsset, resolvePreviewGrant } from "../apps/preview.service";
@@ -81,6 +82,10 @@ async function serveAsset(c: Context): Promise<Response> {
       // The token is the only credential, so nothing in between should keep
       // a copy of a private app's build.
       private: true,
+      // The token is also the only place the viewer's identity can ride
+      // (no cookie in the sandboxed iframe) — `__data/viewer.json` is
+      // answered from it (apps.md §28).
+      viewer: grant.viewer ?? null,
     });
     if (!response) {
       return c.json({ success: false, error: "Not found" }, 404);
@@ -93,6 +98,19 @@ async function serveAsset(c: Context): Promise<Response> {
     const headers = new Headers(response.headers);
     headers.set("Access-Control-Allow-Origin", "*");
     return new Response(response.body, { status: response.status, headers });
+  }
+
+  // A build preview is the builder looking at their own build: tell the app
+  // so, the same way the published route does (apps.md §28).
+  if (assetPathFor(c, token) === "__data/viewer.json") {
+    const viewer = await resolveAppViewerById(
+      grant.projectId,
+      grant.viewer ?? null,
+    );
+    return c.json(viewer, 200, {
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    });
   }
 
   // Data bindings: `__data/<name>.parquet` (app-relative, so it works under

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -118,6 +118,12 @@ import fs from "node:fs/promises";
 import { readBoxDir } from "../apps/box";
 import { mintPreviewGrant, mintPublishedGrant } from "../apps/preview.service";
 import {
+  resolveAppViewer,
+  resolveAppViewerByEmail,
+  type ViewerIdentity,
+} from "../apps/app-viewer.service";
+import { ensureAutoJoin } from "../services/auto-join.service";
+import {
   forgetTerminalCaches,
   killAllTerminalSessions,
   killTerminalSession,
@@ -181,7 +187,11 @@ appsRoutes.use("*", async (c: AuthenticatedContext, next) => {
         );
       }
     } else if (user) {
-      const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+      // A stranger from a trusted domain joins here — this is the request
+      // their first click on a published app's link makes (apps.md §28).
+      const hasAccess =
+        (await workspaceService.hasAccess(workspaceId, user.id)) ||
+        (await ensureAutoJoin(workspaceId, user)) !== null;
       if (!hasAccess) {
         return c.json(
           { success: false, error: "Access denied to workspace" },
@@ -1298,6 +1308,59 @@ appsRoutes.openapi(
 appsRoutes.openapi(
   createRoute({
     method: "get",
+    path: "/{id}/viewer",
+    tags: ["Apps"],
+    summary: "Who the caller is to this app (what `useViewer()` sees)",
+    description:
+      "What `__data/viewer.json` says for the caller: their id and email, " +
+      "the workspace (id, name, their access role) and their role on this " +
+      "app (owner / editor / viewer). Nothing else — an app looks up what " +
+      "it needs about the person in the warehouse by email (apps.md §28). " +
+      "Editors of the app may pass `?as=<email>` to see another member's " +
+      "resolution; a laptop `vite dev` uses this for MAKO_VIEWER_AS.",
+    security: AUTH_SECURITY,
+    request: {
+      params: ProjectParam,
+      query: z.object({ as: z.string().optional() }),
+    },
+    responses: OPEN_RESPONSES,
+  }),
+  async c => {
+    try {
+      const loaded = await loadProject(c, { write: false });
+      if ("errorResponse" in loaded) return loaded.errorResponse;
+      const { as } = c.req.valid("query");
+      const self = viewerOf(c);
+      if (!self) {
+        return c.json(
+          { success: false, error: "No signed-in viewer to resolve" },
+          403,
+        );
+      }
+      if (as && as.toLowerCase() !== self.email.toLowerCase()) {
+        // Previewing as someone else is a builder's tool.
+        const builder = await loadProject(c, { write: true });
+        if ("errorResponse" in builder) return builder.errorResponse;
+        const viewer = await resolveAppViewerByEmail(loaded.project, as);
+        if (!viewer) {
+          return c.json(
+            { success: false, error: `No Mako user has the email ${as}` },
+            404,
+          );
+        }
+        return c.json({ success: true as const, viewer }, 200);
+      }
+      const viewer = await resolveAppViewer(loaded.project, self);
+      return c.json({ success: true as const, viewer }, 200);
+    } catch (error) {
+      return handleError(c, error);
+    }
+  },
+);
+
+appsRoutes.openapi(
+  createRoute({
+    method: "get",
     path: "/{id}/bindings/{name}/artifact",
     tags: ["Apps"],
     summary: "Serve a binding's materialized parquet artifact",
@@ -1620,6 +1683,8 @@ appsRoutes.openapi(
         workspaceId: loaded.project.workspaceId.toString(),
         projectId: loaded.project._id.toString(),
         rootDir: staging,
+        // The builder previewing their own build: `useViewer()` is them.
+        viewer: viewerOf(c) ?? undefined,
       });
       return c.json(
         {
@@ -2410,8 +2475,15 @@ async function serveLive(c: AuthenticatedContext): Promise<Response> {
     projectId,
     sha,
     assetPath: rest.replace(/^\/+/, ""),
+    viewer: viewerOf(c),
   });
   return response ?? c.json({ success: false, error: "Not found" }, 404);
+}
+
+/** The signed-in person, as the published serving layer wants them. */
+function viewerOf(c: AuthenticatedContext): ViewerIdentity | null {
+  const user = c.get("user");
+  return user?.email ? { id: user.id, email: user.email } : null;
 }
 
 appsRoutes.openapi(
@@ -2441,6 +2513,9 @@ appsRoutes.openapi(
         workspaceId: loaded.project.workspaceId.toString(),
         projectId: loaded.project._id.toString(),
         sha,
+        // Binds the token to this person: the cookie-free serving route
+        // answers `__data/viewer.json` from it (apps.md §28).
+        viewer: viewerOf(c) ?? undefined,
       });
       return c.json(
         {

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -662,6 +662,8 @@ async function serveSharedApp(c: Context): Promise<Response> {
     sha,
     assetPath,
     private: true,
+    // Anonymous: `__data/viewer.json` is null — there is nobody to describe.
+    viewer: null,
   });
   return response ?? c.json({ success: false, error: "Not found" }, 404);
 }

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -30,7 +30,11 @@ import {
   optionalWorkspace,
 } from "../middleware/workspace.middleware";
 import { Types } from "mongoose";
-import { Workspace } from "../database/workspace-schema";
+import {
+  Workspace,
+  type IWorkspaceAutoJoin,
+} from "../database/workspace-schema";
+import { normalizeAutoJoin } from "../services/auto-join.service";
 import { User } from "../database/schema";
 import { normalizeEmail } from "../utils/email.utils";
 import { loggers } from "../logging";
@@ -85,6 +89,12 @@ const AddMemberBody = jsonBody(
   z.object({ userId: z.string(), role: MemberRole }),
 );
 const UpdateMemberRoleBody = jsonBody(z.object({ role: MemberRole }));
+const AutoJoinBody = jsonBody(
+  z.object({
+    domains: z.array(z.string()).max(20),
+    role: z.enum(["member", "viewer"]).default("viewer"),
+  }),
+);
 const CreateInviteBody = jsonBody(
   z.object({ email: z.string(), role: MemberRole }),
 );
@@ -1298,6 +1308,110 @@ workspaceRoutes.openapi(
           success: false,
           error:
             error instanceof Error ? error.message : "Failed to remove member",
+        },
+        500,
+      );
+    }
+  },
+);
+
+function serializeAutoJoin(autoJoin: IWorkspaceAutoJoin | null | undefined) {
+  if (!autoJoin || autoJoin.domains.length === 0) return null;
+  return { domains: autoJoin.domains, role: autoJoin.role };
+}
+
+// Domain auto-join — read
+workspaceRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/auto-join",
+    tags: ["Workspaces"],
+    summary: "Domain auto-join settings",
+    description:
+      "Email domains whose signed-in users become members on first contact " +
+      "(no invitation), and the access role they get (viewer or member). " +
+      "`null` when off. How someone opens a published app's link, signs in, " +
+      "and is simply in (apps.md §28).",
+    security: AUTH_SECURITY,
+    middleware: [
+      unifiedAuthMiddleware,
+      requireWorkspace,
+      requireWorkspaceRole(["owner", "admin"]),
+    ] as const,
+    request: { params: IdParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    const workspace = c.get("workspace");
+    if (c.req.param("id") !== workspace._id.toString()) {
+      return c.json({ success: false, error: "Workspace ID mismatch" }, 400);
+    }
+    const fresh = await workspaceService.getWorkspaceById(
+      workspace._id.toString(),
+    );
+    return c.json({
+      success: true,
+      data: serializeAutoJoin(fresh?.settings?.autoJoin),
+    });
+  },
+);
+
+// Domain auto-join — write (an empty domain list turns it off)
+workspaceRoutes.openapi(
+  createRoute({
+    method: "put",
+    path: "/{id}/auto-join",
+    tags: ["Workspaces"],
+    summary: "Set domain auto-join",
+    security: AUTH_SECURITY,
+    middleware: [
+      unifiedAuthMiddleware,
+      requireWorkspace,
+      requireWorkspaceRole(["owner", "admin"]),
+    ] as const,
+    request: { params: IdParam, body: AutoJoinBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspace = c.get("workspace");
+      const workspaceId = c.req.param("id");
+      if (workspaceId !== workspace._id.toString()) {
+        return c.json({ success: false, error: "Workspace ID mismatch" }, 400);
+      }
+      const body = c.req.valid("json");
+      const normalized = normalizeAutoJoin(body);
+      const rejected = body.domains
+        .filter(d => d.trim() !== "")
+        .filter(
+          d =>
+            !normalized?.domains.includes(
+              d.trim().toLowerCase().replace(/^@/, ""),
+            ),
+        );
+      if (rejected.length > 0) {
+        return c.json(
+          { success: false, error: `Not a domain: ${rejected.join(", ")}` },
+          400,
+        );
+      }
+      await workspaceService.setAutoJoin(workspaceId, normalized);
+      logger.info("Workspace auto-join updated", {
+        workspaceId,
+        by: c.get("user")?.id,
+        domains: normalized?.domains ?? [],
+        role: normalized?.role ?? null,
+      });
+      return c.json({ success: true, data: serializeAutoJoin(normalized) });
+    } catch (error) {
+      logger.error("Error updating auto-join", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to update auto-join",
         },
         500,
       );

--- a/api/src/services/auto-join.service.test.ts
+++ b/api/src/services/auto-join.service.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Domain auto-join: a signed-in person whose email domain a workspace lists
+ * becomes a member on first contact — with the access role the workspace
+ * chose and nothing else — so someone who clicks an app link and signs in
+ * is simply in, without an invitation.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { Workspace, WorkspaceMember } from "../database/workspace-schema";
+import { ensureAutoJoin, normalizeAutoJoin } from "./auto-join.service";
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId();
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+beforeEach(async () => {
+  await Workspace.deleteMany({});
+  await WorkspaceMember.deleteMany({});
+  await Workspace.create({
+    _id: WS,
+    name: "Acme",
+    slug: "acme",
+    createdBy: "u-owner",
+    settings: { autoJoin: { domains: ["acme.com"], role: "viewer" } },
+    billing: {},
+  });
+});
+
+describe("ensureAutoJoin", () => {
+  it("makes a matching-domain stranger a member with the workspace's access role", async () => {
+    const member = await ensureAutoJoin(WS.toString(), {
+      id: "u-sam",
+      email: "Sam@Acme.com",
+    });
+    expect(member).toMatchObject({ userId: "u-sam", role: "viewer" });
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(1);
+  });
+
+  it("is idempotent and never touches an existing membership", async () => {
+    await WorkspaceMember.create({
+      workspaceId: WS,
+      userId: "u-lead",
+      role: "admin",
+    });
+    const member = await ensureAutoJoin(WS.toString(), {
+      id: "u-lead",
+      email: "lead@acme.com",
+    });
+    expect(member?.role).toBe("admin");
+    await ensureAutoJoin(WS.toString(), { id: "u-sam", email: "sam@acme.com" });
+    await ensureAutoJoin(WS.toString(), { id: "u-sam", email: "sam@acme.com" });
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(2);
+  });
+
+  it("refuses other domains, sub-domains, and a workspace with no auto-join", async () => {
+    expect(
+      await ensureAutoJoin(WS.toString(), { id: "u-x", email: "x@gmail.com" }),
+    ).toBeNull();
+    expect(
+      await ensureAutoJoin(WS.toString(), {
+        id: "u-y",
+        email: "y@evil.acme.com",
+      }),
+    ).toBeNull();
+    await Workspace.updateOne(
+      { _id: WS },
+      { $unset: { "settings.autoJoin": 1 } },
+    );
+    expect(
+      await ensureAutoJoin(WS.toString(), { id: "u-z", email: "z@acme.com" }),
+    ).toBeNull();
+    expect(await WorkspaceMember.countDocuments({ workspaceId: WS })).toBe(0);
+  });
+
+  it("never grants more than member, whatever the stored role says", async () => {
+    await Workspace.updateOne(
+      { _id: WS },
+      { $set: { "settings.autoJoin.role": "admin" } },
+      { strict: false },
+    );
+    const member = await ensureAutoJoin(WS.toString(), {
+      id: "u-sam",
+      email: "sam@acme.com",
+    });
+    expect(member?.role).toBe("viewer");
+  });
+});
+
+describe("normalizeAutoJoin", () => {
+  it("lowercases and dedupes domains, rejects junk, and drops the block when no domain is left", () => {
+    expect(
+      normalizeAutoJoin({
+        domains: [" Acme.com", "acme.com", "@acme.ch", "", "not a domain"],
+        role: "member",
+      }),
+    ).toEqual({ domains: ["acme.com", "acme.ch"], role: "member" });
+    expect(normalizeAutoJoin({ domains: ["acme.com"], role: "owner" })).toEqual(
+      { domains: ["acme.com"], role: "viewer" },
+    );
+    expect(
+      normalizeAutoJoin({ domains: ["", "x"], role: "viewer" }),
+    ).toBeNull();
+    expect(normalizeAutoJoin(null)).toBeNull();
+  });
+});

--- a/api/src/services/auto-join.service.ts
+++ b/api/src/services/auto-join.service.ts
@@ -1,0 +1,107 @@
+/**
+ * Domain auto-join (apps.md §28).
+ *
+ * The flow it exists for: someone gets a published app's link, clicks, signs
+ * in, and is in — no invitation, no admin action per person. A workspace
+ * lists the email domains it trusts and the ACCESS role every newcomer from
+ * those domains gets (viewer or member, never more); the first request that
+ * would otherwise be refused for "not a member" creates the membership
+ * instead. Exact domain match only: a sub-domain is somebody else's.
+ *
+ * That is all the platform knows about a newcomer. What they should see
+ * inside an app is the app's business (`useViewer()` + the warehouse).
+ */
+import { Types } from "mongoose";
+import {
+  Workspace,
+  WorkspaceMember,
+  type IWorkspaceAutoJoin,
+  type IWorkspaceMember,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+
+const logger = loggers.workspace();
+
+const DOMAIN_RE =
+  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+/**
+ * Clean a submitted auto-join block: domains lowercased, de-duplicated,
+ * a leading `@` tolerated, junk dropped. Null when nothing valid is left —
+ * which also means "turn auto-join off".
+ */
+export function normalizeAutoJoin(
+  input: { domains?: unknown; role?: unknown } | null,
+): IWorkspaceAutoJoin | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = Array.isArray(input.domains) ? input.domains : [];
+  const domains: string[] = [];
+  for (const d of raw) {
+    if (typeof d !== "string") continue;
+    const clean = d.trim().toLowerCase().replace(/^@/, "");
+    if (DOMAIN_RE.test(clean) && !domains.includes(clean)) domains.push(clean);
+  }
+  if (domains.length === 0) return null;
+  return { domains, role: input.role === "member" ? "member" : "viewer" };
+}
+
+export function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at === -1) return null;
+  return (
+    email
+      .slice(at + 1)
+      .trim()
+      .toLowerCase() || null
+  );
+}
+
+/**
+ * The person's membership in `workspaceId`, creating it when the workspace
+ * auto-joins their email domain. Null when they are not a member and the
+ * domain is not trusted. Safe to call on every request: one read for a
+ * member, and the (workspaceId, userId) unique index makes a concurrent
+ * first contact create exactly one row.
+ */
+export async function ensureAutoJoin(
+  workspaceId: string,
+  user: { id: string; email?: string | null },
+): Promise<IWorkspaceMember | null> {
+  if (!Types.ObjectId.isValid(workspaceId)) return null;
+  const wsId = new Types.ObjectId(workspaceId);
+  const existing = await WorkspaceMember.findOne({
+    workspaceId: wsId,
+    userId: user.id,
+  });
+  if (existing) return existing;
+
+  const domain = user.email ? emailDomain(user.email) : null;
+  if (!domain) return null;
+  const workspace = await Workspace.findById(wsId)
+    .select("settings.autoJoin")
+    .lean<{ settings?: { autoJoin?: IWorkspaceAutoJoin } }>();
+  const autoJoin = workspace?.settings?.autoJoin;
+  if (!autoJoin || !autoJoin.domains?.includes(domain)) return null;
+
+  try {
+    const member = await WorkspaceMember.create({
+      workspaceId: wsId,
+      userId: user.id,
+      role: autoJoin.role === "member" ? "member" : "viewer",
+      joinedAt: new Date(),
+    });
+    logger.info("Auto-joined a member by email domain", {
+      workspaceId,
+      userId: user.id,
+      domain,
+      role: member.role,
+    });
+    return member;
+  } catch (error) {
+    // Lost a race with another first request: the row now exists.
+    if ((error as { code?: number }).code === 11000) {
+      return WorkspaceMember.findOne({ workspaceId: wsId, userId: user.id });
+    }
+    throw error;
+  }
+}

--- a/api/src/services/workspace.service.ts
+++ b/api/src/services/workspace.service.ts
@@ -6,6 +6,7 @@ import {
   IWorkspace,
   IWorkspaceMember,
   IWorkspaceInvite,
+  type IWorkspaceAutoJoin,
 } from "../database/workspace-schema";
 import { Session, User } from "../database/schema";
 import { v4 as uuidv4 } from "uuid";
@@ -173,6 +174,20 @@ export class WorkspaceService {
     updates: Partial<IWorkspace>,
   ): Promise<IWorkspace | null> {
     return Workspace.findByIdAndUpdate(workspaceId, updates, { new: true });
+  }
+
+  /** Domain auto-join settings; null turns it off. */
+  async setAutoJoin(
+    workspaceId: string,
+    autoJoin: IWorkspaceAutoJoin | null,
+  ): Promise<void> {
+    await Workspace.updateOne(
+      { _id: new Types.ObjectId(workspaceId) },
+      autoJoin
+        ? { $set: { "settings.autoJoin": autoJoin } }
+        : { $unset: { "settings.autoJoin": 1 } },
+      { runValidators: true },
+    );
   }
 
   /**

--- a/api/vitest.apps.config.ts
+++ b/api/vitest.apps.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
       "src/agent-lib/capabilities/runtime.test.ts",
       "src/apps/preview.service.test.ts",
       "src/apps/deployment.service.test.ts",
+      // Viewer identity (apps.md §28): who an app is talking to, and the
+      // domain auto-join that lets a link-clicker become a member.
+      "src/apps/app-viewer.service.test.ts",
+      "src/services/auto-join.service.test.ts",
       "src/apps/deploy-on-push.test.ts",
       "src/inngest/functions/apps-binding-refresh.test.ts",
       // These two were written as vitest suites but listed in no vitest

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -538,6 +538,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{id}/auto-join": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Domain auto-join settings
+         * @description Email domains whose signed-in users become members on first contact (no invitation), and the access role they get (viewer or member). `null` when off. How someone opens a published app's link, signs in, and is simply in (apps.md §28).
+         */
+        get: operations["get_api_workspaces_id_auto_join"];
+        /** Set domain auto-join */
+        put: operations["put_api_workspaces_id_auto_join"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{id}/invites": {
         parameters: {
             query?: never;
@@ -3994,6 +4015,26 @@ export interface paths {
         };
         /** List the app's data bindings (front matter + build state) */
         get: operations["get_api_workspaces_workspaceId_apps_id_bindings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/viewer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Who the caller is to this app (what `useViewer()` sees)
+         * @description What `__data/viewer.json` says for the caller: their id and email, the workspace (id, name, their access role) and their role on this app (owner / editor / viewer). Nothing else — an app looks up what it needs about the person in the warehouse by email (apps.md §28). Editors of the app may pass `?as=<email>` to see another member's resolution; a laptop `vite dev` uses this for MAKO_VIEWER_AS.
+         */
+        get: operations["get_api_workspaces_workspaceId_apps_id_viewer"];
         put?: never;
         post?: never;
         delete?: never;
@@ -7731,6 +7772,97 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_id_auto_join: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    put_api_workspaces_id_auto_join: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    domains: string[];
+                    /**
+                     * @default viewer
+                     * @enum {string}
+                     */
+                    role?: "member" | "viewer";
+                };
+            };
+        };
         responses: {
             /** @description Successful response */
             "2XX": {
@@ -19054,6 +19186,49 @@ export interface operations {
     get_api_workspaces_workspaceId_apps_id_bindings: {
         parameters: {
             query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_viewer: {
+        parameters: {
+            query?: {
+                as?: string;
+            };
             header?: never;
             path: {
                 workspaceId: string;

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Box,
   Typography,
@@ -34,6 +34,7 @@ import {
   Close,
 } from "@mui/icons-material";
 import { useWorkspace } from "../contexts/workspace-context";
+import { workspaceClient } from "../lib/workspace-client";
 import { useAuth } from "../contexts/auth-context";
 import { trackEvent } from "../lib/analytics";
 import { useConfirm } from "./ConfirmDialog";
@@ -240,6 +241,8 @@ export function WorkspaceMembers() {
         </Alert>
       )}
 
+      {canManageMembers && <AutoJoinCard workspaceId={currentWorkspace.id} />}
+
       <TableContainer
         component={Paper}
         sx={{ boxShadow: "none", border: "1px solid rgba(224, 224, 224, 1)" }}
@@ -439,5 +442,135 @@ export function WorkspaceMembers() {
         </DialogActions>
       </Dialog>
     </Box>
+  );
+}
+
+/**
+ * Domain auto-join: anyone signing in with an email on these domains joins
+ * the workspace on first contact — no invitation — with this access role.
+ * The way someone clicks a published app's link, signs in, and is in.
+ * What they then see inside an app is the app's business (apps.md §28).
+ */
+function AutoJoinCard({ workspaceId }: { workspaceId: string }) {
+  const [loaded, setLoaded] = useState(false);
+  const [domains, setDomains] = useState("");
+  const [role, setRole] = useState<"member" | "viewer">("viewer");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    workspaceClient
+      .getAutoJoin(workspaceId)
+      .then(current => {
+        if (cancelled) return;
+        setDomains(current?.domains.join(", ") ?? "");
+        setRole(current?.role ?? "viewer");
+      })
+      .catch((e: any) => setError(e.message || "Failed to load auto-join"))
+      .finally(() => !cancelled && setLoaded(true));
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const list = domains
+        .split(/[,\s]+/)
+        .map(d => d.trim())
+        .filter(Boolean);
+      const saved = await workspaceClient.setAutoJoin(workspaceId, {
+        domains: list,
+        role,
+      });
+      setMessage(
+        saved
+          ? `Anyone with an email on ${saved.domains.join(", ")} now joins as ${saved.role} the first time they open the workspace or one of its apps.`
+          : "Auto-join is off.",
+      );
+      setTimeout(() => setMessage(null), 6000);
+    } catch (e: any) {
+      setError(e.message || "Failed to save auto-join");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        mb: 2,
+        boxShadow: "none",
+        border: "1px solid rgba(224, 224, 224, 1)",
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        Auto-join by email domain
+      </Typography>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mb: 1.5 }}
+      >
+        People who sign in with an email on these domains become members the
+        first time they open the workspace or one of its apps — no invitation
+        needed — with the access role below. Leave the domains empty to turn it
+        off.
+      </Typography>
+      {error && (
+        <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {message && (
+        <Alert
+          severity="success"
+          sx={{ mb: 1.5 }}
+          onClose={() => setMessage(null)}
+        >
+          {message}
+        </Alert>
+      )}
+      <Box
+        sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}
+      >
+        <TextField
+          size="small"
+          label="Domains"
+          placeholder="acme.com, acme.ch"
+          value={domains}
+          onChange={e => setDomains(e.target.value)}
+          disabled={!loaded || saving}
+          sx={{ minWidth: 260, flex: 1 }}
+        />
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel>Access</InputLabel>
+          <Select
+            value={role}
+            label="Access"
+            onChange={e => setRole(e.target.value as "member" | "viewer")}
+            disabled={!loaded || saving}
+          >
+            <MenuItem value="viewer">Viewer</MenuItem>
+            <MenuItem value="member">Member</MenuItem>
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          size="small"
+          onClick={save}
+          disabled={!loaded || saving}
+        >
+          {saving ? <CircularProgress size={18} /> : "Save"}
+        </Button>
+      </Box>
+    </Paper>
   );
 }

--- a/app/src/lib/workspace-client.ts
+++ b/app/src/lib/workspace-client.ts
@@ -91,6 +91,12 @@ export interface UpdateMemberRoleData {
   role: "admin" | "member" | "viewer";
 }
 
+/** Domain auto-join: who joins by email domain, and with which access. null = off. */
+export interface WorkspaceAutoJoin {
+  domains: string[];
+  role: "member" | "viewer";
+}
+
 export interface WorkspaceDatabase {
   id: string;
   name: string;
@@ -217,6 +223,30 @@ class WorkspaceClient {
       }),
     );
     return body.data as WorkspaceMember;
+  }
+
+  /** Domain auto-join settings (owner/admin). */
+  async getAutoJoin(workspaceId: string): Promise<WorkspaceAutoJoin | null> {
+    const body = unwrap(
+      await api.GET("/api/workspaces/{id}/auto-join", {
+        params: { path: { id: workspaceId } },
+      }),
+    );
+    return (body.data ?? null) as WorkspaceAutoJoin | null;
+  }
+
+  /** An empty domain list turns auto-join off. */
+  async setAutoJoin(
+    workspaceId: string,
+    data: WorkspaceAutoJoin,
+  ): Promise<WorkspaceAutoJoin | null> {
+    const body = unwrap(
+      await api.PUT("/api/workspaces/{id}/auto-join", {
+        params: { path: { id: workspaceId } },
+        body: data,
+      }),
+    );
+    return (body.data ?? null) as WorkspaceAutoJoin | null;
   }
 
   /**

--- a/apps.md
+++ b/apps.md
@@ -3141,3 +3141,88 @@ Two limits are now about the prompt, not a schema: descriptions cap at 300
 characters (they are index lines), and the 200-skill cap stays as the point
 past which an index alone stops routing well. Unbound workspaces have no
 skills — the posture every other kind already had.
+
+## 28. Who is looking: identity is a primitive, permissions are the app's (2026-09-07)
+
+> Supersedes §27 (viewer roles). Rolled back the same evening (PR #988):
+> #983 put a fixed list of job roles (`sdr`, `bdr`, `csm`, …) and an ISO
+> country on every workspace member, #984 auto-joined domains with a
+> default job role and country, #985/#987 added a "wait for an admin"
+> gate. Joan: *"Mako is meant to be an Open Source data platform as well
+> as a SaaS. It cannot be so opinionated about roles and countries. These
+> are specific to RealAdvisor and don't belong in the platform."* The
+> problem stands; the solution is replaced by this section.
+
+**The rule.** The platform knows WHO a person is and WHAT THEY MAY TOUCH,
+and nothing about what they do for a living. Workspace roles stay access
+levels — owner / admin / member / viewer — and `WorkspaceMember` gains no
+field a company would want to rename. Anything an app needs to shape its
+view (team, territory, seniority, quota) is data the app owns, looked up in
+the warehouse by the one key every CRM, HRIS and warehouse already share:
+the email address.
+
+**The primitive: `useViewer()`.** A published app can ask who is looking.
+`__data/viewer.json` — next to `__data/index.json` and the parquet files,
+so it exists in the sandbox, the published app and a laptop `vite dev`
+alike — answers:
+
+```json
+{
+  "id": "…", "email": "sam@acme.com",
+  "workspace": { "id": "…", "name": "Acme", "role": "viewer" },
+  "app": { "id": "…", "slug": "fr-sales", "role": "viewer" }
+}
+```
+
+or `null` on an anonymous share link. `workspace.role` is the access role;
+`app.role` is the resource ACL's answer (owner / editor / viewer,
+`utils/resource-acl.ts`). Nothing else, deliberately: every extra key here
+would be the first step back to §27.
+
+**Identity reaches the cookie-free route through the grant.** The
+sandboxed iframe has an opaque origin and no cookies, so the `pub.` token
+minted by `POST /apps/{id}/view-token` carries `u`/`e` (user id, email)
+under the HMAC — a tampered email fails like any other byte. Static build
+previews carry the builder the same way (in-memory grant). `/live/*` uses
+the session. `serveDeploymentFile({ viewer })` is still the one function
+all three published routes converge on; the anonymous share passes `null`.
+The identity lookup (workspace name, membership, ACL) happens only on the
+`viewer.json` request — never per asset.
+
+**The pattern (the apps skill teaches it):** a roster binding —
+`bindings/viewers.sql`, `email` plus only the columns the app's logic
+needs — joined on `lower(viewer.email)` in `useDuckDB`, and the UI
+branches on the row. A promotion in the CRM changes the view the next
+morning with no commit and no admin click. `MAKO_VIEWER_AS=<email>` in the
+repo's `.env` (or `GET /apps/{id}/viewer?as=`) previews the app as another
+member; editors of the app only.
+
+**What this is not (yet).** Every binding an admitted viewer can read is
+downloaded whole into their browser, so the roster pattern shapes the UI;
+it is not access control. Accepted for now (Joan: *"I don't care about
+that at this point"*). Server-side enforcement is an additive step on the
+same primitive when the day comes: `mako.json` names a claims binding
+whose row for `viewer.email` supplies `{{ viewer.<column> }}`, a single
+`-- row_filter:` per binding compiles to a bound-parameter predicate, and
+the DuckDB filter service from #983 (`filtered-parquet.service.ts`,
+`compileRowFilter`) streams the result. That was Théo's rejected `source`
+design, which was the generic one: claims from data, never from an enum.
+
+**Domain auto-join stays, stripped.** The UX Théo needed — *"un bdr reçoit
+le lien … il passe par gauth mako, et pouf il est sur sa vue"* — needs
+membership without an invitation, which Slack, Notion and Google Workspace
+all offer. `settings.autoJoin = { domains, role: "viewer" | "member" }`,
+one card on the Members page, applied by `requireWorkspace` and the apps
+router's access check on the first request that would have refused the
+person. No default job role, no country, no pending gate: a newcomer with
+no roster row simply sees an empty app.
+
+Code: `api/src/apps/app-viewer.service.ts` (resolution),
+`preview.service.ts` (`viewer` on grants), `deployment.service.ts`,
+routes `apps.ts` (`GET /{id}/viewer`, view-token, preview grant) /
+`apps-preview.ts` / `public-share.ts`; `services/auto-join.service.ts`,
+`routes/workspaces.ts` (`GET`/`PUT /{id}/auto-join`); SDK `useViewer()` /
+`getViewer()` and the Vite plugin's `viewer.json` + `MAKO_VIEWER_AS`
+(2.4.0); workspace template v12. Tests: `app-viewer.service.test.ts`,
+`preview.service.test.ts`, `deployment.service.test.ts`,
+`auto-join.service.test.ts`.

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -4256,6 +4256,173 @@
         "operationId": "delete_api_workspaces_id_members_userId"
       }
     },
+    "/api/workspaces/{id}/auto-join": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Domain auto-join settings",
+        "description": "Email domains whose signed-in users become members on first contact (no invitation), and the access role they get (viewer or member). `null` when off. How someone opens a published app's link, signs in, and is simply in (apps.md §28).",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_id_auto_join"
+      },
+      "put": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Set domain auto-join",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "domains": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 20
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "member",
+                      "viewer"
+                    ],
+                    "default": "viewer"
+                  }
+                },
+                "required": [
+                  "domains"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "put_api_workspaces_id_auto_join"
+      }
+    },
     "/api/workspaces/{id}/invites": {
       "post": {
         "tags": [
@@ -25514,6 +25681,92 @@
           }
         },
         "operationId": "get_api_workspaces_workspaceId_apps_id_bindings"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/viewer": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Who the caller is to this app (what `useViewer()` sees)",
+        "description": "What `__data/viewer.json` says for the caller: their id and email, the workspace (id, name, their access role) and their role on this app (owner / editor / viewer). Nothing else — an app looks up what it needs about the person in the warehouse by email (apps.md §28). Editors of the app may pass `?as=<email>` to see another member's resolution; a laptop `vite dev` uses this for MAKO_VIEWER_AS.",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "as",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_viewer"
       }
     },
     "/api/workspaces/{workspaceId}/apps/{id}/bindings/{name}/artifact": {

--- a/packages/app-sdk/README.md
+++ b/packages/app-sdk/README.md
@@ -45,6 +45,48 @@ or 502 with the query's error.
 Data arrives from `__data/<name>.parquet`, relative to the page — the same
 path in Mako's sandbox, in a published app, and on a laptop.
 
+### Who is looking: `useViewer()`
+
+```tsx
+import { useViewer } from "@makoai/app-sdk";
+
+const { viewer, loading } = useViewer();
+// viewer === null       → anonymous share link (or still loading)
+// viewer.email          → "sam@acme.com"
+// viewer.workspace.role → "owner" | "admin" | "member" | "viewer" | null
+// viewer.app.role       → "owner" | "editor" | "viewer" | null
+```
+
+Mako resolves the viewer server-side from the session or the signed view
+token — the page cannot forge it — and reports only what the platform
+knows: identity, the workspace and the person's **access** role in it, and
+their role on this app. There is no job title, team or country in the
+platform, on purpose: those are your data. Put a roster in a binding and
+join on the email:
+
+```sql
+-- bindings/viewers.sql
+SELECT lower(email) AS email, team, country, is_lead FROM hr.people
+```
+
+```tsx
+const { viewer } = useViewer();
+const me = useDuckDB(
+  viewer ? `select * from viewers where email = '${viewer.email.replace(/'/g, "''")}'` : "select 1 where false",
+);
+const board = useDuckDB(
+  me.data?.[0]?.is_lead
+    ? "select * from pipeline"
+    : `select * from pipeline where team = '${me.data?.[0]?.team ?? ""}'`,
+);
+```
+
+Keep the roster binding to the columns the app needs for its logic: every
+binding the app can read is downloaded whole into the viewer's browser, so
+this shapes the UI rather than enforcing access. Who may *open* the app is
+the app's access setting in Mako; server-side row filtering is a follow-up
+on the same identity (apps.md §28).
+
 ## In `vite.config.ts`
 
 ```ts
@@ -61,6 +103,10 @@ materialized is built on first request, and `POST __data/<name>/refresh`
 `node_modules/.mako-data/` for five minutes (`?refresh` bypasses; a stale
 copy is served if the API is unreachable). It is `apply: "serve"` only —
 production builds never load it.
+
+It also answers `__data/viewer.json` (you, as Mako sees you), and
+`MAKO_VIEWER_AS=<email>` — in the environment or the repo's `.env` —
+previews the app as that member instead (editors of the app only).
 
 Credentials, in order: `MAKO_API_URL` / `MAKO_API_KEY` in the environment,
 then in the repo-root `.env`. The workspace id comes from

--- a/packages/app-sdk/index.d.ts
+++ b/packages/app-sdk/index.d.ts
@@ -76,6 +76,41 @@ export function refreshBindings(
   names?: string[],
 ): Promise<RefreshResult[]>;
 
+/**
+ * The person viewing the app, as Mako resolved them from the session or the
+ * signed view token (apps.md §28). Only what the platform knows: identity,
+ * the workspace and their ACCESS role in it, their role on this app. Look
+ * up anything else (team, territory, …) in the warehouse by `email`.
+ */
+export interface Viewer {
+  id: string;
+  /** Signed-in email, lowercased. */
+  email: string;
+  workspace: {
+    id: string;
+    name: string;
+    /** Access role in the workspace; null when not a member. */
+    role: "owner" | "admin" | "member" | "viewer" | null;
+  };
+  app: {
+    id: string;
+    slug: string | null;
+    /** What they may do to this app. */
+    role: "owner" | "editor" | "viewer" | null;
+  };
+}
+export interface ViewerState {
+  /** null while loading, on an anonymous share, or on an older server. */
+  viewer: Viewer | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/** Who is looking. The app decides what that means for its UI and data. */
+export function useViewer(): ViewerState;
+/** The same, outside a component; resolved once per page. */
+export function getViewer(): Promise<Viewer | null>;
+
 export function useTheme(): { theme: "light" | "dark" };
 export function useLocation(): MakoLocation;
 export function useSearchParams(): [

--- a/packages/app-sdk/index.js
+++ b/packages/app-sdk/index.js
@@ -179,6 +179,54 @@ export async function refreshBindings(names) {
   return settled.map(s => s.value);
 }
 
+// ---------------------------------------------------------------------------
+// Viewer — who is looking. `__data/viewer.json` is answered per request by
+// whoever serves the app (Mako's published/preview routes from the session
+// or the signed token, the Vite plugin from the API), so the app cannot
+// forge it. `null` on an anonymous share link, and on servers that predate
+// it (404). Mako says only what it knows: id, email, the workspace and the
+// person's ACCESS role in it, their role on this app. Anything else about
+// the person is data the app looks up in the warehouse by email.
+// ---------------------------------------------------------------------------
+let viewerPromise = null;
+function normalizeViewer(body) {
+  if (!body || typeof body !== "object" || typeof body.email !== "string") return null;
+  const ws = body.workspace && typeof body.workspace === "object" ? body.workspace : {};
+  const app = body.app && typeof body.app === "object" ? body.app : {};
+  return {
+    id: typeof body.id === "string" ? body.id : "",
+    email: body.email,
+    workspace: {
+      id: typeof ws.id === "string" ? ws.id : "",
+      name: typeof ws.name === "string" ? ws.name : "",
+      role: typeof ws.role === "string" ? ws.role : null,
+    },
+    app: {
+      id: typeof app.id === "string" ? app.id : "",
+      slug: typeof app.slug === "string" ? app.slug : null,
+      role: typeof app.role === "string" ? app.role : null,
+    },
+  };
+}
+
+/** The viewer, once per page. Resolves to null when nobody is known. */
+export function getViewer() {
+  viewerPromise ??= fetch("__data/viewer.json").then(async r => {
+    if (r.status === 404) return null;
+    const body = await r.json().catch(() => null);
+    if (!r.ok) {
+      throw new Error(
+        body && body.error ? String(body.error) : "Viewer lookup failed (HTTP " + r.status + ")",
+      );
+    }
+    return normalizeViewer(body);
+  });
+  viewerPromise.catch(() => {
+    viewerPromise = null;
+  });
+  return viewerPromise;
+}
+
 /** Names of every staged binding — written by the dev server next to the
  * parquet files. Absent (older servers, published builds): empty list. */
 let indexPromise = null;
@@ -304,6 +352,37 @@ export function useQuery(name, opts) {
   );
   const refresh = React.useCallback(() => refreshBinding(name), [name]);
   return { ...state, refresh };
+}
+
+/**
+ * Who is looking at the app: `{ viewer, loading, error }`. `viewer` is null
+ * while loading, on an anonymous share link, and when the server does not
+ * know. Join `viewer.email` against your own roster binding for anything
+ * beyond identity and access role — that is the app's call, not Mako's.
+ */
+export function useViewer() {
+  const [state, setState] = React.useState({ viewer: null, loading: true, error: null });
+  React.useEffect(() => {
+    let active = true;
+    getViewer().then(
+      viewer => {
+        if (active) setState({ viewer, loading: false, error: null });
+      },
+      error => {
+        if (active) {
+          setState({
+            viewer: null,
+            loading: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, []);
+  return state;
 }
 
 export function useDuckDB(sql, opts) {

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makoai/app-sdk",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Mako app SDK: data bindings (useQuery/useDuckDB), URL state, theme.",
   "license": "MIT",
   "repository": {

--- a/packages/app-sdk/vite.d.ts
+++ b/packages/app-sdk/vite.d.ts
@@ -15,6 +15,11 @@ export interface MakoDataOptions {
   revalidateMs?: number;
   /** Build a never-materialized binding on first request. Default: true. */
   materialize?: boolean;
+  /**
+   * Preview the app as this member (an email): `__data/viewer.json` answers
+   * as Mako would for them. Default: MAKO_VIEWER_AS, else yourself.
+   */
+  viewAs?: string;
 }
 
 export interface MakoContext {
@@ -25,6 +30,8 @@ export interface MakoContext {
   slug: string;
   bindingsDir: string;
   cacheDir: string;
+  /** Email of the member being previewed, or "" for yourself. */
+  viewAs: string;
 }
 
 /** Resolve credentials and identity the way `makoData` does. */

--- a/packages/app-sdk/vite.js
+++ b/packages/app-sdk/vite.js
@@ -88,6 +88,8 @@ export function resolveMakoContext(appDir, options = {}) {
     slug: options.slug ?? path.basename(path.resolve(appDir)),
     bindingsDir: path.join(appDir, "bindings"),
     cacheDir: path.join(appDir, "node_modules", ".mako-data"),
+    /** Preview the app as this viewer (email) — see makoData(). */
+    viewAs: options.viewAs ?? env("MAKO_VIEWER_AS") ?? "",
   };
 }
 
@@ -223,11 +225,31 @@ export function makoData(options = {}) {
         }
       }
 
+      // `__data/viewer.json` — the SDK's useViewer(): the developer's own
+      // identity, or, with MAKO_VIEWER_AS=<email> (env or .env), another
+      // member's, exactly as Mako would answer for them.
+      const viewAsQuery = ctx.viewAs ? `?as=${encodeURIComponent(ctx.viewAs)}` : "";
+      async function serveViewer(res) {
+        if (problems.length) return json(res, 200, null);
+        try {
+          const r = await apiFetch(`${appBase()}/viewer${viewAsQuery}`, {
+            headers: await headers(),
+          });
+          const body = await r.json().catch(() => ({}));
+          if (r.status === 404) return json(res, 200, null);
+          if (!r.ok) return json(res, r.status, { error: body.error ?? `viewer: HTTP ${r.status}` });
+          return json(res, 200, body.viewer ?? null);
+        } catch (error) {
+          return json(res, 502, { error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+
       server.middlewares.use(async (req, res, next) => {
         const [pathname, query = ""] = (req.url || "").split("?");
         if (pathname === "/__data/index.json") {
           return json(res, 200, listBindings(ctx.bindingsDir));
         }
+        if (pathname === "/__data/viewer.json") return serveViewer(res);
         const match = /^\/__data\/([^/]+)(\.parquet|\/refresh)$/.exec(pathname);
         if (!match) return next();
         const name = decodeURIComponent(match[1]);


### PR DESCRIPTION
## Summary

The generic replacement for the rolled-back viewer roles (#983/#984/#987, reverted in #988). Design note: `apps.md §28`.

**The rule.** The platform knows who a person is and what they may touch, nothing about what they do for a living. Workspace roles stay access levels (owner / admin / member / viewer). No job roles, no countries, no enums.

**Phase 1 — the identity primitive**
- `__data/viewer.json` next to the parquet files, answered by every server that serves an app (published `/live/*`, the token route for the sandboxed iframe, the build preview, the laptop Vite plugin): `{ id, email, workspace: { id, name, role }, app: { id, slug, role } }`, or `null` on an anonymous share.
- Identity rides in the HMAC-signed `pub.` token (`u`/`e`) and on the builder's static preview grant, so the cookie-free iframe gets it and cannot forge it. Resolved only on the `viewer.json` request, never per asset.
- `GET /apps/{id}/viewer?as=<email>` and `MAKO_VIEWER_AS` in `.env` preview the app as another member (editors of the app only).
- SDK **2.4.0**: `useViewer()` / `getViewer()`; the Vite plugin answers `viewer.json`.
- The apps skill and the workspace template (v12) teach the pattern: a roster binding (`email` + only the columns the logic needs) joined on the viewer's email in DuckDB. The skill tells the agent never to propose such fields on Mako users.

**Phase 2 — domain auto-join, stripped**
- `settings.autoJoin = { domains, role: "viewer" | "member" }`, one card on the Members page, `GET`/`PUT /workspaces/{id}/auto-join` (owner/admin).
- Applied by `requireWorkspace` and the apps router's access check on the first request that would have refused the person. Never grants more than member. No default job role, no country, no pending gate.

**Not in this PR (deferred, §28 "What this is not yet").** Server-side row filtering on the same primitive. Every binding an admitted viewer can read is still downloaded whole; the roster pattern shapes the UI, it is not access control.

## Test plan
- [x] `app-viewer.service.test.ts` (ACL → app role, non-member, preview-as by email), `preview.service.test.ts` (viewer round-trip, forged email rejected, static grant), `deployment.service.test.ts` (`viewer.json` known / anonymous), `auto-join.service.test.ts` (join, idempotent, sub-domains refused, never above member)
- [x] pre-push: both vitest configs green (33 + 32 files)
- [x] API + app typecheck, lint, `openapi:sync`, template fingerprint pinned (v12)
- [x] frontend unit tests (75 files)
- [ ] CI
- [ ] After merge: `MAKO_VIEWER_AS` + `useViewer()` in the RealAdvisor dashboard; publish `@makoai/app-sdk@2.4.0` (`app-sdk-v2.4.0` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aPGkHWQW8TeYtzjEVQ5pb