### PR TITLE
fix(apps): useViewer() from a laptop — login token may GET /apps/{id}/viewer; template v13 unsticks repos refreshed by the rolled-back #983

### DIFF
--- a/api/src/apps/workspace-template.test.ts
+++ b/api/src/apps/workspace-template.test.ts
@@ -8,7 +8,7 @@ import {
 
 // When this fails you changed a managed file: bump WORKSPACE_TEMPLATE_VERSION
 // and paste the new fingerprint. The bump is what moves existing repos.
-const PINNED = { version: 12, fingerprint: "6807799526ab90df" };
+const PINNED = { version: 13, fingerprint: "e2185d0400a6c61d" };
 assert.equal(WORKSPACE_TEMPLATE_VERSION, PINNED.version);
 assert.equal(
   templateFingerprint(),

--- a/api/src/apps/workspace-template.ts
+++ b/api/src/apps/workspace-template.ts
@@ -31,7 +31,7 @@ import { fetchFromCloud, queueMirrorPush } from "./cloud-repo.service";
 
 const logger = loggers.app();
 
-export const WORKSPACE_TEMPLATE_VERSION = 12;
+export const WORKSPACE_TEMPLATE_VERSION = 13;
 
 /** Where `.mcp.json` points when MAKO_API_URL is not exported. */
 export const HOSTED_MAKO_URL = "https://app.mako.ai";

--- a/api/src/auth/scoped-key-routes.test.ts
+++ b/api/src/auth/scoped-key-routes.test.ts
@@ -21,6 +21,27 @@ for (const app of ["latest-sales", "68b0c0ffee0000000000abcd"]) {
     scopedKeyMayAccess("POST", `${base}/latest_sales/materialize`, read),
     true,
   );
+  // The viewer lookup behind `__data/viewer.json` in a laptop `vite dev`.
+  assert.equal(
+    scopedKeyMayAccess("GET", `/api/workspaces/${WS}/apps/${app}/viewer`, read),
+    true,
+  );
+  assert.equal(
+    scopedKeyMayAccess(
+      "POST",
+      `/api/workspaces/${WS}/apps/${app}/viewer`,
+      read,
+    ),
+    false,
+  );
+  assert.equal(
+    scopedKeyMayAccess(
+      "GET",
+      `/api/workspaces/${WS}/apps/${app}/viewer`,
+      mcpOnly,
+    ),
+    false,
+  );
   // Wrong verb on an allowed path is not allowed.
   assert.equal(scopedKeyMayAccess("POST", base, read), false);
   assert.equal(

--- a/api/src/auth/scoped-key-routes.ts
+++ b/api/src/auth/scoped-key-routes.ts
@@ -38,6 +38,13 @@ const BINDING_ROUTES: ReadonlyArray<{
       /^\/api\/workspaces\/[^/]+\/apps\/[^/]+\/bindings\/[^/]+\/materialize\/?$/,
     scope: "query:read",
   },
+  // `__data/viewer.json` on a laptop: the Vite plugin asks who the login
+  // belongs to with the same token it reads bindings with (apps.md §28).
+  {
+    method: "GET",
+    pattern: /^\/api\/workspaces\/[^/]+\/apps\/[^/]+\/viewer\/?$/,
+    scope: "query:read",
+  },
 ];
 
 export function isMcpEndpoint(path: string): boolean {


### PR DESCRIPTION
Two gaps left by #989 (apps.md §28):

1. **useViewer() 403s on a laptop.** The Vite plugin answers `__data/viewer.json` by calling `GET /workspaces/{ws}/apps/{slug}/viewer` with the `mako login` OAuth token, but scoped tokens were allowlisted only for the three binding routes. The viewer route joins the `query:read` allowlist (GET only), with tests.
2. **Connected repos stuck on the reverted SDK.** #983 refreshed repos to template v12 with SDK 2.3.0 before it was reverted; #989 re-used v12 for SDK 2.4.0. Refresh is monotonic on `templateVersion`, so `realadvisor/mako-workspace` (and any other repo refreshed this afternoon) kept the job-role SDK. Bumped to v13, fingerprint re-pinned, content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yfZ44aCHShdnXxxkoFMuk