### PR TITLE
docs: document useViewer() identity + domain auto-join

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -46,6 +46,8 @@ Create API keys in **Workspace settings → API Keys**. The same page surfaces y
 | `GET`  | `/api/workspaces/:id` | Get workspace details  |
 | `GET`  | `/api/workspaces/:id/settings/limits` | Get refresh concurrency limits (`dashboardRefreshConcurrency`, `appBindingRefreshConcurrency`; defaults 2, clamped to the per-workspace max) |
 | `PUT`  | `/api/workspaces/:id/settings/limits` | Update refresh concurrency limits |
+| `GET`  | `/api/workspaces/:id/auto-join` | Get domain auto-join settings (email domains that auto-join on first sign-in, and the role granted: `member` \| `viewer`) |
+| `PUT`  | `/api/workspaces/:id/auto-join` | Set domain auto-join (`{ domains: string[] (max 20), role?: "member" \| "viewer" }`, default role `viewer`) |
 
 ## Database Connections
 
@@ -363,6 +365,7 @@ Git-backed React apps built inside the workspace ([Apps](/apps/)). Private apps 
 | `POST`   | `/api/workspaces/:wid/apps/:id/preview` / `…/dev-preview`     | Published-build preview / live dev server preview          |
 | `POST`   | `/api/workspaces/:wid/apps/:id/public-share`                  | Manage the anonymous public link (also `PATCH`/`DELETE`)   |
 | `GET`    | `/api/workspaces/:wid/apps/:id/sandbox`                       | Sandbox status (also `POST …/sandbox/recycle`)             |
+| `GET`    | `/api/workspaces/:wid/apps/:id/viewer`                        | Resolve the caller's viewer identity (what `useViewer()` sees): id, email, workspace role, app role. Editors may pass `?as=<email>` to preview another member's resolution |
 
 ## Notebooks
 

--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -82,6 +82,43 @@ Apps follow the same model as dashboards (see [Sharing & Collaborators](/dashboa
 
 Public links (optionally password-protected) render the published deployment for anonymous viewers.
 
+## Identity: `useViewer()`
+
+Apps can ask who's looking. `@makoai/app-sdk` (v2.4+) exports a `useViewer()`
+hook:
+
+```ts
+const { viewer, loading, error } = useViewer();
+```
+
+`viewer` is `null` for an anonymous visitor on a public share link.
+Otherwise it resolves to:
+
+```ts
+{
+  id: string;
+  email: string; // lowercased
+  workspace: { id: string; name: string; role: "owner" | "admin" | "member" | "viewer" | null };
+  app: { id: string; slug: string; role: "owner" | "editor" | "viewer" | null };
+}
+```
+
+`workspace.role` is the person's access role on the workspace itself;
+`app.role` is their role on this specific app (owner/editor/viewer). Mako
+resolves both server-side from the session or a signed token — the app's
+own code cannot forge them. A standalone `getViewer()` promise is also
+available for non-React contexts.
+
+This is UI-shaping data, not access control: every binding an app can read
+is downloaded whole to the browser regardless of who's viewing, so don't
+rely on `useViewer()` to hide data — gate what a binding *contains*
+instead if that's the goal. Team, seniority, quota, or any other business
+attribute isn't part of the viewer shape by design; join a roster binding
+on `lower(viewer.email)` if the app needs it.
+
+For local development, set `MAKO_VIEWER_AS=<email>` in the app's `.env` to
+preview the app as a specific workspace member during `npm run dev`.
+
 ## Security Model
 
 - Binding queries are validated against the workspace's connections and run server-side with read-only enforcement on materialization SQL.


### PR DESCRIPTION
## What
Ships public docs for a feature that landed with zero Starlight coverage: PR #989 (feat/viewer-identity) + #990 (fixup), which added:

- `useViewer()` SDK hook (`@makoai/app-sdk` v2.4.0) — resolves the caller's id/email/workspace-role/app-role
- `GET /api/workspaces/:wid/apps/:id/viewer` — server-side viewer resolution, with `?as=<email>` for editor preview
- `GET/PUT /api/workspaces/:id/auto-join` — domain auto-join settings (email domains that auto-join, role `member`|`viewer`)

The internal design doc (`apps.md` §28, repo root) already described the final state correctly — this PR brings the public docs (`docs/src/content/docs/`) up to date to match.

## Changes
- `docs/src/content/docs/apps.md`: new **Identity: useViewer()** section between Access Control and Security Model — hook signature, viewer shape, `workspace.role` vs `app.role`, `MAKO_VIEWER_AS` local preview, and a callout that it's UI-shaping data, not access control.
- `docs/src/content/docs/api-reference.md`: added the `/viewer` row to the Apps table, and two `/auto-join` rows to the Workspaces table.

No nav changes needed (single existing Apps sidebar entry).

🤖 Docs gap found and filed by Aura's recurring docs-freshness check.