### PR TITLE
feat(flows): unify sync triggers into Webhook + a schedule list with per-row entity scope

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -929,6 +929,25 @@ export interface ISyncStateMeta {
 }
 
 /**
+ * One cron row of a flow's unified schedule list.
+ */
+export interface IFlowSchedule {
+  /** Stable id so a run can stamp `lastRunAt` on the right row. */
+  id: string;
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+  /**
+   * Entities this cadence syncs. Empty = every entity enabled in the flow's
+   * entity selection (`entityLayouts` / `entityFilter`).
+   */
+  entities?: string[];
+  /** "poll" honors `syncMode`; "reconcile" always does a full re-pull. */
+  kind: "poll" | "reconcile";
+  lastRunAt?: Date;
+}
+
+/**
  * Flow model interface (data sync flow configuration)
  */
 export interface IFlow extends Document {
@@ -979,14 +998,23 @@ export interface IFlow extends Document {
   destinationDatabaseName?: string;
   tableDestination?: ITableDestination; // For writing to SQL tables instead of MongoDB collections
 
+  /**
+   * Unified cron trigger list. Each row is one cadence with its own entity
+   * scope and run kind ("poll" = a normal run honoring `syncMode`,
+   * "reconcile" = a full re-pull of the scoped entities). This supersedes the
+   * `schedule` / `backfillSchedule` pair below, which is still written as a
+   * back-compat mirror (first poll row / first reconcile row) and is the only
+   * source for flows created before the list existed.
+   */
+  schedules?: IFlowSchedule[];
   schedule?: {
     enabled: boolean;
     cron?: string;
     timezone?: string;
   };
   /**
-   * Optional periodic full backfill cadence for CDC flows. Independent of
-   * `schedule` (which only drives `type: scheduled` batch runs). When enabled,
+   * Back-compat mirror of the first `kind: "reconcile"` schedule (and the
+   * only reconcile source for pre-`schedules[]` flows). When enabled,
    * `cdcScheduledBackfillFunction` triggers `cdcBackfillService.startBackfill`
    * on the cron cadence so a streaming CDC flow gets a periodic full
    * reconciliation while the live stream stays active between runs.
@@ -2372,6 +2400,38 @@ const FlowSchema = new Schema<IFlow>(
         fields: [String],
       },
     },
+    schedules: {
+      type: [
+        new Schema(
+          {
+            id: { type: String, required: true },
+            enabled: { type: Boolean, default: true },
+            cron: {
+              type: String,
+              required: true,
+              validate: {
+                validator: function (v: string) {
+                  if (!v) return false;
+                  const fields = v.trim().split(/\s+/);
+                  return fields.length === 5 || fields.length === 6;
+                },
+                message: "Invalid cron expression",
+              },
+            },
+            timezone: { type: String, default: "UTC" },
+            entities: { type: [String], default: undefined },
+            kind: {
+              type: String,
+              enum: ["poll", "reconcile"],
+              default: "poll",
+            },
+            lastRunAt: Date,
+          },
+          { _id: false },
+        ),
+      ],
+      default: undefined,
+    },
     schedule: {
       enabled: {
         type: Boolean,
@@ -2632,6 +2692,7 @@ FlowSchema.index({ "tableDestination.connectionId": 1 }, { sparse: true });
 FlowSchema.index({ nextRunAt: 1 });
 FlowSchema.index({ workspaceId: 1, syncEngine: 1 });
 FlowSchema.index({ syncEngine: 1, "backfillSchedule.enabled": 1 });
+FlowSchema.index({ "schedules.enabled": 1, "schedules.kind": 1 });
 
 /**
  * FlowExecution Schema (binds to 'flow_executions' collection)

--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -34,9 +34,12 @@ import {
 import { syncBackfillEntityFunction } from "./sync-entity";
 import { emitFlowExecutionTerminalEvent } from "../../services/flow-run-notification.emit";
 import {
+  buildReconcileFlowSelection,
   buildScheduledFlowSelection,
   hasScheduleTrigger,
   hasWebhookTrigger,
+  resolveFlowSchedules,
+  type ResolvedFlowSchedule,
 } from "../../services/flow-triggers.service";
 import { ensureFlowDerivedCache } from "../../services/flow-sync.service";
 
@@ -375,6 +378,7 @@ export const flowFunction = inngest.createFunction(
       backfill,
       backfillRunId,
       backfillEntities,
+      entityScope,
       triggerType: eventTriggerType,
     } = event.data as {
       flowId: string;
@@ -382,6 +386,12 @@ export const flowFunction = inngest.createFunction(
       backfill?: boolean;
       backfillRunId?: string;
       backfillEntities?: string[];
+      /**
+       * Entity narrowing requested by the trigger (a schedule row's scope).
+       * `backfillEntities` is the older name for the same thing on backfill
+       * runs and stays accepted.
+       */
+      entityScope?: string[];
       triggerType?: "manual" | "schedule";
     };
     const runTriggerType: "manual" | "schedule" =
@@ -392,18 +402,21 @@ export const flowFunction = inngest.createFunction(
           : noJitter
             ? "manual"
             : "schedule";
-    const requestedBackfillEntities = Array.isArray(backfillEntities)
-      ? Array.from(
-          new Set(
-            backfillEntities
-              .filter(
-                (entity): entity is string =>
-                  typeof entity === "string" && entity.trim().length > 0,
-              )
-              .map(entity => entity.trim()),
-          ),
-        )
-      : [];
+    const requestedEntityScopeInput = Array.isArray(entityScope)
+      ? entityScope
+      : Array.isArray(backfillEntities)
+        ? backfillEntities
+        : [];
+    const requestedBackfillEntities = Array.from(
+      new Set(
+        requestedEntityScopeInput
+          .filter(
+            (entity): entity is string =>
+              typeof entity === "string" && entity.trim().length > 0,
+          )
+          .map(entity => entity.trim()),
+      ),
+    );
 
     logger.info("Flow function started", {
       flowId,
@@ -1233,7 +1246,7 @@ export const flowFunction = inngest.createFunction(
                   `Invalid entities: ${invalidEntities.join(", ")}. Available: ${availableEntities.join(", ")}`,
                 );
               }
-              if (backfill && scopedBackfillEntities.length > 0) {
+              if (scopedBackfillEntities.length > 0) {
                 const invalidScope = scopedBackfillEntities.filter(
                   entity => !configuredEntities.includes(entity),
                 );
@@ -1247,7 +1260,7 @@ export const flowFunction = inngest.createFunction(
               return configuredEntities;
             }
 
-            if (backfill && scopedBackfillEntities.length > 0) {
+            if (scopedBackfillEntities.length > 0) {
               const invalidScope = scopedBackfillEntities.filter(
                 entity => !availableEntities.includes(entity),
               );
@@ -1432,7 +1445,7 @@ export const flowFunction = inngest.createFunction(
                   );
                 }
 
-                if (backfill && scopedBackfillEntities.length > 0) {
+                if (scopedBackfillEntities.length > 0) {
                   const invalidScope = scopedBackfillEntities.filter(
                     entity => !configuredEntities.includes(entity),
                   );
@@ -1446,7 +1459,7 @@ export const flowFunction = inngest.createFunction(
                 }
               }
 
-              if (backfill && scopedBackfillEntities.length > 0) {
+              if (scopedBackfillEntities.length > 0) {
                 const invalidScope = scopedBackfillEntities.filter(
                   entity => !availableEntities.includes(entity),
                 );
@@ -1994,37 +2007,45 @@ export const flowSchedulerFunction = inngest.createFunction(
     const executedFlows: string[] = [];
     let schedulingJitter = 0;
 
-    // Check each flow to see if it should run
+    // A flow can carry several poll cadences (e.g. hourly for every entity,
+    // plus a slower row scoped to a few heavy ones), so the unit of work here
+    // is one schedule row rather than one flow.
+    const duePolls: { flow: IFlow; schedule: ResolvedFlowSchedule }[] = [];
     for (const flow of flows) {
-      const shouldRun = await step.run(`check-flow-${flow._id}`, async () => {
+      for (const schedule of resolveFlowSchedules(flow)) {
+        if (schedule.kind !== "poll") continue;
+        duePolls.push({ flow, schedule });
+      }
+    }
+
+    for (const { flow, schedule } of duePolls) {
+      const stepKey = `${flow._id}-${schedule.id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+      const shouldRun = await step.run(`check-flow-${stepKey}`, async () => {
         try {
           const flowLogger = getSyncLogger(`scheduler.${flow._id}`);
 
-          // Safety check: skip flows without a poll cron (a webhook flow
-          // with an enabled schedule is a valid hybrid and must be polled).
-          if (!flow.schedule?.cron) {
-            flowLogger.warn(
-              "CRITICAL: Flow without poll schedule found in scheduler!",
-              {
-                flowId: flow._id.toString(),
-                flowType: flow.type,
-                hasSchedule: !!flow.schedule,
-                hasCron: !!flow.schedule?.cron,
-                schedule: flow.schedule,
-              },
-            );
-            return false;
-          }
+          flowLogger.debug("Checking flow schedule", {
+            flowId: flow._id.toString(),
+            scheduleId: schedule.id,
+            cronExpression: schedule.cron,
+            timezone: schedule.timezone,
+            entityScope: schedule.entities.length ? schedule.entities : "all",
+            currentTime: now.toISOString(),
+          });
+
+          // Legacy `schedule` rows have always tracked their cadence off the
+          // flow-level lastRunAt (stamped by the execution itself); rows from
+          // the `schedules[]` list carry their own, stamped at dispatch.
+          const lastRunSource =
+            schedule.origin === "schedule" ? flow.lastRunAt : schedule.lastRunAt;
 
           // Due = the schedule has an occurrence after the last run that has
-          // already passed (never ran → due). This replaces three hand-rolled
-          // heuristics ("original", "alternative", "missed run") that were
-          // equivalent to exactly this predicate.
+          // already passed (never ran → due).
           if (
             !isCronDue({
-              cron: flow.schedule.cron,
-              timezone: flow.schedule.timezone || "UTC",
-              lastRunAt: flow.lastRunAt ? new Date(flow.lastRunAt) : null,
+              cron: schedule.cron,
+              timezone: schedule.timezone,
+              lastRunAt: lastRunSource ? new Date(lastRunSource) : null,
               now,
             })
           ) {
@@ -2056,6 +2077,7 @@ export const flowSchedulerFunction = inngest.createFunction(
           logger.error(`Failed to parse cron expression for flow ${flow._id}`, {
             error,
             flowId: flow._id.toString(),
+            scheduleId: schedule.id,
           });
           return false;
         }
@@ -2064,15 +2086,32 @@ export const flowSchedulerFunction = inngest.createFunction(
       if (shouldRun) {
         // Add small scheduling jitter (0-5 seconds) between flows to spread out the load
         if (schedulingJitter > 0) {
-          await step.sleep(`scheduling-jitter-${flow._id}`, schedulingJitter);
+          await step.sleep(`scheduling-jitter-${stepKey}`, schedulingJitter);
+        }
+
+        // Rows from the `schedules[]` list own their cadence bookkeeping:
+        // stamp before dispatch so a slow or failed start doesn't re-trigger
+        // on every cron tick.
+        if (schedule.origin === "list") {
+          await step.run(`stamp-schedule-${stepKey}`, async () => {
+            await Flow.updateOne(
+              { _id: new Types.ObjectId(flow._id) },
+              { $set: { "schedules.$[row].lastRunAt": now } },
+              { arrayFilters: [{ "row.id": schedule.id }] },
+            );
+          });
         }
 
         // Trigger the flow (without noJitter flag, so jitter will be applied)
-        await step.sendEvent(`trigger-flow-${flow._id}`, {
+        await step.sendEvent(`trigger-flow-${stepKey}`, {
           name: "flow.execute",
           data: {
             flowId: flow._id.toString(),
             triggerType: "schedule",
+            scheduleId: schedule.id,
+            ...(schedule.entities.length > 0
+              ? { entityScope: schedule.entities }
+              : {}),
           },
         });
 
@@ -2098,10 +2137,11 @@ export const flowSchedulerFunction = inngest.createFunction(
   },
 );
 
-// Scheduled CDC full backfill - triggers a periodic full reconciliation
-// backfill for CDC flows that opted into `backfillSchedule`. The live stream
-// stays active between runs; this just kicks `cdcBackfillService.startBackfill`
-// on the configured cadence.
+// Scheduled full reconcile - runs every schedule row with
+// `kind: "reconcile"` (and the legacy `backfillSchedule`). On the CDC engine
+// the live stream stays active between runs and this just kicks
+// `cdcBackfillService.startBackfill` on the configured cadence; on the legacy
+// engine the same row dispatches a `backfill: true` run.
 export const cdcScheduledBackfillFunction = inngest.createFunction(
   {
     id: "cdc-scheduled-backfill",
@@ -2113,8 +2153,7 @@ export const cdcScheduledBackfillFunction = inngest.createFunction(
       "fetch-backfill-scheduled-flows",
       async () => {
         const found = await Flow.find({
-          syncEngine: "cdc",
-          "backfillSchedule.enabled": true,
+          ...buildReconcileFlowSelection(),
           enabled: { $ne: false },
         }).lean();
         return found;
@@ -2124,72 +2163,119 @@ export const cdcScheduledBackfillFunction = inngest.createFunction(
     const now = new Date();
     const triggered: string[] = [];
 
+    // One flow can hold several reconcile cadences with different entity
+    // scopes, so iterate schedule rows rather than flows.
+    const dueReconciles: { flow: IFlow; schedule: ResolvedFlowSchedule }[] = [];
     for (const flow of flows) {
+      for (const schedule of resolveFlowSchedules(flow)) {
+        if (schedule.kind !== "reconcile") continue;
+        dueReconciles.push({ flow, schedule });
+      }
+    }
+
+    for (const { flow, schedule } of dueReconciles) {
       const flowId = flow._id.toString();
       const workspaceId = String(flow.workspaceId);
-      const schedule = flow.backfillSchedule;
-      const cron = schedule?.cron;
-      if (!cron) continue;
+      const cron = schedule.cron;
+      const stepKey = `${flowId}-${schedule.id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+      const isCdcFlow = flow.syncEngine === "cdc";
+      // The legacy `backfillSchedule` field only ever drove CDC flows; keep
+      // that scope so this selection change can't start firing reconciles on
+      // legacy-engine flows that carry a stale field.
+      if (!isCdcFlow && schedule.origin === "backfillSchedule") continue;
 
-      const shouldRun = await step.run(`check-backfill-${flowId}`, async () => {
-        const backfillLogger = getSyncLogger(
-          `cdc-backfill-scheduler.${flowId}`,
-        );
-        try {
-          // Don't pile up: skip if a backfill is already in flight, the
-          // stream is paused, or an execution is currently running.
-          if (flow.backfillState?.status === "running") {
-            return false;
-          }
-          if (flow.streamState === "paused") {
-            return false;
-          }
-          const activeExecution = await Flow.db
-            .collection("flow_executions")
-            .findOne({
-              flowId: new Types.ObjectId(flowId),
-              status: "running",
+      const shouldRun = await step.run(
+        `check-backfill-${stepKey}`,
+        async () => {
+          const backfillLogger = getSyncLogger(
+            `cdc-backfill-scheduler.${flowId}`,
+          );
+          try {
+            // Don't pile up: skip if a backfill is already in flight, the
+            // stream is paused, or an execution is currently running.
+            if (flow.backfillState?.status === "running") {
+              return false;
+            }
+            if (flow.streamState === "paused") {
+              return false;
+            }
+            const activeExecution = await Flow.db
+              .collection("flow_executions")
+              .findOne({
+                flowId: new Types.ObjectId(flowId),
+                status: "running",
+              });
+            if (activeExecution) {
+              return false;
+            }
+
+            return isCronDue({
+              cron,
+              timezone: schedule.timezone,
+              lastRunAt: schedule.lastRunAt,
+              now,
             });
-          if (activeExecution) {
+          } catch (error) {
+            backfillLogger.error("Failed to evaluate reconcile schedule", {
+              flowId,
+              scheduleId: schedule.id,
+              cron,
+              error: error instanceof Error ? error.message : String(error),
+            });
             return false;
           }
-
-          return isCronDue({
-            cron,
-            timezone: schedule?.timezone,
-            lastRunAt: schedule?.lastRunAt
-              ? new Date(schedule.lastRunAt)
-              : null,
-            now,
-          });
-        } catch (error) {
-          backfillLogger.error("Failed to evaluate CDC backfill schedule", {
-            flowId,
-            cron,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return false;
-        }
-      });
+        },
+      );
 
       if (!shouldRun) continue;
 
-      await step.run(`trigger-backfill-${flowId}`, async () => {
+      await step.run(`trigger-backfill-${stepKey}`, async () => {
         // Stamp lastRunAt first so a slow/failed start doesn't re-trigger every
         // cron tick (next attempt waits for the next cron occurrence).
-        await Flow.updateOne(
-          { _id: new Types.ObjectId(flowId) },
-          { $set: { "backfillSchedule.lastRunAt": now } },
-        );
-        await cdcBackfillService.startBackfill(workspaceId, flowId, {
-          reason: "Scheduled full backfill",
+        if (schedule.origin === "list") {
+          await Flow.updateOne(
+            { _id: new Types.ObjectId(flowId) },
+            { $set: { "schedules.$[row].lastRunAt": now } },
+            { arrayFilters: [{ "row.id": schedule.id }] },
+          );
+        } else {
+          await Flow.updateOne(
+            { _id: new Types.ObjectId(flowId) },
+            { $set: { "backfillSchedule.lastRunAt": now } },
+          );
+        }
+
+        const scope =
+          schedule.entities.length > 0 ? schedule.entities : undefined;
+        const reason = scope
+          ? `Scheduled full reconcile (${scope.join(", ")})`
+          : "Scheduled full backfill";
+
+        if (isCdcFlow) {
+          await cdcBackfillService.startBackfill(workspaceId, flowId, {
+            reason,
+            ...(scope ? { entities: scope } : {}),
+          });
+          return;
+        }
+
+        // Legacy engine: a reconcile row is a full re-pull run.
+        await inngest.send({
+          name: "flow.execute",
+          data: {
+            flowId,
+            triggerType: "schedule",
+            scheduleId: schedule.id,
+            backfill: true,
+            ...(scope ? { entityScope: scope } : {}),
+          },
         });
       });
 
       triggered.push(flowId);
     }
 
-    logger.info("Scheduled CDC backfill runner completed", {
+    logger.info("Scheduled reconcile runner completed", {
       checked: flows.length,
       triggered: triggered.length,
       flowIds: triggered,

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -19,6 +19,7 @@ import {
   commitFlowFile,
   deleteFlowFile,
 } from "../services/flow-config.service";
+import { randomUUID } from "crypto";
 import { Types } from "mongoose";
 import { inngest } from "../inngest";
 import { generateWebhookEndpoint } from "../utils/webhook.utils";
@@ -60,7 +61,11 @@ import {
   hasCdcDestinationAdapter,
   supportedCdcWriteModes,
 } from "../sync-cdc/adapters/registry";
-import { resolveDefaultSyncEngine } from "../services/flow-triggers.service";
+import {
+  deriveLegacyScheduleMirrors,
+  normalizeFlowScheduleList,
+  resolveDefaultSyncEngine,
+} from "../services/flow-triggers.service";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
 import { connectorRegistry } from "../connectors/registry";
 import {
@@ -1094,7 +1099,24 @@ flowRoutes.openapi(
         flowData.entityLayouts = body.entityLayouts;
       }
 
-      if (flowType === "scheduled") {
+      // Unified schedule list: when the client sends `schedules`, it is the
+      // source of truth and the standalone schedule fields become mirrors.
+      if (body.schedules !== undefined) {
+        const normalized = normalizeFlowScheduleList(body.schedules, {
+          generateId: randomUUID,
+        });
+        if (!normalized.ok) {
+          return c.json({ success: false, error: normalized.error }, 400);
+        }
+        flowData.schedules = normalized.schedules;
+        const mirrors = deriveLegacyScheduleMirrors(normalized.schedules);
+        flowData.schedule = mirrors.schedule;
+        if (mirrors.backfillSchedule.enabled) {
+          flowData.backfillSchedule = mirrors.backfillSchedule;
+        } else {
+          delete flowData.backfillSchedule;
+        }
+      } else if (flowType === "scheduled") {
         const scheduleEnabled = body.schedule?.enabled === true;
         flowData.schedule = {
           enabled: scheduleEnabled,
@@ -1105,7 +1127,7 @@ flowRoutes.openapi(
             ? body.schedule?.timezone || body.timezone || "UTC"
             : undefined,
         };
-      } else if (flowType === "webhook") {
+      } else if (flowType === "webhook" && body.schedules === undefined) {
         // Unified trigger model: a webhook flow may also carry a poll
         // schedule (hybrid trigger set). Persist it so the scheduler's
         // trigger-based selection picks it up.
@@ -1116,6 +1138,9 @@ flowRoutes.openapi(
             timezone: body.schedule?.timezone || body.timezone || "UTC",
           };
         }
+      }
+
+      if (flowType === "webhook") {
         // Generate webhook configuration
         const requestBaseUrl = getRequestBaseUrl(c);
         const webhookEndpoint = generateWebhookEndpoint(
@@ -1368,7 +1393,22 @@ flowRoutes.openapi(
 
       // Update common fields. Under the unified trigger model any flow may
       // carry a poll schedule (hybrid trigger set), not only type=scheduled.
-      if (body.schedule) {
+      if (body.schedules !== undefined) {
+        const normalized = normalizeFlowScheduleList(body.schedules, {
+          previous: (flow as any).schedules,
+          generateId: randomUUID,
+        });
+        if (!normalized.ok) {
+          return c.json({ success: false, error: normalized.error }, 400);
+        }
+        (flow as any).schedules = normalized.schedules;
+        const mirrors = deriveLegacyScheduleMirrors(normalized.schedules);
+        flow.schedule = mirrors.schedule;
+        flow.backfillSchedule = {
+          ...mirrors.backfillSchedule,
+          lastRunAt: flow.backfillSchedule?.lastRunAt,
+        };
+      } else if (body.schedule) {
         const scheduleEnabled = body.schedule.enabled === true;
         flow.schedule = {
           enabled: scheduleEnabled,
@@ -1620,7 +1660,11 @@ flowRoutes.openapi(
 
       // Periodic full backfill cadence (CDC flows only). The dedicated
       // /backfill-schedule endpoint offers the same behavior for API consumers.
-      if (body.backfillSchedule !== undefined && flow.syncEngine === "cdc") {
+      if (
+        body.backfillSchedule !== undefined &&
+        body.schedules === undefined &&
+        flow.syncEngine === "cdc"
+      ) {
         const sched = body.backfillSchedule || {};
         const enabled = Boolean(sched.enabled);
         const cron = typeof sched.cron === "string" ? sched.cron.trim() : "";

--- a/api/src/services/flow-config-files.test.ts
+++ b/api/src/services/flow-config-files.test.ts
@@ -298,6 +298,92 @@ assert.equal(slugFromFlowFilePath("flows/Bad_Slug.yml"), null);
   );
 }
 
+// ── the unified `schedules:` list round-trips, and wins over the pair ──
+{
+  const listed = {
+    _id: new Types.ObjectId("00aabbccddeeff0011223348"),
+    name: "Listed schedules",
+    workspaceId: new Types.ObjectId(),
+    type: "scheduled",
+    sourceType: "connector",
+    dataSourceId: connectorId,
+    destinationDatabaseId: destId,
+    createdBy: "u1",
+    schedules: [
+      {
+        id: "poll-row",
+        enabled: true,
+        cron: "0 * * * *",
+        timezone: "UTC",
+        kind: "poll",
+        // A scheduler claim: it must never reach the file.
+        lastRunAt: new Date("2026-01-02T03:04:05.000Z"),
+      },
+      {
+        id: "reconcile-row",
+        enabled: true,
+        cron: "0 3 * * 0",
+        timezone: "Europe/Zurich",
+        kind: "reconcile",
+        entities: ["customers", "invoices"],
+      },
+      // Disabled rows are definition noise; they are not committed.
+      { id: "off-row", enabled: false, cron: "0 5 * * *", kind: "poll" },
+    ],
+    // Stale mirrors must not be written alongside the list.
+    schedule: { enabled: true, cron: "*/5 * * * *", timezone: "UTC" },
+    backfillSchedule: { enabled: true, cron: "0 9 * * *", timezone: "UTC" },
+  } as unknown as IFlow;
+
+  const text = serializeFlowFile(flowToFile(listed));
+  assert.match(text, /schedules:/);
+  assert.doesNotMatch(text, /backfill_schedule:/);
+  assert.doesNotMatch(text, /\*\/5 \* \* \* \*/, "no legacy mirror in the file");
+  assert.doesNotMatch(text, /2026-01-02/, "lastRunAt is a claim, not definition");
+
+  const parsed = parseFlowFile(text);
+  assert.ok(parsed);
+  assert.equal(parsed.schedules?.length, 2, "the disabled row is not written");
+  assert.deepEqual(parsed.schedules?.[0], {
+    id: "poll-row",
+    cron: "0 * * * *",
+    timezone: "UTC",
+    kind: "poll",
+  });
+  assert.deepEqual(parsed.schedules?.[1], {
+    id: "reconcile-row",
+    cron: "0 3 * * 0",
+    timezone: "Europe/Zurich",
+    kind: "reconcile",
+    entities: ["customers", "invoices"],
+  });
+  assert.equal(parsed.schedule, null);
+  assert.equal(parsed.backfillSchedule, null);
+}
+
+// A hand-written row without `kind:` is a poll; a row without a cron is skipped.
+{
+  const parsed = parseFlowFile(
+    [
+      "name: Hand written",
+      "type: scheduled",
+      "source:",
+      "  type: connector",
+      "  connection_id: 6a2bd881b6f8c41ea17e9bc7",
+      "destination:",
+      "  connection_id: 69c2719490eb18199aafa882",
+      "schedules:",
+      "  - cron: '0 * * * *'",
+      "  - timezone: UTC",
+      "",
+    ].join("\n"),
+  );
+  assert.ok(parsed);
+  assert.equal(parsed.schedules?.length, 1);
+  assert.equal(parsed.schedules?.[0].kind, "poll");
+  assert.equal(parsed.schedules?.[0].timezone, "UTC");
+}
+
 // ── malformed input is rejected, not half-parsed ──
 assert.equal(parseFlowFile("this: [is: not: valid"), null);
 assert.equal(parseFlowFile("just a string"), null);

--- a/api/src/services/flow-config-files.ts
+++ b/api/src/services/flow-config-files.ts
@@ -56,6 +56,21 @@ export interface FlowFileSchedule {
   timezone: string;
 }
 
+/**
+ * One row of the unified `schedules:` list — the file form of
+ * `IFlow.schedules`. `lastRunAt` is a scheduler claim and stays on the row,
+ * exactly like `backfillSchedule.lastRunAt`.
+ */
+export interface FlowFileScheduleRow {
+  /** Stable across edits so the row keeps its `lastRunAt`. */
+  id?: string;
+  cron: string;
+  timezone: string;
+  /** Empty/absent = every entity the flow syncs. */
+  entities?: string[];
+  kind: "poll" | "reconcile";
+}
+
 export interface FlowFile {
   name: string;
   type: "scheduled" | "webhook";
@@ -84,6 +99,12 @@ export interface FlowFile {
       clustering?: Record<string, unknown>;
     };
   };
+  /**
+   * The unified cron list. When present it is authoritative and the two
+   * single-schedule keys below are omitted from the file; flows written
+   * before the list carry `schedule:` / `backfill_schedule:` instead.
+   */
+  schedules?: FlowFileScheduleRow[] | null;
   schedule?: FlowFileSchedule | null;
   backfillSchedule?: FlowFileSchedule | null;
   /** Only whether inbound delivery is on; never the endpoint or secret. */
@@ -224,17 +245,29 @@ export function serializeFlowFile(flow: FlowFile): string {
       : undefined,
   });
 
-  if (flow.schedule) {
-    doc.schedule = {
-      cron: flow.schedule.cron,
-      timezone: flow.schedule.timezone,
-    };
-  }
-  if (flow.backfillSchedule) {
-    doc.backfill_schedule = {
-      cron: flow.backfillSchedule.cron,
-      timezone: flow.backfillSchedule.timezone,
-    };
+  if (flow.schedules && flow.schedules.length > 0) {
+    doc.schedules = flow.schedules.map(row =>
+      omitEmpty({
+        id: row.id,
+        cron: row.cron,
+        timezone: row.timezone,
+        kind: row.kind,
+        entities: row.entities?.length ? row.entities : undefined,
+      }),
+    );
+  } else {
+    if (flow.schedule) {
+      doc.schedule = {
+        cron: flow.schedule.cron,
+        timezone: flow.schedule.timezone,
+      };
+    }
+    if (flow.backfillSchedule) {
+      doc.backfill_schedule = {
+        cron: flow.backfillSchedule.cron,
+        timezone: flow.backfillSchedule.timezone,
+      };
+    }
   }
   if (flow.type === "webhook") {
     doc.webhook = { enabled: flow.webhookEnabled !== false };
@@ -282,6 +315,30 @@ export function serializeFlowFile(flow: FlowFile): string {
 
 function str(v: unknown): string | undefined {
   return typeof v === "string" && v.trim() ? v.trim() : undefined;
+}
+
+function schedulesFrom(v: unknown): FlowFileScheduleRow[] | null {
+  if (!Array.isArray(v)) return null;
+  const rows: FlowFileScheduleRow[] = [];
+  for (const entry of v) {
+    if (!entry || typeof entry !== "object") continue;
+    const row = entry as Record<string, unknown>;
+    const cron = str(row.cron);
+    if (!cron) continue;
+    const entities = Array.isArray(row.entities)
+      ? row.entities
+          .map(e => str(e))
+          .filter((e): e is string => typeof e === "string")
+      : undefined;
+    rows.push({
+      id: str(row.id),
+      cron,
+      timezone: str(row.timezone) ?? "UTC",
+      kind: str(row.kind) === "reconcile" ? "reconcile" : "poll",
+      ...(entities && entities.length > 0 ? { entities } : {}),
+    });
+  }
+  return rows.length > 0 ? rows : null;
 }
 
 function scheduleFrom(v: unknown): FlowFileSchedule | null {
@@ -391,6 +448,7 @@ export function parseFlowFileResult(contents: string): FlowFileParse {
     type,
     source,
     destination,
+    schedules: schedulesFrom(doc.schedules),
     schedule: scheduleFrom(doc.schedule),
     backfillSchedule: scheduleFrom(doc.backfill_schedule),
     webhookEnabled: webhookDoc ? webhookDoc.enabled !== false : undefined,
@@ -483,8 +541,20 @@ export function flowToFile(flow: IFlow): FlowFile {
           }
         : undefined,
     },
-    // Schedules carry cron + timezone only; `backfillSchedule.lastRunAt` is
-    // a scheduler claim and stays on the row.
+    // Schedules carry the definition only; `lastRunAt` (per row, and on
+    // `backfillSchedule`) is a scheduler claim and stays on the row.
+    schedules:
+      flow.schedules && flow.schedules.length > 0
+        ? flow.schedules
+            .filter(row => row.enabled !== false && row.cron)
+            .map(row => ({
+              id: row.id,
+              cron: row.cron,
+              timezone: row.timezone || "UTC",
+              kind: row.kind === "reconcile" ? ("reconcile" as const) : ("poll" as const),
+              ...(row.entities?.length ? { entities: [...row.entities] } : {}),
+            }))
+        : null,
     schedule:
       flow.schedule?.enabled && flow.schedule.cron
         ? {

--- a/api/src/services/flow-sync.service.ts
+++ b/api/src/services/flow-sync.service.ts
@@ -53,6 +53,7 @@ import { boundRepoDirIfExists } from "../apps/workspace-repo-required";
 import { getWorkspaceRepo } from "./workspace-repos.service";
 import { Flow, type IFlow } from "../database/workspace-schema";
 import { generateWebhookEndpoint } from "../utils/webhook.utils";
+import { deriveLegacyScheduleMirrors } from "./flow-triggers.service";
 import {
   flowToFile,
   parseFlowFile,
@@ -155,11 +156,16 @@ async function markFlowInvalid(
   const set: Record<string, unknown> = { definitionInvalid };
   if (doc.schedule) set["schedule.enabled"] = false;
   if (doc.backfillSchedule) set["backfillSchedule.enabled"] = false;
+  // An invalid definition must not keep firing any of its cadences.
+  (doc.schedules ?? []).forEach((_row, index) => {
+    set[`schedules.${index}.enabled`] = false;
+  });
   try {
     await Flow.updateOne({ _id: doc._id }, { $set: set });
     doc.definitionInvalid = definitionInvalid;
     if (doc.schedule) doc.schedule.enabled = false;
     if (doc.backfillSchedule) doc.backfillSchedule.enabled = false;
+    for (const row of doc.schedules ?? []) row.enabled = false;
   } catch (error) {
     logger.warn("Failed to mark flow invalid", {
       flowId: doc._id.toString(),
@@ -558,20 +564,49 @@ function applyDefinition(doc: IFlow, file: FlowFile): string | null {
     } as IFlow["tableDestination"];
   }
 
-  // Schedules: cron + timezone only. `backfillSchedule.lastRunAt` is a
-  // scheduler claim (`isCronDue` reads it) and must survive a file edit.
-  doc.schedule = {
-    ...(doc.schedule ?? {}),
-    enabled: Boolean(file.schedule),
-    cron: file.schedule?.cron,
-    timezone: file.schedule?.timezone,
-  } as IFlow["schedule"];
-  doc.backfillSchedule = {
-    ...(doc.backfillSchedule ?? {}),
-    enabled: Boolean(file.backfillSchedule),
-    cron: file.backfillSchedule?.cron,
-    timezone: file.backfillSchedule?.timezone,
-  } as IFlow["backfillSchedule"];
+  // Schedules: the definition only. Every `lastRunAt` (per row, and on
+  // `backfillSchedule`) is a scheduler claim that `isCronDue` reads, so it
+  // must survive a file edit — carried over by row id below.
+  if (file.schedules && file.schedules.length > 0) {
+    const previousRun = new Map(
+      (doc.schedules ?? []).map(row => [row.id, row.lastRunAt]),
+    );
+    doc.schedules = file.schedules.map((row, index) => {
+      const id = row.id || `${file.name}-${index}`;
+      const carried = previousRun.get(id);
+      return {
+        id,
+        enabled: true,
+        cron: row.cron,
+        timezone: row.timezone || "UTC",
+        entities: row.entities,
+        kind: row.kind,
+        ...(carried ? { lastRunAt: carried } : {}),
+      };
+    }) as IFlow["schedules"];
+    // Legacy mirrors so readers that still consult the single-schedule
+    // fields (list payloads, the flow panels) stay correct.
+    const mirrors = deriveLegacyScheduleMirrors(doc.schedules ?? []);
+    doc.schedule = mirrors.schedule as IFlow["schedule"];
+    doc.backfillSchedule = {
+      ...mirrors.backfillSchedule,
+      lastRunAt: doc.backfillSchedule?.lastRunAt,
+    } as IFlow["backfillSchedule"];
+  } else {
+    doc.schedules = undefined;
+    doc.schedule = {
+      ...(doc.schedule ?? {}),
+      enabled: Boolean(file.schedule),
+      cron: file.schedule?.cron,
+      timezone: file.schedule?.timezone,
+    } as IFlow["schedule"];
+    doc.backfillSchedule = {
+      ...(doc.backfillSchedule ?? {}),
+      enabled: Boolean(file.backfillSchedule),
+      cron: file.backfillSchedule?.cron,
+      timezone: file.backfillSchedule?.timezone,
+    } as IFlow["backfillSchedule"];
+  }
 
   // Enabled-ness only. The endpoint is inbound URL identity minted once in
   // Mongo (17 of 31 production flows have external systems POSTing to it) and

--- a/api/src/services/flow-triggers.service.test.ts
+++ b/api/src/services/flow-triggers.service.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 import {
+  buildReconcileFlowSelection,
   buildScheduledFlowSelection,
   deriveFlowType,
+  deriveLegacyScheduleMirrors,
   deriveTriggerSet,
   hasAnyTrigger,
+  normalizeFlowScheduleList,
   resolveDefaultSyncEngine,
+  resolveFlowSchedules,
 } from "./flow-triggers.service";
 
 function testScheduledFlowTriggerSet() {
@@ -153,15 +157,145 @@ function testDefaultSyncEngine() {
 
 function testScheduledFlowSelection() {
   const selection = buildScheduledFlowSelection() as Record<string, any>;
-  assert.equal(selection["schedule.enabled"], true);
-  const cronCond = selection["schedule.cron"];
+  // Legacy `schedule` flows and `schedules[]` flows are both selected.
+  const legacyBranch = selection.$or[0];
+  assert.equal(legacyBranch["schedule.enabled"], true);
+  const cronCond = legacyBranch["schedule.cron"];
   assert.equal(cronCond.$exists, true);
   assert.equal(cronCond.$type, "string");
   // Whitespace-only crons must be excluded.
   assert.equal(cronCond.$not.test("   "), true);
   assert.equal(cronCond.$not.test("*/5 * * * *"), false);
+  const listBranch = selection.$or[1];
+  assert.deepEqual(listBranch.schedules.$elemMatch.enabled, { $ne: false });
   // No type partitioning — hybrids (webhook flows with a cron) are polled.
   assert.equal("type" in selection, false);
+
+  // Reconcile selection is kind-scoped on the list side.
+  const reconcile = buildReconcileFlowSelection() as Record<string, any>;
+  assert.equal(reconcile.$or[0]["backfillSchedule.enabled"], true);
+  assert.equal(reconcile.$or[1].schedules.$elemMatch.kind, "reconcile");
+}
+
+function testScheduleListWinsOverLegacyFields() {
+  const flow = {
+    // Stale legacy fields must be ignored once the list exists.
+    schedule: { enabled: true, cron: "0 * * * *" },
+    backfillSchedule: { enabled: true, cron: "0 3 * * *" },
+    schedules: [
+      { id: "a", cron: "*/15 * * * *", kind: "poll" as const },
+      {
+        id: "b",
+        cron: "0 4 * * 0",
+        kind: "reconcile" as const,
+        entities: ["customers", " invoices ", ""],
+      },
+      // Disabled rows never produce a trigger.
+      { id: "c", enabled: false, cron: "0 5 * * *", kind: "poll" as const },
+    ],
+  };
+
+  const resolved = resolveFlowSchedules(flow);
+  assert.equal(resolved.length, 2);
+  assert.deepEqual(
+    resolved.map(s => [s.id, s.kind, s.origin]),
+    [
+      ["a", "poll", "list"],
+      ["b", "reconcile", "list"],
+    ],
+  );
+  assert.deepEqual(resolved[0].entities, []);
+  assert.deepEqual(resolved[1].entities, ["customers", "invoices"]);
+  assert.deepEqual(deriveTriggerSet(flow), {
+    schedule: true,
+    webhook: false,
+    reconcile: true,
+  });
+}
+
+function testLegacyFieldsProjectIntoScheduleRows() {
+  const resolved = resolveFlowSchedules({
+    schedule: { enabled: true, cron: "0 * * * *", timezone: "Europe/Zurich" },
+    backfillSchedule: {
+      enabled: true,
+      cron: "0 3 * * *",
+      lastRunAt: "2026-01-02T03:00:00.000Z",
+    },
+  });
+  assert.deepEqual(
+    resolved.map(s => [s.kind, s.cron, s.origin]),
+    [
+      ["poll", "0 * * * *", "schedule"],
+      ["reconcile", "0 3 * * *", "backfillSchedule"],
+    ],
+  );
+  assert.equal(resolved[0].timezone, "Europe/Zurich");
+  // Legacy reconcile bookkeeping is preserved; the poll row keeps using the
+  // flow-level lastRunAt, so it resolves to null here.
+  assert.equal(resolved[0].lastRunAt, null);
+  assert.equal(
+    resolved[1].lastRunAt?.toISOString(),
+    "2026-01-02T03:00:00.000Z",
+  );
+}
+
+function testNormalizeScheduleList() {
+  const bad = normalizeFlowScheduleList([{ cron: "not a cron" }], {
+    generateId: () => "generated",
+  });
+  assert.equal(bad.ok, false);
+
+  let counter = 0;
+  const result = normalizeFlowScheduleList(
+    [
+      { cron: " 0 * * * * ", entities: ["a", "a", " b "] },
+      {
+        id: "kept",
+        cron: "0 3 * * *",
+        kind: "reconcile",
+        timezone: "UTC",
+        // Client-supplied lastRunAt must be ignored...
+        lastRunAt: "2030-01-01T00:00:00.000Z",
+      },
+    ],
+    {
+      // ...while the stored value for the same id is carried over.
+      previous: [
+        {
+          id: "kept",
+          cron: "0 3 * * *",
+          lastRunAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      generateId: () => `gen-${++counter}`,
+    },
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.schedules[0].id, "gen-1");
+  assert.equal(result.schedules[0].kind, "poll");
+  assert.deepEqual(result.schedules[0].entities, ["a", "b"]);
+  assert.equal(result.schedules[0].lastRunAt, undefined);
+  assert.equal(
+    result.schedules[1].lastRunAt?.toISOString(),
+    "2026-01-01T00:00:00.000Z",
+  );
+
+  const mirrors = deriveLegacyScheduleMirrors(result.schedules);
+  assert.deepEqual(mirrors.schedule, {
+    enabled: true,
+    cron: "0 * * * *",
+    timezone: "UTC",
+  });
+  assert.deepEqual(mirrors.backfillSchedule, {
+    enabled: true,
+    cron: "0 3 * * *",
+    timezone: "UTC",
+  });
+  assert.deepEqual(deriveLegacyScheduleMirrors([]), {
+    schedule: { enabled: false },
+    backfillSchedule: { enabled: false },
+  });
 }
 
 function main() {
@@ -172,6 +306,9 @@ function main() {
   testNoTriggers();
   testDefaultSyncEngine();
   testScheduledFlowSelection();
+  testScheduleListWinsOverLegacyFields();
+  testLegacyFieldsProjectIntoScheduleRows();
+  testNormalizeScheduleList();
   // eslint-disable-next-line no-console
   console.log("flow-triggers.service tests passed");
 }

--- a/api/src/services/flow-triggers.service.ts
+++ b/api/src/services/flow-triggers.service.ts
@@ -5,17 +5,45 @@
  * existing fields instead of the hard `type: "scheduled" | "webhook"`
  * discriminator:
  *
- * - poll trigger      → `schedule.enabled` + a cron expression
+ * - poll trigger      → a `schedules[]` row with `kind: "poll"`
  * - webhook trigger   → `webhookConfig.enabled`
- * - reconcile trigger → `backfillSchedule.enabled` + a cron expression
+ * - reconcile trigger → a `schedules[]` row with `kind: "reconcile"`
+ *
+ * Flows written before the unified `schedules[]` list carry the same two cron
+ * triggers in the standalone `schedule` (poll) and `backfillSchedule`
+ * (reconcile) fields; `resolveFlowSchedules` projects both generations into
+ * one shape, so nothing below branches on storage layout.
  *
  * This module is intentionally dependency-free (structural types only) so it
  * can be imported from `workspace-schema.ts` without creating import cycles.
  */
 
+/**
+ * One row of the unified `schedules[]` list. Replaces the split
+ * `schedule` (poll) / `backfillSchedule` (reconcile) pair: a flow now has a
+ * list of cron rows, each with its own entity scope and run kind.
+ */
+export interface FlowScheduleEntry {
+  /** Stable client-generated id (used to stamp `lastRunAt` on the right row). */
+  id?: string;
+  enabled?: boolean;
+  cron?: string | null;
+  timezone?: string;
+  /** Empty/absent = every entity enabled in the flow's entity selection. */
+  entities?: string[];
+  /**
+   * - "poll": a normal run honoring the flow's `syncMode`.
+   * - "reconcile": a full re-pull of the scoped entities (CDC backfill on the
+   *   CDC engine, a `backfill: true` run otherwise).
+   */
+  kind?: "poll" | "reconcile";
+  lastRunAt?: Date | string | null;
+}
+
 /** Structural subset of IFlow used for trigger derivation. */
 export interface FlowTriggerFields {
   type?: "scheduled" | "webhook";
+  schedules?: FlowScheduleEntry[] | null;
   schedule?: {
     enabled?: boolean;
     cron?: string | null;
@@ -29,15 +57,16 @@ export interface FlowTriggerFields {
     enabled?: boolean;
     cron?: string | null;
     timezone?: string;
+    lastRunAt?: Date | string | null;
   } | null;
 }
 
 export interface FlowTriggerSet {
-  /** Cron-driven poll (`schedule.enabled` with a cron expression). */
+  /** At least one cron-driven poll schedule. */
   schedule: boolean;
   /** Push-driven ingest (`webhookConfig.enabled`). */
   webhook: boolean;
-  /** Periodic full reconcile (`backfillSchedule.enabled` with a cron). */
+  /** At least one periodic full reconcile schedule. */
   reconcile: boolean;
 }
 
@@ -45,8 +74,209 @@ function hasCron(cron: string | null | undefined): boolean {
   return typeof cron === "string" && cron.trim().length > 0;
 }
 
+/** A schedule row normalized for the schedulers to act on. */
+export interface ResolvedFlowSchedule {
+  id: string;
+  cron: string;
+  timezone: string;
+  /** Empty = no per-schedule narrowing (use the flow's entity selection). */
+  entities: string[];
+  kind: "poll" | "reconcile";
+  lastRunAt: Date | null;
+  /**
+   * Where this row came from. Legacy rows are derived from the pre-list
+   * `schedule` / `backfillSchedule` fields and keep their original
+   * `lastRunAt` bookkeeping; "list" rows stamp `schedules.$[...].lastRunAt`.
+   */
+  origin: "list" | "schedule" | "backfillSchedule";
+}
+
+function normalizeScheduleEntities(entities: unknown): string[] {
+  if (!Array.isArray(entities)) return [];
+  const seen = new Set<string>();
+  for (const entity of entities) {
+    if (typeof entity !== "string") continue;
+    const trimmed = entity.trim();
+    if (trimmed.length > 0) seen.add(trimmed);
+  }
+  return Array.from(seen);
+}
+
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * The flow's effective schedule rows. `schedules[]` wins when present;
+ * otherwise the legacy `schedule` (poll) + `backfillSchedule` (reconcile)
+ * pair is projected into the same shape so both storage generations run
+ * through one code path.
+ */
+export function resolveFlowSchedules(
+  flow: FlowTriggerFields,
+): ResolvedFlowSchedule[] {
+  const list = Array.isArray(flow.schedules) ? flow.schedules : [];
+  if (list.length > 0) {
+    return list
+      .filter(entry => entry?.enabled !== false && hasCron(entry?.cron))
+      .map((entry, index) => ({
+        id: entry.id || `schedule-${index}`,
+        cron: (entry.cron as string).trim(),
+        timezone: entry.timezone || "UTC",
+        entities: normalizeScheduleEntities(entry.entities),
+        kind: entry.kind === "reconcile" ? "reconcile" : "poll",
+        lastRunAt: toDate(entry.lastRunAt),
+        origin: "list" as const,
+      }));
+  }
+
+  const resolved: ResolvedFlowSchedule[] = [];
+  if (flow.schedule?.enabled === true && hasCron(flow.schedule.cron)) {
+    resolved.push({
+      id: "legacy-schedule",
+      cron: (flow.schedule.cron as string).trim(),
+      timezone: flow.schedule.timezone || "UTC",
+      entities: [],
+      kind: "poll",
+      // The poll runner has always tracked its cadence off the flow-level
+      // `lastRunAt`, which the execution itself updates.
+      lastRunAt: null,
+      origin: "schedule",
+    });
+  }
+  if (
+    flow.backfillSchedule?.enabled === true &&
+    hasCron(flow.backfillSchedule.cron)
+  ) {
+    resolved.push({
+      id: "legacy-backfill-schedule",
+      cron: (flow.backfillSchedule.cron as string).trim(),
+      timezone: flow.backfillSchedule.timezone || "UTC",
+      entities: [],
+      kind: "reconcile",
+      lastRunAt: toDate(flow.backfillSchedule.lastRunAt),
+      origin: "backfillSchedule",
+    });
+  }
+  return resolved;
+}
+
+export interface NormalizedFlowSchedule {
+  id: string;
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+  entities?: string[];
+  kind: "poll" | "reconcile";
+  lastRunAt?: Date;
+}
+
+export type NormalizeSchedulesResult =
+  | { ok: true; schedules: NormalizedFlowSchedule[] }
+  | { ok: false; error: string };
+
+function isValidCron(cron: string): boolean {
+  const fields = cron.trim().split(/\s+/).filter(Boolean);
+  return fields.length === 5 || fields.length === 6;
+}
+
+/**
+ * Validate and normalize a client-supplied `schedules[]` payload.
+ * `lastRunAt` is never taken from the client — it is carried over from the
+ * stored row with the same id so an edit can't replay or skip a cadence.
+ */
+export function normalizeFlowScheduleList(
+  input: unknown,
+  options: {
+    previous?: FlowScheduleEntry[] | null;
+    generateId: () => string;
+  },
+): NormalizeSchedulesResult {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "schedules must be an array" };
+  }
+
+  const previousById = new Map<string, FlowScheduleEntry>();
+  for (const entry of options.previous || []) {
+    if (entry?.id) previousById.set(entry.id, entry);
+  }
+
+  const schedules: NormalizedFlowSchedule[] = [];
+  const seenIds = new Set<string>();
+
+  for (const raw of input) {
+    if (!raw || typeof raw !== "object") {
+      return { ok: false, error: "Each schedule must be an object" };
+    }
+    const entry = raw as FlowScheduleEntry;
+    const cron = typeof entry.cron === "string" ? entry.cron.trim() : "";
+    if (!cron || !isValidCron(cron)) {
+      return {
+        ok: false,
+        error: `Invalid cron expression: "${cron}". Use 5 or 6 space-separated fields.`,
+      };
+    }
+
+    let id =
+      typeof entry.id === "string" && entry.id.trim().length > 0
+        ? entry.id.trim()
+        : options.generateId();
+    while (seenIds.has(id)) id = options.generateId();
+    seenIds.add(id);
+
+    const entities = normalizeScheduleEntities(entry.entities);
+    const previousRun = toDate(previousById.get(id)?.lastRunAt);
+
+    schedules.push({
+      id,
+      enabled: entry.enabled !== false,
+      cron,
+      timezone:
+        typeof entry.timezone === "string" && entry.timezone.trim()
+          ? entry.timezone.trim()
+          : "UTC",
+      ...(entities.length > 0 ? { entities } : {}),
+      kind: entry.kind === "reconcile" ? "reconcile" : "poll",
+      ...(previousRun ? { lastRunAt: previousRun } : {}),
+    });
+  }
+
+  return { ok: true, schedules };
+}
+
+/**
+ * Back-compat projection of a `schedules[]` list onto the standalone
+ * `schedule` / `backfillSchedule` fields that older readers (list payloads,
+ * the flow detail panels, the /toggle-schedule endpoint) still consult.
+ */
+export function deriveLegacyScheduleMirrors(
+  schedules: NormalizedFlowSchedule[],
+): {
+  schedule: { enabled: boolean; cron?: string; timezone?: string };
+  backfillSchedule: { enabled: boolean; cron?: string; timezone?: string };
+} {
+  const firstPoll = schedules.find(s => s.enabled && s.kind === "poll");
+  const firstReconcile = schedules.find(
+    s => s.enabled && s.kind === "reconcile",
+  );
+  return {
+    schedule: firstPoll
+      ? { enabled: true, cron: firstPoll.cron, timezone: firstPoll.timezone }
+      : { enabled: false },
+    backfillSchedule: firstReconcile
+      ? {
+          enabled: true,
+          cron: firstReconcile.cron,
+          timezone: firstReconcile.timezone,
+        }
+      : { enabled: false },
+  };
+}
+
 export function hasScheduleTrigger(flow: FlowTriggerFields): boolean {
-  return flow.schedule?.enabled === true && hasCron(flow.schedule?.cron);
+  return resolveFlowSchedules(flow).some(s => s.kind === "poll");
 }
 
 export function hasWebhookTrigger(flow: FlowTriggerFields): boolean {
@@ -62,10 +292,7 @@ export function hasWebhookTrigger(flow: FlowTriggerFields): boolean {
 }
 
 export function hasReconcileTrigger(flow: FlowTriggerFields): boolean {
-  return (
-    flow.backfillSchedule?.enabled === true &&
-    hasCron(flow.backfillSchedule?.cron)
-  );
+  return resolveFlowSchedules(flow).some(s => s.kind === "reconcile");
 }
 
 export function deriveTriggerSet(flow: FlowTriggerFields): FlowTriggerSet {
@@ -123,9 +350,39 @@ export function resolveDefaultSyncEngine(params: {
  * cron is polled (a webhook flow with a poll schedule is a hybrid).
  */
 export function buildScheduledFlowSelection(): Record<string, unknown> {
+  // Non-empty cron string, not whitespace-only — mirrors hasCron.
+  const cronMatch = { $exists: true, $type: "string", $not: /^\s*$/ };
   return {
-    "schedule.enabled": true,
-    // String, non-empty, not whitespace-only — mirrors hasScheduleTrigger.
-    "schedule.cron": { $exists: true, $type: "string", $not: /^\s*$/ },
+    $or: [
+      { "schedule.enabled": true, "schedule.cron": cronMatch },
+      {
+        schedules: {
+          $elemMatch: { enabled: { $ne: false }, cron: cronMatch },
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Mongo selection for the reconcile-trigger scheduler
+ * (`cdcScheduledBackfillFunction`): legacy `backfillSchedule` rows plus any
+ * `schedules[]` row with `kind: "reconcile"`.
+ */
+export function buildReconcileFlowSelection(): Record<string, unknown> {
+  const cronMatch = { $exists: true, $type: "string", $not: /^\s*$/ };
+  return {
+    $or: [
+      { "backfillSchedule.enabled": true, "backfillSchedule.cron": cronMatch },
+      {
+        schedules: {
+          $elemMatch: {
+            enabled: { $ne: false },
+            kind: "reconcile",
+            cron: cronMatch,
+          },
+        },
+      },
+    ],
   };
 }

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -113,6 +113,20 @@ interface TransferQueryField {
   rows?: number;
 }
 
+/**
+ * One cron row of the Schedule trigger. Replaces the old
+ * scheduled-poll / periodic-full-reconcile pair of checkboxes: a sync has a
+ * list of cadences, each with its own entity scope and run kind.
+ */
+interface ScheduleRowConfig {
+  id: string;
+  cron: string;
+  timezone: string;
+  /** Empty = every entity enabled in the Entities step. */
+  entities: string[];
+  kind: "poll" | "reconcile";
+}
+
 interface FormData {
   dataSourceId: string;
   destinationDatabaseId: string;
@@ -121,19 +135,14 @@ interface FormData {
     tablePrefix?: string;
     schema?: string;
   };
-  // Trigger set
-  scheduleEnabled: boolean;
-  scheduleCron: string;
-  scheduleTimezone: string;
+  // Trigger set: a list of cron rows plus the optional webhook push.
+  schedules: ScheduleRowConfig[];
   webhookEnabled: boolean;
   webhookSecret?: string;
   // Sync configuration
   syncMode: "full" | "incremental";
   writeMode: "append_dedup" | "append" | "overwrite";
   deleteMode?: "hard" | "soft";
-  backfillScheduleEnabled?: boolean;
-  backfillScheduleCron?: string;
-  backfillScheduleTimezone?: string;
   // Entities
   entityFilter: string[];
   entityLayouts?: EntityLayoutConfig[];
@@ -165,6 +174,74 @@ const SCHEDULE_PRESETS = [
   { label: "Monthly on 1st", cron: "0 0 1 * *" },
 ];
 
+const DEFAULT_POLL_CRON = "0 * * * *";
+const DEFAULT_RECONCILE_CRON = "0 3 * * *";
+
+function newScheduleId(): string {
+  const cryptoRef = globalThis.crypto;
+  return cryptoRef?.randomUUID
+    ? cryptoRef.randomUUID()
+    : `schedule-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeScheduleRow(
+  kind: "poll" | "reconcile",
+  overrides: Partial<ScheduleRowConfig> = {},
+): ScheduleRowConfig {
+  return {
+    id: newScheduleId(),
+    cron: kind === "reconcile" ? DEFAULT_RECONCILE_CRON : DEFAULT_POLL_CRON,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    entities: [],
+    kind,
+    ...overrides,
+  };
+}
+
+/**
+ * Schedule rows for an existing sync. Flows saved before the unified list
+ * still carry the standalone `schedule` (poll) / `backfillSchedule`
+ * (reconcile) fields, so project those into rows when the list is absent.
+ */
+function scheduleRowsFromFlow(flow: any): ScheduleRowConfig[] {
+  const stored = Array.isArray(flow?.schedules) ? flow.schedules : [];
+  if (stored.length > 0) {
+    return stored
+      .filter((row: any) => row?.enabled !== false && row?.cron)
+      .map((row: any) => ({
+        id: row.id || newScheduleId(),
+        cron: row.cron,
+        timezone: row.timezone || "UTC",
+        entities: Array.isArray(row.entities) ? row.entities : [],
+        kind: row.kind === "reconcile" ? "reconcile" : "poll",
+      }));
+  }
+
+  const rows: ScheduleRowConfig[] = [];
+  if (flow?.schedule?.enabled && flow.schedule?.cron) {
+    rows.push(
+      makeScheduleRow("poll", {
+        cron: flow.schedule.cron,
+        timezone: flow.schedule.timezone || "UTC",
+      }),
+    );
+  }
+  if (flow?.backfillSchedule?.enabled && flow.backfillSchedule?.cron) {
+    rows.push(
+      makeScheduleRow("reconcile", {
+        cron: flow.backfillSchedule.cron,
+        timezone: flow.backfillSchedule.timezone || "UTC",
+      }),
+    );
+  }
+  return rows;
+}
+
+function isValidCron(cron: string): boolean {
+  const fields = cron.trim().split(/\s+/).filter(Boolean);
+  return fields.length === 5 || fields.length === 6;
+}
+
 /**
  * Airbyte-style per-entity incremental badge — mirrors backend
  * `IncrementalMode` (BaseConnector.getIncrementalCapabilities). Shown in the
@@ -191,8 +268,7 @@ const STEPS = [
   { label: "Entities", description: "What data is synced" },
   {
     label: "Triggers",
-    description:
-      "How the sync is triggered — schedule, webhook, or periodic reconcile",
+    description: "How the sync is triggered — schedules and/or webhook",
   },
 ];
 
@@ -273,8 +349,10 @@ export function SyncFlowForm({
     FlattenedConnectorEntity[]
   >([]);
   const [openSteps, setOpenSteps] = useState<Set<number>>(new Set([0]));
-  const [scheduleCronMode, setScheduleCronMode] = useState<"preset" | "custom">(
-    "preset",
+  // Schedule rows whose cadence the user switched to a raw cron expression
+  // (a cron that matches no preset renders as custom regardless).
+  const [customCronRows, setCustomCronRows] = useState<Set<string>>(
+    () => new Set(),
   );
   const [pendingLayoutReset, setPendingLayoutReset] = useState<{
     data: FormData;
@@ -337,18 +415,12 @@ export function SyncFlowForm({
       destinationDatabaseId: "",
       destinationDatabaseName: "",
       tableDestination: { tablePrefix: "", schema: "" },
-      scheduleEnabled: true,
-      scheduleCron: "0 * * * *",
-      scheduleTimezone:
-        Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+      schedules: [makeScheduleRow("poll")],
       webhookEnabled: false,
       webhookSecret: "",
       syncMode: "incremental",
       writeMode: "append_dedup",
       deleteMode: "hard",
-      backfillScheduleEnabled: false,
-      backfillScheduleCron: "0 3 * * *",
-      backfillScheduleTimezone: "UTC",
       entityFilter: [],
       entityLayouts: [],
       queries: [],
@@ -357,12 +429,10 @@ export function SyncFlowForm({
 
   const watchDataSourceId = watch("dataSourceId");
   const watchDestinationId = watch("destinationDatabaseId");
-  const watchScheduleEnabled = watch("scheduleEnabled");
-  const watchScheduleCron = watch("scheduleCron");
+  const watchSchedules = watch("schedules") || [];
   const watchWebhookEnabled = watch("webhookEnabled");
   const watchEntityLayouts = watch("entityLayouts") || [];
   const watchDeleteMode = watch("deleteMode");
-  const watchBackfillScheduleEnabled = watch("backfillScheduleEnabled");
   const watchSyncMode = watch("syncMode");
   const watchWriteMode = watch("writeMode");
 
@@ -371,6 +441,19 @@ export function SyncFlowForm({
     append: appendQuery,
     remove: removeQuery,
   } = useFieldArray({ control, name: "queries" });
+
+  const {
+    fields: scheduleFields,
+    append: appendSchedule,
+    remove: removeSchedule,
+  } = useFieldArray({ control, name: "schedules" });
+
+  const hasReconcileSchedule = watchSchedules.some(
+    row => row.kind === "reconcile",
+  );
+  // Stable dependency for the kind-legality effect below (`watchSchedules` is
+  // a fresh array every render).
+  const scheduleKindsKey = watchSchedules.map(row => row.kind).join(",");
 
   const selectedConnector = connectors.find(ds => ds._id === watchDataSourceId);
   const selectedConnectorType = selectedConnector?.type;
@@ -505,6 +588,12 @@ export function SyncFlowForm({
       incrementalCheckEntities,
     );
 
+  // Rows can only scope down to entities the sync already syncs.
+  const scheduleEntityOptions =
+    enabledEntityNames.length > 0
+      ? enabledEntityNames
+      : entityMetadata.map(e => e.name);
+
   const layoutMode: "partition" | "index" | "none" = hasStagingDest
     ? "partition"
     : destType === "postgresql" ||
@@ -526,11 +615,20 @@ export function SyncFlowForm({
   const requiresQueries = Boolean(transferQueriesSchema?.required);
   const requiresDestinationDatabaseName =
     !isCdcCapableDest && availableDatabases.length > 0;
-  // For Full Refresh on a CDC destination, "poll on a cron" and "periodic
-  // full reconcile" both mean "run a complete backfill on this cadence" —
-  // the same underlying operation exposed as two controls. Collapse to the
-  // single reconcile cron below and hide the redundant Scheduled trigger.
-  const showScheduleTrigger = !(isCdcCapableDest && watchSyncMode === "full");
+  // For Full Refresh on a CDC destination, "poll on a cron" and "run a full
+  // reconcile on a cron" are the same operation, and only the reconcile path
+  // drives the CDC backfill machinery (table swap, event drain). Force every
+  // schedule row to that kind and hide the per-row kind picker.
+  const forceReconcileKind = isCdcCapableDest && watchSyncMode === "full";
+  // The reconcile kind only exists on CDC destinations; elsewhere a schedule
+  // row is always a normal run.
+  const allowReconcileKind = isCdcCapableDest;
+  const pollKindLabel =
+    watchSyncMode === "incremental" ? "Incremental poll" : "Full sync";
+  const pollDescription =
+    watchSyncMode === "incremental"
+      ? "Fetches records changed since this schedule's last run."
+      : "Re-pulls every record in scope on this cadence.";
   const reconcileDescription =
     watchSyncMode === "full" && watchWriteMode === "overwrite"
       ? "Refreshes an exact snapshot each run — additions, edits, and deletions at the source are all reflected."
@@ -579,18 +677,30 @@ export function SyncFlowForm({
     setValue,
   ]);
 
-  // The Scheduled trigger is hidden (see showScheduleTrigger) once Full
-  // Refresh + a CDC destination make it redundant with the reconcile cron —
-  // disable it too so it doesn't keep firing invisibly in the background.
+  // Keep row kinds legal for the current destination + sync mode: Full
+  // Refresh on CDC is always a reconcile, and non-CDC destinations have no
+  // reconcile path at all.
   useEffect(() => {
-    if (
-      !showScheduleTrigger &&
-      watchScheduleEnabled &&
-      formTouchedRef.current
-    ) {
-      setValue("scheduleEnabled", false);
-    }
-  }, [showScheduleTrigger, watchScheduleEnabled, setValue]);
+    if (!formTouchedRef.current) return;
+    const rows = getValues("schedules") || [];
+    const target: "poll" | "reconcile" | null = forceReconcileKind
+      ? "reconcile"
+      : !allowReconcileKind
+        ? "poll"
+        : null;
+    if (!target) return;
+    rows.forEach((row, index) => {
+      if (row.kind !== target) {
+        setValue(`schedules.${index}.kind`, target, { shouldDirty: true });
+      }
+    });
+  }, [
+    forceReconcileKind,
+    allowReconcileKind,
+    scheduleKindsKey,
+    setValue,
+    getValues,
+  ]);
 
   // Incremental requires at least one selected entity to do better than a
   // full re-pull; fall back to Full Refresh | Deduped when the connector (or
@@ -614,9 +724,9 @@ export function SyncFlowForm({
 
   // The periodic full reconcile is opt-in. When Incremental polls cannot see
   // updates for the selected entities (created-anchor or none), the form
-  // RECOMMENDS it (warning + "Enable daily" button, see step 3) but never
-  // switches it on by itself: a reconcile re-upserts every current record on
-  // a cron, which is a cost and a load on the source the user must choose.
+  // RECOMMENDS it (warning + "Add daily" button, see step 3) but never adds a
+  // reconcile schedule by itself: a reconcile re-upserts every current record
+  // on a cron, which is a cost and a load on the source the user must choose.
 
   // transferQueries schema (GraphQL/PostHog-style connectors).
   // Stale-while-revalidate: show the persisted cache immediately, but always
@@ -759,17 +869,11 @@ export function SyncFlowForm({
     const hasWebhookTrigger = Boolean(
       flow.webhookConfig?.enabled && flow.webhookConfig?.endpoint,
     );
-    const hasScheduleTrigger = Boolean(
-      flow.schedule?.enabled && flow.schedule?.cron,
-    );
-
     const formData: FormData = {
       dataSourceId: dataSourceId || "",
       destinationDatabaseId: destinationDatabaseId || "",
       destinationDatabaseName: flow.destinationDatabaseName || "",
-      scheduleEnabled: hasScheduleTrigger,
-      scheduleCron: flow.schedule?.cron || "0 * * * *",
-      scheduleTimezone: flow.schedule?.timezone || "UTC",
+      schedules: scheduleRowsFromFlow(flow),
       webhookEnabled: hasWebhookTrigger,
       // Prefer the server secret when present. If a flows refresh races with
       // one-click provisioning (secret just set in the form, not yet visible
@@ -781,9 +885,6 @@ export function SyncFlowForm({
         (flow.writeMode as "append_dedup" | "append" | "overwrite") ||
         "append_dedup",
       deleteMode: flow.deleteMode || "hard",
-      backfillScheduleEnabled: flow.backfillSchedule?.enabled ?? false,
-      backfillScheduleCron: flow.backfillSchedule?.cron || "0 3 * * *",
-      backfillScheduleTimezone: flow.backfillSchedule?.timezone || "UTC",
       entityFilter: flow.entityFilter || [],
       entityLayouts: (flow.entityLayouts || []).map((l: any) => ({
         ...l,
@@ -803,11 +904,7 @@ export function SyncFlowForm({
       setWebhookUrl(flow.webhookConfig.endpoint);
     }
 
-    setScheduleCronMode(
-      SCHEDULE_PRESETS.some(p => p.cron === formData.scheduleCron)
-        ? "preset"
-        : "custom",
-    );
+    setCustomCronRows(new Set());
     formTouchedRef.current = false;
     reset(formData);
   }, [isNewMode, currentFlowId, flows, reset, getValues]);
@@ -863,8 +960,33 @@ export function SyncFlowForm({
       return;
     }
 
-    if (data.scheduleEnabled && !data.scheduleCron.trim()) {
-      setError("A cron expression is required for the scheduled trigger.");
+    // Destination + sync mode decide which kinds are legal, so normalize here
+    // rather than trusting whatever the row last held: Full Refresh on a CDC
+    // destination is always a reconcile (only that path drives the CDC
+    // backfill), and non-CDC destinations have no reconcile path at all.
+    // A row can only scope down to entities the sync still syncs — otherwise
+    // a stale scope makes every scheduled run fail on an unknown entity.
+    const scopeableEntities = (data.entityLayouts || [])
+      .filter(l => l.enabled !== false)
+      .map(l => l.entity);
+    const schedules = (data.schedules || []).map(row => ({
+      ...row,
+      cron: (row.cron || "").trim(),
+      timezone: (row.timezone || "").trim() || "UTC",
+      entities:
+        scopeableEntities.length > 0
+          ? (row.entities || []).filter(e => scopeableEntities.includes(e))
+          : row.entities || [],
+      kind: forceReconcileKind
+        ? ("reconcile" as const)
+        : allowReconcileKind
+          ? row.kind
+          : ("poll" as const),
+    }));
+    if (schedules.some(row => !isValidCron(row.cron))) {
+      setError(
+        "Every schedule needs a valid cron expression (5 or 6 space-separated fields).",
+      );
       setOpenSteps(prev => new Set([...prev, 4]));
       return;
     }
@@ -926,21 +1048,6 @@ export function SyncFlowForm({
       setOpenSteps(prev => new Set([...prev, 3]));
       return;
     }
-    const backfillSchedule = {
-      enabled: Boolean(data.backfillScheduleEnabled),
-      cron: (data.backfillScheduleCron || "").trim(),
-      timezone: data.backfillScheduleTimezone || "UTC",
-    };
-    if (
-      backfillSchedule.enabled &&
-      backfillSchedule.cron.split(" ").filter(Boolean).length < 5
-    ) {
-      setError(
-        "A valid cron expression is required to enable the periodic full reconcile.",
-      );
-      setOpenSteps(prev => new Set([...prev, 4]));
-      return;
-    }
 
     setIsSubmitting(true);
     setError(null);
@@ -967,13 +1074,17 @@ export function SyncFlowForm({
         destinationDatabaseId: data.destinationDatabaseId,
         syncMode: data.syncMode,
         writeMode: data.writeMode,
-        schedule: data.scheduleEnabled
-          ? {
-              enabled: true,
-              cron: data.scheduleCron.trim(),
-              timezone: data.scheduleTimezone || "UTC",
-            }
-          : { enabled: false },
+        // Unified trigger list; the API mirrors it onto the legacy
+        // schedule / backfillSchedule fields for older readers.
+        schedules: schedules.map(row => ({
+          id: row.id,
+          enabled: true,
+          cron: row.cron,
+          timezone: row.timezone,
+          kind: row.kind,
+          // Empty scope = every entity enabled in the Entities step.
+          ...(row.entities.length > 0 ? { entities: row.entities } : {}),
+        })),
         queries: data.queries,
       };
 
@@ -984,7 +1095,6 @@ export function SyncFlowForm({
         payload.deleteMode = isBigQueryDest
           ? "soft"
           : data.deleteMode || "hard";
-        payload.backfillSchedule = backfillSchedule;
         payload.tableDestination = {
           connectionId: data.destinationDatabaseId,
           schema: data.tableDestination?.schema,
@@ -1051,12 +1161,13 @@ export function SyncFlowForm({
           flow_type: flowType,
           connector_type: selectedSource?.type,
           triggers: [
-            ...(data.scheduleEnabled ? ["schedule"] : []),
+            ...(schedules.some(row => row.kind === "poll") ? ["schedule"] : []),
             ...(data.webhookEnabled ? ["webhook"] : []),
-            ...(isCdcCapableDest && data.backfillScheduleEnabled
+            ...(schedules.some(row => row.kind === "reconcile")
               ? ["reconcile"]
               : []),
           ].join("+"),
+          schedule_count: schedules.length,
         });
         await useFlowStore.getState().fetchFlows(currentWorkspace.id);
         setIsNewMode(false);
@@ -1249,12 +1360,6 @@ export function SyncFlowForm({
       </Box>
     </AccordionSummary>
   );
-
-  const cronPresetValue = SCHEDULE_PRESETS.some(
-    p => p.cron === watchScheduleCron,
-  )
-    ? watchScheduleCron
-    : "__custom__";
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
@@ -1676,15 +1781,13 @@ export function SyncFlowForm({
                     <Alert
                       severity="info"
                       action={
-                        !watchBackfillScheduleEnabled ? (
+                        !hasReconcileSchedule ? (
                           <Button
                             color="inherit"
                             size="small"
                             onClick={() => {
                               formTouchedRef.current = true;
-                              setValue("backfillScheduleEnabled", true, {
-                                shouldDirty: true,
-                              });
+                              appendSchedule(makeScheduleRow("reconcile"));
                               setOpenSteps(prev => {
                                 const next = new Set(prev);
                                 next.add(4);
@@ -1692,14 +1795,14 @@ export function SyncFlowForm({
                               });
                             }}
                           >
-                            Enable reconcile
+                            Add reconcile schedule
                           </Button>
                         ) : undefined
                       }
                     >
-                      {watchBackfillScheduleEnabled
-                        ? "Periodic full reconcile is on — it covers updates and snapshot entities that Incremental polls cannot see."
-                        : "Enable the periodic full reconcile trigger (step 3) so created-anchor / full-repull entities stay current."}
+                      {hasReconcileSchedule
+                        ? "A full reconcile schedule is set — it covers updates and snapshot entities that Incremental polls cannot see."
+                        : "Add a full reconcile schedule in Triggers so created-anchor / full-repull entities stay current."}
                     </Alert>
                   )}
 
@@ -2232,127 +2335,323 @@ export function SyncFlowForm({
               {renderStepHeader(4)}
               <AccordionDetails>
                 <Stack spacing={2}>
-                  {!watchScheduleEnabled &&
-                    !watchWebhookEnabled &&
-                    !(isCdcCapableDest && watchBackfillScheduleEnabled) && (
-                      <Alert severity="info">
-                        No automatic triggers are enabled. You can still run
-                        this sync manually.
+                  {watchSchedules.length === 0 && !watchWebhookEnabled && (
+                    <Alert severity="info">
+                      No automatic triggers are enabled. You can still run this
+                      sync manually.
+                    </Alert>
+                  )}
+
+                  {/* Schedule trigger. One list of cron rows instead of a
+                      "scheduled poll" and a "periodic full reconcile"
+                      checkbox: each row carries its own cadence, entity
+                      scope and run kind, so "poll everything hourly" and
+                      "fully reconcile the heavy entities nightly" are two
+                      rows of the same trigger. */}
+                  <Box
+                    sx={{
+                      border: 1,
+                      borderColor:
+                        suggestReconcile && !hasReconcileSchedule
+                          ? "warning.main"
+                          : "divider",
+                      borderRadius: 1,
+                      p: 2,
+                    }}
+                  >
+                    <Stack
+                      direction="row"
+                      justifyContent="space-between"
+                      alignItems="flex-start"
+                      spacing={2}
+                    >
+                      <Box>
+                        <Typography variant="subtitle2">Schedule</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Run the sync on one or more cron cadences. Each row
+                          syncs the entities you scope it to — leave the scope
+                          empty for every entity enabled in the Entities step.
+                        </Typography>
+                      </Box>
+                      <Button
+                        size="small"
+                        startIcon={<AddIcon />}
+                        onClick={() => {
+                          formTouchedRef.current = true;
+                          appendSchedule(
+                            makeScheduleRow(
+                              forceReconcileKind ? "reconcile" : "poll",
+                            ),
+                          );
+                        }}
+                        sx={{ flexShrink: 0 }}
+                      >
+                        Add schedule
+                      </Button>
+                    </Stack>
+
+                    {suggestReconcile && !hasReconcileSchedule && (
+                      <Alert
+                        severity="warning"
+                        sx={{ mt: 2 }}
+                        action={
+                          <Button
+                            color="inherit"
+                            size="small"
+                            onClick={() => {
+                              formTouchedRef.current = true;
+                              appendSchedule(makeScheduleRow("reconcile"));
+                            }}
+                          >
+                            Add daily
+                          </Button>
+                        }
+                      >
+                        Incremental polls for the selected entities miss updates
+                        (created-only) or silently re-fetch everything. Add a
+                        full reconcile schedule so the destination stays honest
+                        between webhook events.
                       </Alert>
                     )}
 
-                  {/* Scheduled trigger. Hidden for Full Refresh on CDC
-                      destinations: "poll on a cron" and "periodic full
-                      reconcile" are the same operation there (a full
-                      backfill), so showing both would just be two cron
-                      controls for one behavior. The reconcile trigger below
-                      becomes the sync's single cron in that case. */}
-                  {showScheduleTrigger && (
-                    <Box
-                      sx={{
-                        border: 1,
-                        borderColor: "divider",
-                        borderRadius: 1,
-                        p: 2,
-                      }}
-                    >
-                      <Controller
-                        name="scheduleEnabled"
-                        control={control}
-                        render={({ field }) => (
-                          <FormControlLabel
-                            control={
-                              <Checkbox
-                                checked={Boolean(field.value)}
-                                onChange={e => field.onChange(e.target.checked)}
-                              />
-                            }
-                            label={
-                              <Box>
-                                <Typography variant="subtitle2">
-                                  Scheduled
-                                </Typography>
+                    {hasReconcileSchedule &&
+                      watchSyncMode === "incremental" &&
+                      watchWriteMode === "append" && (
+                        <Alert severity="warning" sx={{ mt: 2 }}>
+                          Combined with Incremental | Append, each reconcile run
+                          appends a full duplicate snapshot into the history
+                          table. Consider Full Refresh | Append (a
+                          snapshot-per-run table) or Deduped instead.
+                        </Alert>
+                      )}
+
+                    {scheduleFields.length === 0 ? (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block", mt: 2 }}
+                      >
+                        No schedules — this sync runs only when triggered
+                        manually
+                        {watchWebhookEnabled
+                          ? " or by an incoming webhook"
+                          : ""}
+                        .
+                      </Typography>
+                    ) : (
+                      <Stack spacing={2} sx={{ mt: 2 }}>
+                        {scheduleFields.map((field, index) => {
+                          const row = watchSchedules[index];
+                          const rowKey = row?.id || field.id;
+                          const cron = row?.cron || "";
+                          const isCustomCron =
+                            customCronRows.has(rowKey) ||
+                            (cron.length > 0 &&
+                              !SCHEDULE_PRESETS.some(
+                                preset => preset.cron === cron,
+                              ));
+                          const rowIsReconcile =
+                            forceReconcileKind ||
+                            (allowReconcileKind && row?.kind === "reconcile");
+                          return (
+                            <Box
+                              key={field.id}
+                              sx={{
+                                border: 1,
+                                borderColor: "divider",
+                                borderRadius: 1,
+                                p: 2,
+                              }}
+                            >
+                              <Stack
+                                direction={{ xs: "column", sm: "row" }}
+                                spacing={2}
+                                alignItems={{ xs: "stretch", sm: "center" }}
+                              >
+                                <FormControl
+                                  size="small"
+                                  sx={{ minWidth: 170, flex: 1 }}
+                                >
+                                  <InputLabel>Cadence</InputLabel>
+                                  <Select
+                                    label="Cadence"
+                                    value={isCustomCron ? "__custom__" : cron}
+                                    onChange={e => {
+                                      const value = e.target.value as string;
+                                      formTouchedRef.current = true;
+                                      if (value === "__custom__") {
+                                        setCustomCronRows(prev =>
+                                          new Set(prev).add(rowKey),
+                                        );
+                                        return;
+                                      }
+                                      setCustomCronRows(prev => {
+                                        const next = new Set(prev);
+                                        next.delete(rowKey);
+                                        return next;
+                                      });
+                                      setValue(
+                                        `schedules.${index}.cron`,
+                                        value,
+                                        { shouldDirty: true },
+                                      );
+                                    }}
+                                  >
+                                    {SCHEDULE_PRESETS.map(preset => (
+                                      <MenuItem
+                                        key={preset.cron}
+                                        value={preset.cron}
+                                      >
+                                        {preset.label}
+                                      </MenuItem>
+                                    ))}
+                                    <MenuItem value="__custom__">
+                                      Custom cron…
+                                    </MenuItem>
+                                  </Select>
+                                </FormControl>
+
+                                {isCustomCron && (
+                                  <Controller
+                                    name={`schedules.${index}.cron`}
+                                    control={control}
+                                    render={({ field: cronField }) => (
+                                      <TextField
+                                        {...cronField}
+                                        label="Cron expression"
+                                        placeholder="0 * * * *"
+                                        size="small"
+                                        fullWidth
+                                        error={
+                                          Boolean(cronField.value) &&
+                                          !isValidCron(cronField.value)
+                                        }
+                                        helperText="Format: minute hour day month weekday"
+                                      />
+                                    )}
+                                  />
+                                )}
+
+                                <Controller
+                                  name={`schedules.${index}.timezone`}
+                                  control={control}
+                                  render={({ field: tzField }) => (
+                                    <TextField
+                                      {...tzField}
+                                      label="Timezone"
+                                      placeholder="UTC"
+                                      size="small"
+                                      sx={{ minWidth: 150 }}
+                                    />
+                                  )}
+                                />
+
+                                {allowReconcileKind && !forceReconcileKind && (
+                                  <FormControl
+                                    size="small"
+                                    sx={{ minWidth: 170 }}
+                                  >
+                                    <InputLabel>Run</InputLabel>
+                                    <Controller
+                                      name={`schedules.${index}.kind`}
+                                      control={control}
+                                      render={({ field: kindField }) => (
+                                        <Select {...kindField} label="Run">
+                                          <MenuItem value="poll">
+                                            {pollKindLabel}
+                                          </MenuItem>
+                                          <MenuItem value="reconcile">
+                                            Full reconcile
+                                          </MenuItem>
+                                        </Select>
+                                      )}
+                                    />
+                                  </FormControl>
+                                )}
+
+                                <IconButton
+                                  aria-label="Remove schedule"
+                                  size="small"
+                                  onClick={() => {
+                                    formTouchedRef.current = true;
+                                    removeSchedule(index);
+                                  }}
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Stack>
+
+                              {scheduleEntityOptions.length > 0 && (
+                                <FormControl
+                                  size="small"
+                                  fullWidth
+                                  sx={{ mt: 2 }}
+                                >
+                                  <InputLabel>Entities</InputLabel>
+                                  <Controller
+                                    name={`schedules.${index}.entities`}
+                                    control={control}
+                                    render={({ field: entityField }) => (
+                                      <Select
+                                        multiple
+                                        label="Entities"
+                                        value={entityField.value || []}
+                                        onChange={e => {
+                                          formTouchedRef.current = true;
+                                          const value = e.target.value;
+                                          entityField.onChange(
+                                            typeof value === "string"
+                                              ? value.split(",").filter(Boolean)
+                                              : value,
+                                          );
+                                        }}
+                                        renderValue={selected =>
+                                          (selected as string[]).length === 0
+                                            ? "All enabled entities"
+                                            : (selected as string[]).join(", ")
+                                        }
+                                      >
+                                        {scheduleEntityOptions.map(entity => (
+                                          <MenuItem key={entity} value={entity}>
+                                            <Checkbox
+                                              size="small"
+                                              checked={(
+                                                entityField.value || []
+                                              ).includes(entity)}
+                                            />
+                                            <Typography variant="body2">
+                                              {entity}
+                                            </Typography>
+                                          </MenuItem>
+                                        ))}
+                                      </Select>
+                                    )}
+                                  />
+                                  <FormHelperText>
+                                    {rowIsReconcile
+                                      ? reconcileDescription
+                                      : pollDescription}
+                                  </FormHelperText>
+                                </FormControl>
+                              )}
+
+                              {scheduleEntityOptions.length === 0 && (
                                 <Typography
                                   variant="caption"
                                   color="text.secondary"
+                                  sx={{ display: "block", mt: 1 }}
                                 >
-                                  Poll the source on a cron cadence.
+                                  {rowIsReconcile
+                                    ? reconcileDescription
+                                    : pollDescription}
                                 </Typography>
-                              </Box>
-                            }
-                          />
-                        )}
-                      />
-                      {watchScheduleEnabled && (
-                        <Stack
-                          direction={{ xs: "column", sm: "row" }}
-                          spacing={2}
-                          sx={{ mt: 1 }}
-                        >
-                          <FormControl size="small" fullWidth>
-                            <InputLabel>Cadence</InputLabel>
-                            <Select
-                              label="Cadence"
-                              value={
-                                scheduleCronMode === "custom"
-                                  ? "__custom__"
-                                  : cronPresetValue
-                              }
-                              onChange={e => {
-                                const value = e.target.value;
-                                if (value === "__custom__") {
-                                  setScheduleCronMode("custom");
-                                } else {
-                                  setScheduleCronMode("preset");
-                                  setValue("scheduleCron", value, {
-                                    shouldDirty: true,
-                                  });
-                                }
-                              }}
-                            >
-                              {SCHEDULE_PRESETS.map(preset => (
-                                <MenuItem key={preset.cron} value={preset.cron}>
-                                  {preset.label}
-                                </MenuItem>
-                              ))}
-                              <MenuItem value="__custom__">
-                                Custom cron…
-                              </MenuItem>
-                            </Select>
-                          </FormControl>
-                          {scheduleCronMode === "custom" && (
-                            <Controller
-                              name="scheduleCron"
-                              control={control}
-                              render={({ field }) => (
-                                <TextField
-                                  {...field}
-                                  label="Cron Expression"
-                                  placeholder="0 * * * *"
-                                  size="small"
-                                  fullWidth
-                                  helperText="Format: minute hour day month weekday"
-                                />
                               )}
-                            />
-                          )}
-                          <Controller
-                            name="scheduleTimezone"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="Timezone"
-                                placeholder="UTC"
-                                size="small"
-                                fullWidth
-                              />
-                            )}
-                          />
-                        </Stack>
-                      )}
-                    </Box>
-                  )}
+                            </Box>
+                          );
+                        })}
+                      </Stack>
+                    )}
+                  </Box>
 
                   {/* Webhook trigger */}
                   <Tooltip
@@ -2503,134 +2802,6 @@ export function SyncFlowForm({
                       )}
                     </Box>
                   </Tooltip>
-
-                  {/* Periodic full reconcile trigger (CDC destinations).
-                      For Full Refresh, this IS the schedule (see
-                      showScheduleTrigger above) — the label and helper text
-                      reflect that instead of duplicating a second cron. */}
-                  {isCdcCapableDest && (
-                    <Box
-                      sx={{
-                        border: 1,
-                        borderColor:
-                          suggestReconcile && !watchBackfillScheduleEnabled
-                            ? "warning.main"
-                            : "divider",
-                        borderRadius: 1,
-                        p: 2,
-                      }}
-                    >
-                      <Controller
-                        name="backfillScheduleEnabled"
-                        control={control}
-                        render={({ field }) => (
-                          <FormControlLabel
-                            control={
-                              <Checkbox
-                                checked={Boolean(field.value)}
-                                onChange={e => field.onChange(e.target.checked)}
-                              />
-                            }
-                            label={
-                              <Box>
-                                <Typography variant="subtitle2">
-                                  {showScheduleTrigger
-                                    ? "Periodic full reconcile"
-                                    : "Schedule (periodic full reconcile)"}
-                                  {suggestReconcile ? " (recommended)" : ""}
-                                </Typography>
-                                <Typography
-                                  variant="caption"
-                                  color="text.secondary"
-                                >
-                                  {reconcileDescription}
-                                  {showScheduleTrigger &&
-                                    " Other triggers stay active between runs."}
-                                </Typography>
-                              </Box>
-                            }
-                          />
-                        )}
-                      />
-                      {suggestReconcile && !watchBackfillScheduleEnabled && (
-                        <Alert
-                          severity="warning"
-                          sx={{ mt: 1 }}
-                          action={
-                            <Button
-                              color="inherit"
-                              size="small"
-                              onClick={() => {
-                                formTouchedRef.current = true;
-                                setValue("backfillScheduleEnabled", true, {
-                                  shouldDirty: true,
-                                });
-                                if (!getValues("backfillScheduleCron")) {
-                                  setValue(
-                                    "backfillScheduleCron",
-                                    "0 3 * * *",
-                                    { shouldDirty: true },
-                                  );
-                                }
-                              }}
-                            >
-                              Enable daily
-                            </Button>
-                          }
-                        >
-                          Incremental polls for the selected entities miss
-                          updates (created-only) or silently re-fetch
-                          everything. Enable a periodic full reconcile so the
-                          destination stays honest between webhook events.
-                        </Alert>
-                      )}
-                      {watchBackfillScheduleEnabled &&
-                        watchSyncMode === "incremental" &&
-                        watchWriteMode === "append" && (
-                          <Alert severity="warning" sx={{ mt: 1 }}>
-                            Combined with Incremental | Append, each reconcile
-                            run appends a full duplicate snapshot into the
-                            history table. Consider Full Refresh | Append (a
-                            snapshot-per-run table) or Deduped instead.
-                          </Alert>
-                        )}
-                      {watchBackfillScheduleEnabled && (
-                        <Stack
-                          direction={{ xs: "column", sm: "row" }}
-                          spacing={2}
-                          sx={{ mt: 2 }}
-                        >
-                          <Controller
-                            name="backfillScheduleCron"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="Cron expression"
-                                placeholder="0 3 * * *"
-                                size="small"
-                                fullWidth
-                                helperText="e.g. '0 3 * * *' = daily at 03:00"
-                              />
-                            )}
-                          />
-                          <Controller
-                            name="backfillScheduleTimezone"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="Timezone"
-                                placeholder="UTC"
-                                size="small"
-                                fullWidth
-                              />
-                            )}
-                          />
-                        </Stack>
-                      )}
-                    </Box>
-                  )}
 
                   {isNewMode ? (
                     <Button

--- a/docs/unified-sync-flow-proposal.md
+++ b/docs/unified-sync-flow-proposal.md
@@ -86,14 +86,14 @@ merging the two ingest paths.
 
 ### Duplication that actually exists
 
-| Layer | Scheduled | Webhook | Verdict |
-|---|---|---|---|
-| Destination adapter (MERGE) | CDC adapter (if CDC) / legacy | CDC adapter | Shared for CDC |
-| Ingest/staging path | direct `applyBatch` | event store → materialize | Intentionally different |
-| Flow `type` discriminator | `"scheduled"` | `"webhook"` | Duplicated (remove) |
-| UI form | `ScheduledFlowForm` | `WebhookFlowForm` | Duplicated (unify) |
-| Trigger scheduler | `flowSchedulerFunction` | `cdcScheduledBackfillFunction` | Overlapping selection |
-| Engine exposure | legacy (UI never exposes cdc) | cdc only | Inconsistent |
+| Layer                       | Scheduled                     | Webhook                        | Verdict                 |
+| --------------------------- | ----------------------------- | ------------------------------ | ----------------------- |
+| Destination adapter (MERGE) | CDC adapter (if CDC) / legacy | CDC adapter                    | Shared for CDC          |
+| Ingest/staging path         | direct `applyBatch`           | event store → materialize      | Intentionally different |
+| Flow `type` discriminator   | `"scheduled"`                 | `"webhook"`                    | Duplicated (remove)     |
+| UI form                     | `ScheduledFlowForm`           | `WebhookFlowForm`              | Duplicated (unify)      |
+| Trigger scheduler           | `flowSchedulerFunction`       | `cdcScheduledBackfillFunction` | Overlapping selection   |
+| Engine exposure             | legacy (UI never exposes cdc) | cdc only                       | Inconsistent            |
 
 ### Known pain points
 
@@ -133,18 +133,18 @@ interface IFlow {
   syncEngine: "legacy" | "cdc"; // "cdc" for any CDC-capable destination
 
   // Trigger set (already exist) — invariant: at least one enabled.
-  schedule?: { enabled: boolean; cron?: string; timezone?: string };        // poll
-  webhookConfig?: { enabled: boolean; secret: string; /* ... */ };          // push
+  schedule?: { enabled: boolean; cron?: string; timezone?: string }; // poll
+  webhookConfig?: { enabled: boolean; secret: string /* ... */ }; // push
 
   // Backfill / reconcile (already exist).
-  syncMode: "full" | "incremental";                                          // reconcile strategy
+  syncMode: "full" | "incremental"; // reconcile strategy
   backfillSchedule?: { enabled: boolean; cron?: string; timezone?: string }; // periodic full reconcile
 
   // Unchanged.
   sourceType: "connector" | "database";
   dataSourceId?: ObjectId;
   destinationDatabaseId: ObjectId;
-  tableDestination?: { connectionId; schema?; tableName; /* ... */ };
+  tableDestination?: { connectionId; schema?; tableName /* ... */ };
   entityFilter?: string[];
   entityLayouts?: IEntityLayout[];
   deleteMode?: "hard" | "soft";
@@ -193,7 +193,7 @@ Key invariants (enforced by a shared validator, not by `type`):
 
 ### Scheduler model (there are four `*/5` crons, not two)
 
-Only the first two are *triggers*; the other two must stay as-is:
+Only the first two are _triggers_; the other two must stay as-is:
 
 - **`flowSchedulerFunction`** — poll trigger (`schedule.enabled`). Emits
   `flow.execute`.
@@ -291,7 +291,7 @@ and keep `type` authoritative until Phase 3, the flag is a clean rollback.
 
 ### Rollback
 
-- Phases 0–3 keep legacy fields authoritative and only *derive* the new shape;
+- Phases 0–3 keep legacy fields authoritative and only _derive_ the new shape;
   disabling the flag reverts behavior. The Phase 2 migration is `down`-reversible.
 
 ---
@@ -381,7 +381,7 @@ webhook secret / provisioning block, cron editor) so we reuse validated pieces:
 - Flow model: `api/src/database/workspace-schema.ts` — `IFlow` (L856-935),
   `type` enum (L2065), `syncEngine` enum (L2218), `schedule` (L2127),
   `backfillSchedule` (L2154), `webhookConfig` (L2176); `ICdcChangeEvent` (L1002)
-  + `sourceKind` enum (L2537); `IWebhookEvent` (L968).
+  - `sourceKind` enum (L2537); `IWebhookEvent` (L968).
 - Schedulers + executor guards: `api/src/inngest/functions/flow.ts` —
   `flowSchedulerFunction` (L1990), scheduled safety check (L2018),
   `cdcScheduledBackfillFunction` (L2214), executor guards (L633-666, L1558),
@@ -405,3 +405,45 @@ webhook secret / provisioning block, cron editor) so we reuse validated pieces:
   update `PUT .../flows/:flowId`, `POST .../flows/:flowId/sync-engine`).
 - Forms: `app/src/components/ScheduledFlowForm.tsx`,
   `app/src/components/WebhookFlowForm.tsx`, `app/src/components/BackfillPanel.tsx`.
+
+---
+
+## Addendum: schedules as a list (implemented)
+
+The trigger set above shipped as three checkboxes — Scheduled poll, Webhook,
+Periodic full reconcile — where the poll and reconcile boxes were two cron
+controls for what users read as one concept ("when does this sync run?"). The
+Triggers step now exposes **two** triggers, Webhook and Schedule, where
+Schedule is a _list_ of cron rows:
+
+```ts
+schedules: Array<{
+  id: string; // stable; lastRunAt is stamped per row
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+  entities?: string[]; // empty = every entity enabled in the Entities step
+  kind: "poll" | "reconcile"; // "poll" honors syncMode; "reconcile" is a full re-pull
+  lastRunAt?: Date;
+}>;
+```
+
+This subsumes the old pair: the reconcile trigger is a row with
+`kind: "reconcile"`, and per-row `entities` lets one sync poll everything
+hourly while fully reconciling only the expensive entities nightly.
+
+**Compatibility.** `schedule` and `backfillSchedule` remain on the model. When
+a client sends `schedules`, the API mirrors the first enabled poll row onto
+`schedule` and the first enabled reconcile row onto `backfillSchedule`, so
+list payloads and the flow panels keep working unchanged; flows saved before
+the list have no `schedules` and are projected into the same row shape by
+`resolveFlowSchedules()` (`api/src/services/flow-triggers.service.ts`). Every
+scheduler path reads that resolver, never the raw fields.
+
+**Runtime.** `flowSchedulerFunction` iterates `kind: "poll"` rows and emits
+`flow.execute` with `entityScope` (the older `backfillEntities` event field is
+still accepted); `cdcScheduledBackfillFunction` iterates `kind: "reconcile"`
+rows and calls `cdcBackfillService.startBackfill(..., { entities })` on the CDC
+engine, or dispatches a `backfill: true` run otherwise. Rows from the list
+stamp `schedules.$[row].lastRunAt` at dispatch; legacy rows keep their
+original bookkeeping (`flow.lastRunAt` / `backfillSchedule.lastRunAt`).


### PR DESCRIPTION
## Why

The Triggers step exposed three checkboxes — scheduled poll, webhook, and periodic full reconcile — where poll and reconcile were two cron controls for what users read as one question: *when does this sync run?* This collapses them into two triggers, **Webhook** and **Schedule**, where Schedule is a list of cron rows and the reconcile trigger is simply a row with `kind: "reconcile"`.

Each row carries its own cron, timezone, entity scope and run kind, so one sync can poll every entity hourly while fully reconciling only the expensive entities nightly. An empty scope means every entity enabled in the Entities step.

## Model

`flow.schedules[]` — `{ id, enabled, cron, timezone, entities[], kind: "poll" | "reconcile", lastRunAt }`.

The standalone `schedule` / `backfillSchedule` fields remain and are written as mirrors (first enabled poll row / first enabled reconcile row), so the flows list payload, `FlowsExplorer`, `BackfillPanel`, `FlowLogs` and the toggle-schedule endpoint keep working unchanged. Flows saved before the list have no `schedules[]` and are projected into the same row shape by `resolveFlowSchedules()` (`api/src/services/flow-triggers.service.ts`), which every scheduler path reads instead of the raw fields. No migration required.

## Git-backed flow config

Since flows are defined by `flows/<slug>.yml` (RFC #904), the list has to live in the file or a repo sync would quietly revert it. The format gains a `schedules:` list:

```yaml
schedules:
  - id: 7c1f…
    cron: 0 * * * *
    timezone: UTC
    kind: poll
  - id: 9ab3…
    cron: 0 3 * * 0
    timezone: UTC
    kind: reconcile
    entities: [customers, invoices]
```

When present it is authoritative and the single-schedule keys are omitted from the file; flows without it keep writing `schedule:` / `backfill_schedule:` exactly as before. Definition only — every `lastRunAt` is a scheduler claim that stays on the row and is carried across a file edit by row id, and disabled rows are not committed. A hand-written row defaults to `kind: poll`; a row with no cron is skipped.

## Runtime

- `flowSchedulerFunction` iterates `kind: "poll"` rows and emits `flow.execute` with `entityScope` + `scheduleId` (the older `backfillEntities` event field is still accepted). Due-ness goes through the shared `isCronDue()` predicate, per row.
- `cdcScheduledBackfillFunction` iterates `kind: "reconcile"` rows and calls `startBackfill(..., { entities })` on the CDC engine, or dispatches a `backfill: true` run otherwise. Legacy `backfillSchedule` rows stay CDC-only, as before.
- List rows stamp `schedules.$[row].lastRunAt` at dispatch; legacy rows keep their original bookkeeping (`flow.lastRunAt` / `backfillSchedule.lastRunAt`).
- The entity-scope guards in the flow executor no longer require `backfill`, so a scheduled run honors its row's scope too.
- `markFlowInvalid` disables every row, not just the two legacy fields, so a broken definition cannot keep firing a cadence.

## Form

The two trigger boxes become one Schedule section with add/remove rows (cadence preset or custom cron, timezone, entity multi-select defaulting to "All enabled entities", run kind). The run-kind picker is hidden where only one kind is legal — non-CDC destinations are always polls, and Full Refresh on a CDC destination is always a reconcile, since only that path drives the CDC backfill (table swap, event drain) — and kinds are normalized again on submit rather than trusting the row's last value. Row scopes are filtered to still-enabled entities on save, so a stale scope cannot fail every scheduled run. Reconcile stays opt-in: the suggestion banner offers an "Add daily" button and nothing is switched on automatically.

## Validation

- `tsc --noEmit` clean for both `api` and `app`; eslint clean on all touched files; `pnpm openapi:sync` produces no diff.
- Passing: `flow-triggers.service`, `flow-config-files`, `flow-config-mongoose`, `flow-sync`, `flow-validate`, `cron-due`.
- New coverage: list-wins-over-legacy resolution, legacy field projection, payload normalization (client `lastRunAt` ignored, stored value carried over by id), the legacy mirrors, and the YAML round-trip (no `lastRunAt` or stale mirror in the file, disabled rows omitted, hand-written rows defaulted).
- Not run: there is no e2e or integration coverage for the two Inngest schedulers, so multi-row dispatch and per-row `lastRunAt` stamping were verified by reading only. Browser interaction has not been tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GUeEBQ9wyHwfdot8PDVHd