### PR TITLE
fix(api): saving a CDC flow no longer fails with '"undefined" is not valid JSON'

### DIFF
--- a/api/src/services/flow-config-files.ts
+++ b/api/src/services/flow-config-files.ts
@@ -148,6 +148,14 @@ function plain<T>(value: unknown): T | undefined {
           depopulate: true,
         })
       : value;
+  // A nested path (`tableDestination.partitioning`, `.clustering`) is not a
+  // subdocument: Mongoose hands back a getter object whose `toObject()` is
+  // `undefined` when nothing is set — which is the state after the update
+  // route reassigns `tableDestination` from a form payload that never
+  // carries either. `JSON.stringify(undefined)` is `undefined`, and
+  // `JSON.parse(undefined)` throws `"undefined" is not valid JSON`, which
+  // reached the user as the save error for every edit of a CDC flow.
+  if (source === null || source === undefined) return undefined;
   // The round-trip also normalises ObjectIds and Dates to strings, which is
   // what the file wants anyway.
   return JSON.parse(JSON.stringify(source)) as T;

--- a/api/src/services/flow-config-mongoose.test.ts
+++ b/api/src/services/flow-config-mongoose.test.ts
@@ -96,6 +96,28 @@ async function main(): Promise<void> {
       "document and lean projections must agree",
     );
 
+    // The update route replaces `tableDestination` wholesale from the form
+    // payload, which never carries `partitioning` / `clustering`. Those are
+    // nested paths, not subdocuments: Mongoose's getter object for an unset
+    // nested path has a `toObject()` that returns `undefined`, and the
+    // serializer used to feed that to `JSON.parse(JSON.stringify(...))` —
+    // `"undefined" is not valid JSON`, surfaced as the save error on every
+    // edit of a CDC flow.
+    doc.tableDestination = {
+      connectionId: new Types.ObjectId(),
+      schema: "analytics",
+      tableName: "",
+      createIfNotExists: true,
+    } as never;
+    const reassigned = serializeFlowFile(flowToFile(doc));
+    assert.ok(reassigned.includes("schema: analytics"));
+    assert.ok(
+      !reassigned.includes("partitioning") &&
+        !reassigned.includes("clustering"),
+      `unset layout hints must be omitted, not serialized:\n${reassigned}`,
+    );
+    assert.ok(parseFlowFile(reassigned), "reassigned document parses back");
+
     console.log("flow-config mongoose-safety tests passed");
   } finally {
     await mongoose.disconnect();


### PR DESCRIPTION
## Problem

After #995 let users save a sync with no automatic trigger, saving failed with:

```
"undefined" is not valid JSON
```

The message comes from the backend write-through that commits `flows/<slug>.yml` before the Mongo save. `flowToFile()` round-trips Mongoose values through `JSON.parse(JSON.stringify(value.toObject()))`. `tableDestination.partitioning` and `.clustering` are **nested paths, not subdocuments**: Mongoose's getter object for an unset nested path has a `toObject()` that returns `undefined`. `JSON.stringify(undefined)` is `undefined`, and `JSON.parse(undefined)` throws that exact error.

The update route reassigns `tableDestination` wholesale from the form payload, which never carries partitioning or clustering, so **every edit of a CDC flow** hit this. It was independent of the trigger set — #995 simply removed the disabled Save button that had been hiding it.

## Fix

- `plain()` in `api/src/services/flow-config-files.ts` returns `undefined` when `toObject()` yields nothing, so unset layout hints are omitted from the YAML instead of crashing the save.

## Test

- `flow-config-mongoose.test.ts` gains a case that reassigns `tableDestination` on a live document the way the route does. It throws on the old code and passes on the new code.
- The serializer unit test and `flows-writethrough.test.ts` pass; eslint and prettier are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJLtkJJ6BspaTiUP8EwhSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJLtkJJ6BspaTiUP8EwhSE)_